### PR TITLE
test: fill coverage gaps — ema, lock, paginatedScan, predicates, findNode

### DIFF
--- a/packages/lib/src/discovery/discovery.test.ts
+++ b/packages/lib/src/discovery/discovery.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { type MetaJson, metaJsonSchema } from '../schema/index.js';
 import { ensureMetaJson } from './ensureMetaJson.js';
 import { globMetas } from './globMetas.js';
-import { buildOwnershipTree } from './ownershipTree.js';
+import { buildOwnershipTree, findNode } from './ownershipTree.js';
 import { filterInScope, getScopeExclusions, getScopePrefix } from './scope.js';
 
 const testRoot = join(tmpdir(), `jeeves-meta-test-${Date.now().toString()}`);
@@ -156,5 +156,37 @@ describe('scope', () => {
     expect(inScope).toContain(abs('a/file2.txt'));
     expect(inScope).not.toContain(abs('a/b/file3.txt'));
     expect(inScope).toContain(abs('a/b/.meta/meta.json'));
+  });
+});
+
+describe('findNode', () => {
+  it('finds node by metaPath', () => {
+    mkdirSync(join(testRoot, 'domain/.meta'), { recursive: true });
+    const metaPaths = globMetas([testRoot]);
+    const tree = buildOwnershipTree(metaPaths);
+    const metaPath = Array.from(tree.nodes.values())[0].metaPath;
+
+    const found = findNode(tree, metaPath);
+    expect(found).toBeDefined();
+    expect(found!.metaPath).toBe(metaPath);
+  });
+
+  it('finds node by ownerPath', () => {
+    mkdirSync(join(testRoot, 'domain/.meta'), { recursive: true });
+    const metaPaths = globMetas([testRoot]);
+    const tree = buildOwnershipTree(metaPaths);
+    const ownerPath = Array.from(tree.nodes.values())[0].ownerPath;
+
+    const found = findNode(tree, ownerPath);
+    expect(found).toBeDefined();
+    expect(found!.ownerPath).toBe(ownerPath);
+  });
+
+  it('returns undefined for non-existent path', () => {
+    mkdirSync(join(testRoot, 'domain/.meta'), { recursive: true });
+    const metaPaths = globMetas([testRoot]);
+    const tree = buildOwnershipTree(metaPaths);
+
+    expect(findNode(tree, '/nonexistent/path')).toBeUndefined();
   });
 });

--- a/packages/lib/src/ema.test.ts
+++ b/packages/lib/src/ema.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeEma } from './ema.js';
+
+describe('computeEma', () => {
+  it('returns current value when no previous exists', () => {
+    expect(computeEma(100, undefined)).toBe(100);
+  });
+
+  it('applies decay weighting between current and previous', () => {
+    // default decay = 0.3: 0.3 * 200 + 0.7 * 100 = 130
+    expect(computeEma(200, 100)).toBe(130);
+  });
+
+  it('converges toward repeated values', () => {
+    let avg: number | undefined;
+    for (let i = 0; i < 20; i++) {
+      avg = computeEma(500, avg);
+    }
+    // After 20 iterations of 500, should be very close to 500
+    expect(avg).toBeGreaterThan(499);
+    expect(avg).toBeLessThanOrEqual(500);
+  });
+
+  it('respects custom decay factor', () => {
+    // decay=1.0 means only current value matters
+    expect(computeEma(200, 100, 1.0)).toBe(200);
+    // decay=0.0 means only previous value matters
+    expect(computeEma(200, 100, 0.0)).toBe(100);
+  });
+});

--- a/packages/lib/src/lock.test.ts
+++ b/packages/lib/src/lock.test.ts
@@ -1,0 +1,83 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { acquireLock, isLocked, releaseLock } from './lock.js';
+
+const testRoot = join(tmpdir(), `jeeves-meta-lock-${Date.now().toString()}`);
+const metaPath = join(testRoot, '.meta');
+
+beforeEach(() => {
+  mkdirSync(metaPath, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+describe('acquireLock', () => {
+  it('acquires lock on unlocked directory', () => {
+    expect(acquireLock(metaPath)).toBe(true);
+    expect(existsSync(join(metaPath, '.lock'))).toBe(true);
+  });
+
+  it('fails to acquire when already locked', () => {
+    expect(acquireLock(metaPath)).toBe(true);
+    expect(acquireLock(metaPath)).toBe(false);
+  });
+
+  it('overrides stale lock (> 30 min)', () => {
+    const staleDate = new Date(Date.now() - 31 * 60 * 1000).toISOString();
+    writeFileSync(
+      join(metaPath, '.lock'),
+      JSON.stringify({ pid: 99999, startedAt: staleDate }),
+    );
+    expect(acquireLock(metaPath)).toBe(true);
+  });
+
+  it('overrides corrupt lock file', () => {
+    writeFileSync(join(metaPath, '.lock'), 'not json');
+    expect(acquireLock(metaPath)).toBe(true);
+  });
+});
+
+describe('releaseLock', () => {
+  it('removes lock file', () => {
+    acquireLock(metaPath);
+    releaseLock(metaPath);
+    expect(existsSync(join(metaPath, '.lock'))).toBe(false);
+  });
+
+  it('does not throw when no lock exists', () => {
+    expect(() => {
+      releaseLock(metaPath);
+    }).not.toThrow();
+  });
+});
+
+describe('isLocked', () => {
+  it('returns false when no lock exists', () => {
+    expect(isLocked(metaPath)).toBe(false);
+  });
+
+  it('returns true when lock is fresh', () => {
+    acquireLock(metaPath);
+    expect(isLocked(metaPath)).toBe(true);
+  });
+
+  it('returns false when lock is stale', () => {
+    const staleDate = new Date(Date.now() - 31 * 60 * 1000).toISOString();
+    writeFileSync(
+      join(metaPath, '.lock'),
+      JSON.stringify({ pid: 99999, startedAt: staleDate }),
+    );
+    expect(isLocked(metaPath)).toBe(false);
+  });
+
+  it('returns false when lock is corrupt', () => {
+    writeFileSync(join(metaPath, '.lock'), 'garbage');
+    expect(isLocked(metaPath)).toBe(false);
+  });
+});

--- a/packages/lib/src/paginatedScan.test.ts
+++ b/packages/lib/src/paginatedScan.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { WatcherClient } from './interfaces/index.js';
+import { paginatedScan } from './paginatedScan.js';
+
+function createMockWatcher(
+  pages: Array<{ files: Array<Record<string, unknown>>; next?: string }>,
+) {
+  let callIndex = 0;
+  return {
+    scan: vi.fn().mockImplementation(
+      (): Promise<{
+        files: Array<Record<string, unknown>>;
+        next?: string;
+      }> => {
+        const page = pages[callIndex] ?? { files: [] };
+        callIndex++;
+        return Promise.resolve(page);
+      },
+    ),
+    registerRules: vi.fn(),
+    unregisterRules: vi.fn(),
+  } satisfies WatcherClient;
+}
+
+describe('paginatedScan', () => {
+  it('returns files from a single page', async () => {
+    const watcher = createMockWatcher([
+      {
+        files: [
+          { file_path: 'a.md', modified_at: 1000, content_hash: 'h1' },
+          { file_path: 'b.md', modified_at: 2000, content_hash: 'h2' },
+        ],
+      },
+    ]);
+
+    const result = await paginatedScan(watcher, { pathPrefix: '/test' });
+    expect(result).toHaveLength(2);
+    expect(result[0].file_path).toBe('a.md');
+  });
+
+  it('follows cursor across multiple pages', async () => {
+    const watcher = createMockWatcher([
+      {
+        files: [{ file_path: 'a.md', modified_at: 1000, content_hash: 'h1' }],
+        next: 'cursor1',
+      },
+      {
+        files: [{ file_path: 'b.md', modified_at: 2000, content_hash: 'h2' }],
+        next: 'cursor2',
+      },
+      {
+        files: [{ file_path: 'c.md', modified_at: 3000, content_hash: 'h3' }],
+      },
+    ]);
+
+    const result = await paginatedScan(watcher, { pathPrefix: '/test' });
+    expect(result).toHaveLength(3);
+    expect(watcher.scan).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns empty array when no files match', async () => {
+    const watcher = createMockWatcher([{ files: [] }]);
+    const result = await paginatedScan(watcher, { pathPrefix: '/empty' });
+    expect(result).toHaveLength(0);
+  });
+
+  it('passes filter through to watcher', async () => {
+    const watcher = createMockWatcher([{ files: [] }]);
+    await paginatedScan(watcher, {
+      filter: { must: [{ key: 'domains', match: { value: 'synth-meta' } }] },
+    });
+    expect(watcher.scan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter: { must: [{ key: 'domains', match: { value: 'synth-meta' } }] },
+      }),
+    );
+  });
+});

--- a/packages/lib/src/scheduling/scheduling.test.ts
+++ b/packages/lib/src/scheduling/scheduling.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it, vi } from 'vitest';
 import type { MetaNode } from '../discovery/index.js';
 import type { MetaJson } from '../schema/index.js';
 import { selectCandidate } from './selectCandidate.js';
-import { actualStaleness } from './staleness.js';
+import {
+  actualStaleness,
+  hasSteerChanged,
+  isArchitectTriggered,
+} from './staleness.js';
 import { computeEffectiveStaleness } from './weightedFormula.js';
 
 function makeNode(depth: number): MetaNode {
@@ -213,5 +217,50 @@ describe('isStale', () => {
     const meta = makeMeta({ _generatedAt: '2026-01-01T00:00:00Z' });
     const result = await isStale('/test', meta, watcher);
     expect(result).toBe(false);
+  });
+});
+
+describe('isArchitectTriggered', () => {
+  it('triggers when no cached builder', () => {
+    const meta = { _id: 'test' };
+    expect(isArchitectTriggered(meta, false, false, 10)).toBe(true);
+  });
+
+  it('triggers when structure changed', () => {
+    const meta = { _id: 'test', _builder: 'cached' };
+    expect(isArchitectTriggered(meta, true, false, 10)).toBe(true);
+  });
+
+  it('triggers when steer changed', () => {
+    const meta = { _id: 'test', _builder: 'cached' };
+    expect(isArchitectTriggered(meta, false, true, 10)).toBe(true);
+  });
+
+  it('triggers when synthesis count exceeds architectEvery', () => {
+    const meta = { _id: 'test', _builder: 'cached', _synthesisCount: 10 };
+    expect(isArchitectTriggered(meta, false, false, 10)).toBe(true);
+  });
+
+  it('does not trigger when nothing changed and count below threshold', () => {
+    const meta = { _id: 'test', _builder: 'cached', _synthesisCount: 3 };
+    expect(isArchitectTriggered(meta, false, false, 10)).toBe(false);
+  });
+});
+
+describe('hasSteerChanged', () => {
+  it('returns true when steer is set and no archive exists', () => {
+    expect(hasSteerChanged('focus on X', undefined, false)).toBe(true);
+  });
+
+  it('returns false when no steer and no archive', () => {
+    expect(hasSteerChanged(undefined, undefined, false)).toBe(false);
+  });
+
+  it('returns true when steer differs from archive', () => {
+    expect(hasSteerChanged('new focus', 'old focus', true)).toBe(true);
+  });
+
+  it('returns false when steer matches archive', () => {
+    expect(hasSteerChanged('same', 'same', true)).toBe(false);
   });
 });


### PR DESCRIPTION
Coverage audit found 7 untested library modules. Added tests for the 5 with meaningful logic (ema, lock, paginatedScan, isArchitectTriggered, hasSteerChanged, findNode). Skipped normalizePath (one-liner), structureHash (thin crypto wrapper), errors.ts (thin wrapper), engine.ts (thin factory) — all covered transitively by integration tests.

85 → 115 lib tests, 15 plugin tests = **130 total, all passing**.