### PR TITLE
feat: extract token usage from gateway session history

### DIFF
--- a/packages/lib/src/executor/GatewayExecutor.ts
+++ b/packages/lib/src/executor/GatewayExecutor.ts
@@ -115,18 +115,37 @@ export class GatewayExecutor implements SynthExecutor {
       if (!historyRes.ok) continue;
 
       const history = (await historyRes.json()) as {
-        messages?: Array<{ role: string; content: string }>;
+        messages?: Array<{
+          role: string;
+          content: string;
+          usage?: { totalTokens?: number };
+        }>;
         status?: string;
+        usage?: { totalTokens?: number };
       };
 
       if (history.status === 'completed' || history.status === 'done') {
+        // Extract token usage from session-level or message-level usage
+        let tokens: number | undefined;
+        if (history.usage?.totalTokens) {
+          tokens = history.usage.totalTokens;
+        } else {
+          // Sum message-level usage as fallback
+          let sum = 0;
+          for (const msg of history.messages ?? []) {
+            if (msg.usage?.totalTokens) sum += msg.usage.totalTokens;
+          }
+          if (sum > 0) tokens = sum;
+        }
+
+        // Extract the last assistant message as output
         const messages = history.messages ?? [];
         for (let i = messages.length - 1; i >= 0; i--) {
           if (messages[i].role === 'assistant' && messages[i].content) {
-            return { output: messages[i].content };
+            return { output: messages[i].content, tokens };
           }
         }
-        return { output: '' };
+        return { output: '', tokens };
       }
     }
 


### PR DESCRIPTION
Phase 7d: GatewayExecutor now extracts token usage from the gateway session history response and returns it in SynthSpawnResult.tokens.

Checks session-level usage.totalTokens first, falls back to summing message-level usage. This enables token tracking in meta.json fields (_architectTokens, _builderTokens, _criticTokens and their EMA counterparts).

Note: actual token availability depends on the OpenClaw gateway API response format. The extraction is best-effort — if the gateway doesn't include usage data, tokens will be undefined (gracefully handled by the orchestrator).

All checks: build ✅ lint ✅ typecheck ✅ knip ✅ test ✅ docs ✅