### PR TITLE
refactor: simplify plugin config — configPath drives everything

### DIFF
--- a/packages/lib/src/orchestrator/orchestrate.test.ts
+++ b/packages/lib/src/orchestrator/orchestrate.test.ts
@@ -18,6 +18,7 @@ const testRoot = join(
 const config: SynthConfig = {
   watchPaths: [testRoot],
   watcherUrl: 'http://localhost:3456',
+  gatewayUrl: 'http://127.0.0.1:3000',
   depthWeight: 1,
   architectEvery: 10,
   maxArchive: 20,

--- a/packages/lib/src/orchestrator/orchestrator.test.ts
+++ b/packages/lib/src/orchestrator/orchestrator.test.ts
@@ -23,6 +23,7 @@ const testRoot = join(tmpdir(), `jeeves-meta-orch-${Date.now().toString()}`);
 const sampleConfig: SynthConfig = {
   watchPaths: ['/test'],
   watcherUrl: 'http://localhost:3456',
+  gatewayUrl: 'http://127.0.0.1:3000',
   depthWeight: 1,
   architectEvery: 10,
   maxArchive: 20,

--- a/packages/lib/src/schema/config.ts
+++ b/packages/lib/src/schema/config.ts
@@ -17,6 +17,12 @@ export const synthConfigSchema = z.object({
   /** Watcher service base URL. */
   watcherUrl: z.url(),
 
+  /** OpenClaw gateway base URL for subprocess spawning. */
+  gatewayUrl: z.url().default('http://127.0.0.1:3000'),
+
+  /** Optional API key for gateway authentication. */
+  gatewayApiKey: z.string().optional(),
+
   /** Run architect every N cycles (per meta). */
   architectEvery: z.number().int().min(1).default(10),
 

--- a/packages/openclaw/openclaw.plugin.json
+++ b/packages/openclaw/openclaw.plugin.json
@@ -6,12 +6,10 @@
   "skills": [],
   "configSchema": {
     "type": "object",
-    "additionalProperties": false,
     "properties": {
-      "watcherUrl": {
+      "configPath": {
         "type": "string",
-        "description": "jeeves-watcher API base URL",
-        "default": "http://127.0.0.1:1936"
+        "description": "Path to jeeves-meta.config.json. Falls back to JEEVES_META_CONFIG env var."
       }
     }
   }

--- a/packages/openclaw/src/helpers.ts
+++ b/packages/openclaw/src/helpers.ts
@@ -38,25 +38,24 @@ function getPluginConfig(api: PluginApi): Record<string, unknown> | undefined {
   return api.config?.plugins?.entries?.[PLUGIN_NAME]?.config;
 }
 
-/** Resolve watcher URL from plugin config. */
-export function getWatcherUrl(api: PluginApi): string {
-  const url = getPluginConfig(api)?.watcherUrl;
-  return typeof url === 'string' ? url : 'http://127.0.0.1:1936';
-}
-
-/** Resolve watch paths from plugin config. */
-export function getWatchPaths(api: PluginApi): string[] {
-  const paths = getPluginConfig(api)?.watchPaths;
-  return Array.isArray(paths) ? (paths as string[]) : ['j:/domains'];
-}
-
 /**
- * Get the config file path from plugin settings.
- * Default: J:/config/jeeves-meta.config.json
+ * Resolve the config file path.
+ *
+ * Resolution order:
+ * 1. Plugin config `configPath` setting
+ * 2. `JEEVES_META_CONFIG` environment variable
+ * 3. Error — no default path
  */
 export function getConfigPath(api: PluginApi): string {
-  const p = getPluginConfig(api)?.configPath;
-  return typeof p === 'string' ? p : 'J:/config/jeeves-meta.config.json';
+  const fromPlugin = getPluginConfig(api)?.configPath;
+  if (typeof fromPlugin === 'string') return fromPlugin;
+
+  const fromEnv = process.env['JEEVES_META_CONFIG'];
+  if (fromEnv) return fromEnv;
+
+  throw new Error(
+    'jeeves-meta config path not found. Set configPath in plugin config or JEEVES_META_CONFIG env var.',
+  );
 }
 
 /** Format a successful tool result. */

--- a/packages/openclaw/src/index.ts
+++ b/packages/openclaw/src/index.ts
@@ -6,8 +6,9 @@
  * @packageDocumentation
  */
 
+import { loadSynthConfig } from './configLoader.js';
 import type { PluginApi } from './helpers.js';
-import { getWatcherUrl } from './helpers.js';
+import { getConfigPath } from './helpers.js';
 import { registerSynthRules } from './rules.js';
 import { registerSynthTools } from './tools.js';
 
@@ -16,8 +17,8 @@ export default function register(api: PluginApi): void {
   registerSynthTools(api);
 
   // Register virtual rules with watcher (fire-and-forget at startup)
-  const watcherUrl = getWatcherUrl(api);
-  registerSynthRules(watcherUrl).catch((err: unknown) => {
+  const config = loadSynthConfig(getConfigPath(api));
+  registerSynthRules(config.watcherUrl).catch((err: unknown) => {
     const message = err instanceof Error ? err.message : String(err);
     console.error('[jeeves-meta] Failed to register virtual rules:', message);
   });

--- a/packages/openclaw/src/tools.ts
+++ b/packages/openclaw/src/tools.ts
@@ -24,8 +24,6 @@ import { loadSynthConfig } from './configLoader.js';
 import {
   fail,
   getConfigPath,
-  getWatcherUrl,
-  getWatchPaths,
   ok,
   type PluginApi,
   type ToolResult,
@@ -33,8 +31,6 @@ import {
 
 /** Register all synth_* tools. */
 export function registerSynthTools(api: PluginApi): void {
-  const watcherUrl = getWatcherUrl(api);
-  const watchPaths = getWatchPaths(api);
   const configPath = getConfigPath(api);
 
   // Lazy-load config (resolved once on first use)
@@ -60,6 +56,12 @@ export function registerSynthTools(api: PluginApi): void {
     }
     return _config;
   };
+
+  /** Derive watcherUrl from loaded config. */
+  const getWatcherUrl = (): string => getConfig().watcherUrl;
+
+  /** Derive watchPaths from loaded config. */
+  const getWatchPaths = (): string[] => getConfig().watchPaths;
 
   // ─── synth_list ──────────────────────────────────────────────
   api.registerTool({
@@ -100,7 +102,7 @@ export function registerSynthTools(api: PluginApi): void {
       try {
         const pathPrefix = params.pathPrefix as string | undefined;
         await Promise.resolve();
-        const metaPaths = globMetas(watchPaths);
+        const metaPaths = globMetas(getWatchPaths());
         const tree = buildOwnershipTree(metaPaths);
 
         const entities: Array<
@@ -294,7 +296,7 @@ export function registerSynthTools(api: PluginApi): void {
         ]);
         const fields = params.fields as string[] | undefined;
 
-        const metaPaths = globMetas(watchPaths);
+        const metaPaths = globMetas(getWatchPaths());
         const tree = buildOwnershipTree(metaPaths);
 
         const targetNode = Array.from(tree.nodes.values()).find(
@@ -382,7 +384,7 @@ export function registerSynthTools(api: PluginApi): void {
     ): Promise<ToolResult> => {
       try {
         const targetPath = params.path as string | undefined;
-        const metaPaths = globMetas(watchPaths);
+        const metaPaths = globMetas(getWatchPaths());
         const tree = buildOwnershipTree(metaPaths);
 
         let targetNode;
@@ -418,7 +420,7 @@ export function registerSynthTools(api: PluginApi): void {
         }
 
         const meta = ensureMetaJson(targetNode.metaPath);
-        const watcher = new HttpWatcherClient({ baseUrl: watcherUrl });
+        const watcher = new HttpWatcherClient({ baseUrl: getWatcherUrl() });
 
         // Scope files (paginated for completeness)
         const allScanFiles = await paginatedScan(watcher, {
@@ -525,8 +527,11 @@ export function registerSynthTools(api: PluginApi): void {
         // Load config from canonical config file
         const config = getConfig();
 
-        const executor = new GatewayExecutor();
-        const watcher = new HttpWatcherClient({ baseUrl: watcherUrl });
+        const executor = new GatewayExecutor({
+          gatewayUrl: config.gatewayUrl,
+          apiKey: config.gatewayApiKey,
+        });
+        const watcher = new HttpWatcherClient({ baseUrl: getWatcherUrl() });
 
         // If path specified, temporarily override watchPaths to target it
         const targetPath = params.path as string | undefined;


### PR DESCRIPTION
Phase 7g: Plugin now reads only configPath from its settings (or JEEVES_META_CONFIG env var). All other config comes from the config file.

**Changes:**
- Removed getWatcherUrl/getWatchPaths from helpers.ts
- Added gatewayUrl + gatewayApiKey to SynthConfig Zod schema  
- Plugin manifest configSchema: only configPath
- synth_trigger passes gateway config to GatewayExecutor
- Updated test configs

All quality checks pass: build ✅ lint ✅ typecheck ✅ knip ✅ test ✅ (87) docs ✅