### PR TITLE
refactor: normalize paths with shared normalizePath utility

### DIFF
--- a/packages/lib/src/index.ts
+++ b/packages/lib/src/index.ts
@@ -39,6 +39,7 @@ export type {
   WatcherClient,
 } from './interfaces/index.js';
 export { acquireLock, isLocked, releaseLock } from './lock.js';
+export { normalizePath } from './normalizePath.js';
 export {
   buildArchitectTask,
   buildBuilderTask,

--- a/packages/lib/src/normalizePath.ts
+++ b/packages/lib/src/normalizePath.ts
@@ -1,0 +1,19 @@
+/**
+ * Normalize file paths to forward slashes for consistency with watcher-indexed paths.
+ *
+ * Watcher indexes paths with forward slashes (`j:/domains/...`). This utility
+ * ensures all paths in the library use the same convention, regardless of
+ * the platform's native separator.
+ *
+ * @module normalizePath
+ */
+
+/**
+ * Normalize a file path to forward slashes.
+ *
+ * @param p - File path (may contain backslashes).
+ * @returns Path with all backslashes replaced by forward slashes.
+ */
+export function normalizePath(p: string): string {
+  return p.replaceAll('\\', '/');
+}

--- a/packages/lib/src/orchestrator/orchestrate.ts
+++ b/packages/lib/src/orchestrator/orchestrate.ts
@@ -24,6 +24,7 @@ import { filterInScope, getScopePrefix } from '../discovery/scope.js';
 import { toSynthError } from '../errors.js';
 import type { SynthExecutor, WatcherClient } from '../interfaces/index.js';
 import { acquireLock, releaseLock } from '../lock.js';
+import { normalizePath } from '../normalizePath.js';
 import { paginatedScan } from '../paginatedScan.js';
 import {
   actualStaleness,
@@ -32,11 +33,6 @@ import {
 } from '../scheduling/index.js';
 import type { MetaJson, SynthConfig, SynthError } from '../schema/index.js';
 import { computeStructureHash } from '../structureHash.js';
-/** Normalize path separators to forward slashes. */
-function normalizePath(p: string): string {
-  return p.replaceAll('\\', '/');
-}
-
 import {
   buildArchitectTask,
   buildBuilderTask,

--- a/packages/openclaw/src/tools.ts
+++ b/packages/openclaw/src/tools.ts
@@ -14,6 +14,7 @@ import {
   globMetas,
   HttpWatcherClient,
   isLocked,
+  normalizePath,
   paginatedScan,
   readLatestArchive,
   selectCandidate,
@@ -135,7 +136,7 @@ export function registerSynthTools(api: PluginApi): void {
           if (filter) {
             const staleness = actualStaleness(meta);
             const hasErr = Boolean(meta._error);
-            const locked = isLocked(node.metaPath.replaceAll('/', '\\'));
+            const locked = isLocked(normalizePath(node.metaPath));
             const neverSynth = !meta._generatedAt;
 
             if (filter.hasError !== undefined && hasErr !== filter.hasError)
@@ -154,7 +155,7 @@ export function registerSynthTools(api: PluginApi): void {
               continue;
           }
           const staleness = actualStaleness(meta);
-          const locked = isLocked(node.metaPath.replaceAll('/', '\\'));
+          const locked = isLocked(normalizePath(node.metaPath));
           const hasError = Boolean(meta._error);
 
           if (staleness > 0) staleCount++;
@@ -282,7 +283,7 @@ export function registerSynthTools(api: PluginApi): void {
       params: Record<string, unknown>,
     ): Promise<ToolResult> => {
       try {
-        const targetPath = (params.path as string).replaceAll('\\', '/');
+        const targetPath = normalizePath(params.path as string);
         const includeArchive = params.includeArchive as
           | boolean
           | number
@@ -389,7 +390,7 @@ export function registerSynthTools(api: PluginApi): void {
 
         let targetNode;
         if (targetPath) {
-          const normalized = targetPath.replaceAll('\\', '/');
+          const normalized = normalizePath(targetPath);
           targetNode = Array.from(tree.nodes.values()).find(
             (n) => n.metaPath === normalized || n.ownerPath === normalized,
           );


### PR DESCRIPTION
Phase 7h: Introduce normalizePath() (forward-slash normalization) and use it consistently in lib + plugin.

All quality checks pass: build ✅ lint ✅ typecheck ✅ knip ✅ test ✅ docs ✅