### PR TITLE
docs: full documentation pass — sync all docs with implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,23 +10,29 @@ jeeves-meta discovers `.meta/` directories across watched filesystem paths, buil
 2. **Builder** — executes the brief, reads source files, queries the semantic index, and produces a synthesis
 3. **Critic** — spot-checks claims, evaluates against steering prompts, and provides feedback
 
-Results are written to `.meta/meta.json` files with full archive history, enabling self-improving feedback loops and future Supervisor optimization.
+Results are written to `.meta/meta.json` files with full archive history, enabling self-improving feedback loops.
 
 ## Packages
 
 | Package | Description |
 |---------|-------------|
-| [`@karmaniverous/jeeves-meta`](https://github.com/karmaniverous/jeeves-meta/tree/main/packages/lib) | Core synthesis engine library — schemas, discovery, scheduling, orchestration |
-| [`@karmaniverous/jeeves-meta-openclaw`](https://github.com/karmaniverous/jeeves-meta/tree/main/packages/openclaw) | OpenClaw plugin — interactive tools, gateway executor, virtual inference rules |
+| [`@karmaniverous/jeeves-meta`](packages/lib) | Core synthesis engine — schemas, discovery, scheduling, orchestration, CLI |
+| [`@karmaniverous/jeeves-meta-openclaw`](packages/openclaw) | OpenClaw plugin — interactive tools, gateway executor, virtual inference rules, TOOLS.md injection |
 
 ## Architecture
 
-![System Architecture](packages/lib/assets/system-architecture.png)
+```
+jeeves-runner (cron) ──→ jeeves-meta CLI ──→ orchestrator ──→ GatewayExecutor
+                                                  │                    │
+                                                  ├── discovery        ├── architect session
+                                                  ├── scheduling       ├── builder session
+                                                  └── archive          └── critic session
+                                                  │
+                                                  └──→ jeeves-watcher (scan / rules)
+```
 
-For the full per-cycle sequence diagram, see [Orchestration Guide](packages/lib/guides/orchestration.md).
-
-- **jeeves-runner** invokes synthesis cycles on a cron schedule
-- **jeeves-meta** (library) orchestrates the 3-step LLM pipeline
+- **jeeves-runner** invokes `npx @karmaniverous/jeeves-meta synthesize` on a cron schedule
+- **jeeves-meta** (library) orchestrates the 3-step LLM pipeline via pluggable executors
 - **jeeves-watcher** provides structured queries (`POST /scan`) and semantic search
 - **OpenClaw plugin** provides interactive tools (`synth_list`, `synth_detail`, `synth_trigger`, `synth_preview`)
 
@@ -35,20 +41,38 @@ For the full per-cycle sequence diagram, see [Orchestration Guide](packages/lib/
 ### As a library
 
 ```typescript
-import { createSynthEngine } from '@karmaniverous/jeeves-meta';
+import {
+  createSynthEngine,
+  HttpWatcherClient,
+  loadSynthConfig,
+} from '@karmaniverous/jeeves-meta';
 
-const engine = createSynthEngine({
-  config,    // SynthConfig (Zod-validated)
-  executor,  // SynthExecutor implementation
-  watcher,   // WatcherClient implementation
-});
+const config = loadSynthConfig('/path/to/jeeves-meta.config.json');
+const watcher = new HttpWatcherClient({ baseUrl: config.watcherUrl });
 
-const results = await engine.orchestrate();
+const engine = createSynthEngine(config, myExecutor, watcher);
+const results = await engine.synthesize();
+```
+
+### As a CLI
+
+```bash
+# Set config path
+export JEEVES_META_CONFIG=/path/to/jeeves-meta.config.json
+
+# Check engine status
+npx @karmaniverous/jeeves-meta status
+
+# Run synthesis
+npx @karmaniverous/jeeves-meta synthesize
+
+# See all commands
+npx @karmaniverous/jeeves-meta help
 ```
 
 ### As an OpenClaw plugin
 
-Install the plugin package and register it with the gateway. Tools become available to the agent:
+Install and register the plugin package. Four tools become available to the agent:
 
 - `synth_list` — list metas with summary stats and filtering
 - `synth_detail` — full detail for a single meta with optional archive history
@@ -63,14 +87,15 @@ npm run build
 npm run lint
 npm run typecheck
 npm test
-npm run docs    # generate TypeDoc documentation
+npm run knip       # detect unused exports/deps
+npm run docs       # generate TypeDoc documentation
 ```
 
 ## Documentation
 
-Full docs, guides, and API reference:
-
-**[docs.karmanivero.us/jeeves-meta](https://docs.karmanivero.us/jeeves-meta)**
+- **[Engine Guides](packages/lib/guides/index.md)** — concepts, configuration, orchestration, scheduling, architecture patterns
+- **[CLI Reference](packages/lib/guides/cli.md)** — all 10 CLI commands with usage examples
+- **[Plugin Guides](packages/openclaw/guides/index.md)** — setup, tools reference, virtual rules, TOOLS.md injection
 
 ## License
 

--- a/packages/lib/README.md
+++ b/packages/lib/README.md
@@ -1,6 +1,6 @@
 # @karmaniverous/jeeves-meta
 
-Core synthesis engine for the Jeeves platform. Provides schemas, filesystem discovery, weighted staleness scheduling, and the three-step orchestrator (architect → builder → critic).
+Core synthesis engine for the Jeeves platform. Provides schemas, filesystem discovery, weighted staleness scheduling, three-step orchestration, and a full CLI.
 
 ## Features
 
@@ -10,14 +10,12 @@ Core synthesis engine for the Jeeves platform. Provides schemas, filesystem disc
 - **Three-step orchestration** — architect, builder, critic with conditional re-architecture
 - **Archive management** — timestamped snapshots with configurable pruning
 - **Structure hashing** — detect scope changes (file additions/removals)
-- **Lock management** — filesystem locks with stale timeout
+- **Lock management** — filesystem locks with 30-minute stale timeout
 - **Pluggable executor** — `SynthExecutor` interface for runtime-agnostic subprocess spawning
-- **Pluggable watcher client** — `WatcherClient` interface with HTTP implementation included
+- **Pluggable watcher client** — `WatcherClient` interface with HTTP implementation (3-retry exponential backoff)
 - **Token tracking** — per-step token counts with exponential moving averages
-
-## Architecture
-
-![System Architecture](assets/system-architecture.png)
+- **CLI** — 10 commands for status, listing, synthesis, debugging, and maintenance
+- **Config loader** — `loadSynthConfig()` with `@file:` reference resolution
 
 ## Install
 
@@ -27,30 +25,37 @@ npm install @karmaniverous/jeeves-meta
 
 ## Quick Start
 
+### Library usage
+
 ```typescript
-import { createSynthEngine, HttpWatcherClient } from '@karmaniverous/jeeves-meta';
+import {
+  createSynthEngine,
+  HttpWatcherClient,
+  loadSynthConfig,
+} from '@karmaniverous/jeeves-meta';
 
-const watcher = new HttpWatcherClient('http://localhost:1936');
+const config = loadSynthConfig('/path/to/jeeves-meta.config.json');
+const watcher = new HttpWatcherClient({ baseUrl: config.watcherUrl });
 
-const engine = createSynthEngine({
-  config: {
-    watchPaths: ['j:/domains'],
-    watcherUrl: 'http://localhost:1936',
-    defaultArchitect: '...',
-    defaultCritic: '...',
-  },
-  executor: myExecutor,
-  watcher,
-});
+const engine = createSynthEngine(config, myExecutor, watcher);
+const results = await engine.synthesize();
+```
 
-const results = await engine.orchestrate();
+### CLI usage
+
+```bash
+export JEEVES_META_CONFIG=/path/to/jeeves-meta.config.json
+
+npx @karmaniverous/jeeves-meta status       # summary stats
+npx @karmaniverous/jeeves-meta list         # list all metas
+npx @karmaniverous/jeeves-meta synthesize   # run synthesis cycle
+npx @karmaniverous/jeeves-meta help         # all commands
 ```
 
 ## Documentation
 
-Full docs, guides, and API reference:
-
-**[docs.karmanivero.us/jeeves-meta](https://docs.karmanivero.us/jeeves-meta)**
+- **[Engine Guides](guides/index.md)** — concepts, configuration, orchestration, scheduling, architecture patterns
+- **[CLI Reference](guides/cli.md)** — all 10 commands with examples
 
 ## License
 

--- a/packages/lib/guides/architecture-patterns.md
+++ b/packages/lib/guides/architecture-patterns.md
@@ -9,18 +9,23 @@ title: Architecture Patterns
 The `SynthExecutor` interface decouples the engine from any specific LLM runtime:
 
 ```typescript
-interface SynthExecutor {
-  spawn(task: string, options?: { timeout?: number }): Promise<SynthSpawnResult>;
+interface SynthSpawnOptions {
+  model?: string;    // Model override for this subprocess
+  timeout?: number;  // Timeout in seconds
 }
 
 interface SynthSpawnResult {
-  output: string;
-  tokens?: number;
+  output: string;    // Subprocess output text
+  tokens?: number;   // Token count, if available from the executor
+}
+
+interface SynthExecutor {
+  spawn(task: string, options?: SynthSpawnOptions): Promise<SynthSpawnResult>;
 }
 ```
 
 Implementations:
-- **GatewayExecutor** (in the OpenClaw plugin) — spawns sessions via the gateway HTTP API
+- **GatewayExecutor** (included in lib) — spawns sessions via the OpenClaw gateway HTTP API, extracts token counts from session metadata
 - **Mock executor** (in tests) — returns canned responses for unit testing
 
 ## Pluggable WatcherClient
@@ -35,14 +40,37 @@ interface WatcherClient {
 }
 ```
 
-The included `HttpWatcherClient` implementation adds retry logic (3 attempts, exponential backoff).
+The included `HttpWatcherClient` implementation adds retry logic (3 attempts, exponential backoff):
+
+```typescript
+import { HttpWatcherClient } from '@karmaniverous/jeeves-meta';
+
+const watcher = new HttpWatcherClient({ baseUrl: 'http://localhost:1936' });
+```
+
+For paginated scanning across large result sets:
+
+```typescript
+import { paginatedScan } from '@karmaniverous/jeeves-meta';
+
+const allFiles = await paginatedScan(watcher, {
+  pathPrefix: 'j:/domains',
+  fields: ['generated_at_unix', 'has_error'],
+});
+```
 
 ## Engine Factory
 
 `createSynthEngine()` binds config, executor, and watcher into a `SynthEngine`:
 
 ```typescript
-const engine = createSynthEngine({ config, executor, watcher });
-const results = await engine.orchestrate();
-// Also available: engine.orchestrate({ target: 'path/to/.meta' })
+import { createSynthEngine } from '@karmaniverous/jeeves-meta';
+
+const engine = createSynthEngine(config, executor, watcher);
+
+// Synthesize next-stalest candidate(s) up to batchSize
+const results = await engine.synthesize();
+
+// Target a specific owner path
+const results = await engine.synthesizePath('j:/domains/email');
 ```

--- a/packages/lib/guides/cli.md
+++ b/packages/lib/guides/cli.md
@@ -1,0 +1,136 @@
+---
+title: CLI Reference
+---
+
+# CLI Reference
+
+The jeeves-meta CLI provides ad hoc invocation, debugging, and maintenance commands.
+
+## Usage
+
+```bash
+npx @karmaniverous/jeeves-meta <command> [options]
+```
+
+## Config Resolution
+
+All commands except `seed` and `unlock` require a config file:
+
+1. `--config <path>` flag (highest priority)
+2. `JEEVES_META_CONFIG` environment variable
+3. Error if neither is set
+
+## Global Options
+
+| Option | Description |
+|--------|-------------|
+| `--config <path>` | Path to `jeeves-meta.config.json` |
+| `--json` | Output as JSON (default: pretty-printed JSON) |
+| `--help`, `-h` | Show usage |
+
+## Commands
+
+### status
+
+Summary statistics for the entire synthesis fleet.
+
+```bash
+npx @karmaniverous/jeeves-meta status --config config.json
+```
+
+**Output:** total, stale, errors, locked, neverSynthesized, token totals.
+
+### list
+
+List metas with filtering.
+
+```bash
+npx @karmaniverous/jeeves-meta list [--prefix <p>] [--filter <f>]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--prefix <p>` | Filter by path substring |
+| `--filter <f>` | One of: `hasError`, `stale`, `locked`, `never` |
+
+### detail
+
+Full detail for a single meta.
+
+```bash
+npx @karmaniverous/jeeves-meta detail <path> [--archive <n>]
+```
+
+| Option | Description |
+|--------|-------------|
+| `<path>` | `.meta/` directory or owner directory path |
+| `--archive <n>` | Include N most recent archive snapshots |
+
+### preview
+
+Dry-run: show what inputs would be gathered without invoking LLM steps.
+
+```bash
+npx @karmaniverous/jeeves-meta preview [--path <p>]
+```
+
+If `--path` is omitted, previews the stalest candidate.
+
+**Output:** target, scope files count, delta detection, structure changes, steer changes, architect trigger reasons.
+
+### synthesize
+
+Run synthesis cycle(s).
+
+```bash
+npx @karmaniverous/jeeves-meta synthesize [--path <p>] [--batch <n>]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--path <p>` | Target a specific meta (omit for next-stalest) |
+| `--batch <n>` | Override `batchSize` for this run |
+
+This is the command used by jeeves-runner cron jobs.
+
+### seed
+
+Create a new `.meta/` directory with a fresh `meta.json` (UUID only). Does not require config.
+
+```bash
+npx @karmaniverous/jeeves-meta seed <path>
+```
+
+### unlock
+
+Force-remove a `.lock` file from a `.meta/` directory. Does not require config.
+
+```bash
+npx @karmaniverous/jeeves-meta unlock <path>
+```
+
+### validate
+
+Validate config and check service reachability (watcher + gateway).
+
+```bash
+npx @karmaniverous/jeeves-meta validate
+```
+
+**Output:** config validity, watcher status, gateway status, discovered meta count.
+
+### config show
+
+Dump the resolved config (prompts truncated for readability).
+
+```bash
+npx @karmaniverous/jeeves-meta config show
+```
+
+### config check
+
+Alias for `validate`.
+
+```bash
+npx @karmaniverous/jeeves-meta config check
+```

--- a/packages/lib/guides/configuration.md
+++ b/packages/lib/guides/configuration.md
@@ -6,22 +6,40 @@ title: Configuration
 
 ## Config Schema
 
-The `SynthConfigSchema` (Zod) defines all configuration options:
+The `synthConfigSchema` (Zod) defines all configuration options:
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `watchPaths` | `string[]` | required | Glob patterns for `.meta/` discovery |
-| `watcherUrl` | `string` | required | jeeves-watcher HTTP endpoint |
-| `defaultArchitect` | `string` | required | Default architect prompt text |
-| `defaultCritic` | `string` | required | Default critic prompt text |
-| `depthWeight` | `number` | `0.5` | Staleness weighting exponent for depth |
-| `maxArchive` | `number` | `10` | Maximum archive snapshots to retain |
-| `architectTimeout` | `number` | `120` | Architect step timeout (seconds) |
-| `builderTimeout` | `number` | `600` | Builder step timeout (seconds) |
-| `criticTimeout` | `number` | `300` | Critic step timeout (seconds) |
-| `architectRefreshCycles` | `number` | `10` | Re-run architect every N cycles |
-| `skipUnchanged` | `boolean` | `true` | Skip metas with no source changes |
+| `watchPaths` | `string[]` | required | Filesystem paths to scan for `.meta/` directories |
+| `watcherUrl` | `string` (URL) | required | jeeves-watcher HTTP endpoint |
+| `defaultArchitect` | `string` | required | Default architect prompt text (or `@file:` ref) |
+| `defaultCritic` | `string` | required | Default critic prompt text (or `@file:` ref) |
+| `gatewayUrl` | `string` (URL) | `http://127.0.0.1:3000` | OpenClaw gateway URL for subprocess spawning |
+| `gatewayApiKey` | `string` | `undefined` | Optional API key for gateway authentication |
+| `architectEvery` | `number` | `10` | Re-run architect every N synthesis cycles |
+| `depthWeight` | `number` | `0.5` | Exponent for depth weighting in staleness formula |
+| `maxArchive` | `number` | `20` | Maximum archive snapshots to retain per meta |
+| `maxLines` | `number` | `500` | Maximum lines of context in subprocess prompts |
+| `architectTimeout` | `number` | `120` | Architect step timeout (seconds, min 30) |
+| `builderTimeout` | `number` | `600` | Builder step timeout (seconds, min 60) |
+| `criticTimeout` | `number` | `300` | Critic step timeout (seconds, min 30) |
+| `skipUnchanged` | `boolean` | `true` | Skip metas with no source changes since last synthesis |
 | `batchSize` | `number` | `1` | Metas to synthesize per invocation |
+
+## Config Resolution
+
+The config path is resolved in order:
+
+1. `--config <path>` CLI flag
+2. `JEEVES_META_CONFIG` environment variable
+3. Error (no hardcoded default)
+
+```typescript
+import { resolveConfigPath, loadSynthConfig } from '@karmaniverous/jeeves-meta';
+
+const configPath = resolveConfigPath(process.argv.slice(2));
+const config = loadSynthConfig(configPath);
+```
 
 ## Prompt Files
 
@@ -29,12 +47,15 @@ Prompts are stored as Markdown files and referenced via `@file:` indirection in 
 
 ```json
 {
+  "watchPaths": ["j:/domains"],
+  "watcherUrl": "http://localhost:1936",
+  "gatewayUrl": "http://127.0.0.1:3000",
   "defaultArchitect": "@file:jeeves-meta/prompts/architect.md",
   "defaultCritic": "@file:jeeves-meta/prompts/critic.md"
 }
 ```
 
-The `@file:` prefix is resolved relative to the config directory (`J:\config\`) by the OpenClaw plugin's config loader.
+The `@file:` prefix is resolved **relative to the config file's directory**. So if the config is at `/config/jeeves-meta.config.json`, then `@file:jeeves-meta/prompts/architect.md` resolves to `/config/jeeves-meta/prompts/architect.md`.
 
 ## Per-Meta Overrides
 

--- a/packages/lib/guides/index.md
+++ b/packages/lib/guides/index.md
@@ -6,13 +6,15 @@ children:
   - ./orchestration.md
   - ./scheduling.md
   - ./architecture-patterns.md
+  - ./cli.md
   - ../CHANGELOG.md
 ---
 
 # Engine Guides
 
-- [Core Concepts](./concepts.md) -- ownership trees, scopes, meta.json structure, and the three-step pipeline.
-- [Configuration](./configuration.md) -- config schema reference, prompts, timeouts, and tuning parameters.
-- [Orchestration](./orchestration.md) -- the 13-step per-cycle flow, error handling, and output merging.
-- [Scheduling & Staleness](./scheduling.md) -- weighted formula, depth normalization, emphasis, and candidate selection.
-- [Architecture Patterns](./architecture-patterns.md) -- pluggable executor, watcher client, and engine factory patterns.
+- [Core Concepts](./concepts.md) — ownership trees, scopes, meta.json structure, and the three-step pipeline.
+- [Configuration](./configuration.md) — config schema reference, prompts, timeouts, and tuning parameters.
+- [Orchestration](./orchestration.md) — the 13-step per-cycle flow, error handling, and output merging.
+- [Scheduling & Staleness](./scheduling.md) — weighted formula, depth normalization, emphasis, and candidate selection.
+- [Architecture Patterns](./architecture-patterns.md) — pluggable executor, watcher client, and engine factory patterns.
+- [CLI Reference](./cli.md) — all 10 commands for status, listing, synthesis, debugging, and maintenance.

--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -5,14 +5,10 @@ OpenClaw plugin for [jeeves-meta](../lib/). Registers synthesis tools and virtua
 ## Features
 
 - **Four interactive tools** — `synth_list`, `synth_detail`, `synth_trigger`, `synth_preview`
-- **GatewayExecutor** — spawns LLM sessions via the OpenClaw gateway HTTP API
+- **GatewayExecutor** — spawns LLM sessions via the OpenClaw gateway HTTP API (included in core lib)
 - **Virtual inference rules** — registers Qdrant indexing rules for `.meta/meta.json` files, archive snapshots, and config
-- **Config loader** — reads `jeeves-meta.config.json` with `@file:` reference resolution
+- **TOOLS.md injection** — dynamic system prompt with entity stats and tool listing
 - **Consumer skill** — `SKILL.md` for agent integration
-
-## Architecture
-
-![Plugin Lifecycle](assets/plugin-lifecycle.png)
 
 ## Install
 
@@ -20,24 +16,34 @@ OpenClaw plugin for [jeeves-meta](../lib/). Registers synthesis tools and virtua
 npm install @karmaniverous/jeeves-meta-openclaw
 ```
 
+Then run the CLI installer to register with the OpenClaw gateway:
+
+```bash
+npx @karmaniverous/jeeves-meta-openclaw install
+```
+
 ## Configuration
 
-The plugin reads its config from `J:\config\jeeves-meta.config.json`. Prompt files are referenced via `@file:` indirection:
+The plugin reads its config path from the plugin `configPath` setting in `openclaw.json`. The config file itself is a standard `SynthConfig` JSON:
 
 ```json
 {
   "watchPaths": ["j:/domains"],
   "watcherUrl": "http://localhost:1936",
+  "gatewayUrl": "http://127.0.0.1:3000",
   "defaultArchitect": "@file:jeeves-meta/prompts/architect.md",
   "defaultCritic": "@file:jeeves-meta/prompts/critic.md"
 }
 ```
 
+See the [Configuration Guide](../lib/guides/configuration.md) for all fields and defaults.
+
 ## Documentation
 
-Full docs, guides, and API reference:
-
-**[docs.karmanivero.us/jeeves-meta](https://docs.karmanivero.us/jeeves-meta)**
+- **[Plugin Setup](guides/plugin-setup.md)** — installation, config, lifecycle
+- **[Tools Reference](guides/tools-reference.md)** — synth_list, synth_detail, synth_trigger, synth_preview
+- **[Virtual Rules](guides/virtual-rules.md)** — Qdrant inference rules
+- **[TOOLS.md Injection](guides/tools-injection.md)** — dynamic prompt generation
 
 ## License
 

--- a/packages/openclaw/guides/index.md
+++ b/packages/openclaw/guides/index.md
@@ -4,11 +4,13 @@ children:
   - ./plugin-setup.md
   - ./tools-reference.md
   - ./virtual-rules.md
+  - ./tools-injection.md
   - ../CHANGELOG.md
 ---
 
 # OpenClaw Plugin
 
-- [Plugin Setup](./plugin-setup.md) -- installation, configuration, and config loader.
-- [Tools Reference](./tools-reference.md) -- synth_list, synth_detail, synth_trigger, synth_preview.
-- [Virtual Rules](./virtual-rules.md) -- inference rules registered with jeeves-watcher for Qdrant indexing.
+- [Plugin Setup](./plugin-setup.md) — installation, configuration, lifecycle, and config loader.
+- [Tools Reference](./tools-reference.md) — synth_list, synth_detail, synth_trigger, synth_preview.
+- [Virtual Rules](./virtual-rules.md) — inference rules registered with jeeves-watcher for Qdrant indexing.
+- [TOOLS.md Injection](./tools-injection.md) — dynamic system prompt generation with entity stats.

--- a/packages/openclaw/guides/plugin-setup.md
+++ b/packages/openclaw/guides/plugin-setup.md
@@ -12,32 +12,48 @@ Install the plugin package:
 npm install @karmaniverous/jeeves-meta-openclaw
 ```
 
-Register it with the OpenClaw gateway configuration.
+Run the CLI installer to register with the OpenClaw gateway:
+
+```bash
+npx @karmaniverous/jeeves-meta-openclaw install
+```
+
+Then restart the OpenClaw gateway to load the plugin.
 
 ## Configuration
 
-The plugin reads `J:\config\jeeves-meta.config.json` via `loadSynthConfig()`:
+The plugin reads its config path from the `configPath` setting in `openclaw.json`. This points to a `jeeves-meta.config.json` file:
 
 ```json
 {
   "watchPaths": ["j:/domains"],
   "watcherUrl": "http://localhost:1936",
+  "gatewayUrl": "http://127.0.0.1:3000",
   "defaultArchitect": "@file:jeeves-meta/prompts/architect.md",
   "defaultCritic": "@file:jeeves-meta/prompts/critic.md",
   "depthWeight": 0.5,
   "skipUnchanged": true,
-  "batchSize": 1
+  "batchSize": 1,
+  "maxArchive": 20
 }
 ```
 
+See the [Configuration Guide](../../lib/guides/configuration.md) for the complete schema.
+
 ### @file: Resolution
 
-Prompt values prefixed with `@file:` are resolved relative to `J:\config\`. The config loader reads the referenced file and replaces the `@file:` value with its contents.
+Prompt values prefixed with `@file:` are resolved **relative to the config file's directory**. The config loader reads the referenced file and replaces the `@file:` value with its contents.
+
+For example, if the config is at `/config/jeeves-meta.config.json`:
+- `@file:jeeves-meta/prompts/architect.md` resolves to `/config/jeeves-meta/prompts/architect.md`
 
 ## Lifecycle
 
-![Plugin Lifecycle](../assets/plugin-lifecycle.png)
-
 At gateway startup, the plugin:
-1. Registers four tools (`synth_list`, `synth_detail`, `synth_trigger`, `synth_preview`)
-2. Registers three virtual inference rules with jeeves-watcher (fire-and-forget)
+
+1. Loads config via `loadSynthConfig()` (re-exported from the core library)
+2. Registers four tools (`synth_list`, `synth_detail`, `synth_trigger`, `synth_preview`)
+3. Registers three virtual inference rules with jeeves-watcher (fire-and-forget)
+4. Writes the dynamic TOOLS.md section with entity stats
+
+The plugin uses lazy config loading — the config file is read once on first tool invocation, not at startup.

--- a/packages/openclaw/guides/tools-injection.md
+++ b/packages/openclaw/guides/tools-injection.md
@@ -1,0 +1,48 @@
+---
+title: TOOLS.md Injection
+---
+
+# TOOLS.md Injection
+
+The plugin generates a dynamic Markdown section for the agent's TOOLS.md system prompt, providing at-a-glance synthesis engine status.
+
+## How It Works
+
+The `toolsWriter` module queries the watcher API at plugin startup and writes a Meta section into the TOOLS.md file on disk. The agent sees this content in every session.
+
+## Three Output Modes
+
+### 1. Watcher Unreachable
+
+When the watcher API is down or misconfigured:
+
+```
+> **ACTION REQUIRED: jeeves-watcher is unreachable.**
+> ...
+```
+
+### 2. No Entities Found
+
+When the watcher is running but no `.meta/` directories are indexed:
+
+```
+> **ACTION REQUIRED: No synthesis entities found.**
+> ...
+```
+
+### 3. Healthy (normal mode)
+
+Entity summary table, token usage, and tool listing:
+
+- **Entity Summary** — total, stale, errors, never synthesized, stalest, last synthesized
+- **Token Usage** — cumulative architect/builder/critic tokens
+- **Tools** — quick reference table of all four synth tools
+- **Skill reference** — pointer to the jeeves-meta skill for detailed guidance
+
+## TOOLS.md Ordering
+
+The Meta section appears after the Watcher and Server sections:
+
+1. Watcher
+2. Server
+3. Meta

--- a/packages/openclaw/guides/tools-reference.md
+++ b/packages/openclaw/guides/tools-reference.md
@@ -10,10 +10,16 @@ List metas with summary statistics and per-meta projection.
 
 **Parameters:**
 - `pathPrefix?` — filter by path prefix (e.g. `github/`)
-- `filter?` — structured filter: `{ hasError: true }`, `{ staleHours: 24 }`, `{ neverSynthesized: true }`, `{ locked: true }`
-- `fields?` — projection array (default: path, depth, emphasis, stalenessSeconds, lastSynthesized, hasError, locked, architectTokens, builderTokens, criticTokens)
+- `filter?` — structured filter object:
+  - `hasError`: `boolean` — only metas with/without errors
+  - `staleHours`: `number` — only metas stale for at least N hours
+  - `neverSynthesized`: `boolean` — only never-synthesized metas
+  - `locked`: `boolean` — only locked/unlocked metas
+- `fields?` — projection array (default: path, depth, emphasis, stalenessSeconds, lastSynthesized, hasError, locked, architectTokens, builderTokens, criticTokens, children)
 
-**Returns:** Summary object (total, stale, errors, locked, neverSynthesized, token totals) plus filtered item list.
+**Returns:** Summary object (total, stale, errors, locked, neverSynthesized, token totals, stalestPath, lastSynthesizedPath/At) plus filtered item list sorted by path.
+
+**Data source:** Queries watcher via `paginatedScan` with `synth-meta` domain filter (not filesystem).
 
 ## synth_detail
 
@@ -24,22 +30,39 @@ Full detail for a single meta with optional archive history.
 - `fields?` — property projection (default: all except _architect, _builder, _critic, _content, _feedback)
 - `includeArchive?` — `false` (default), `true` (all), or `number` (N most recent)
 
-**Returns:** Full meta.json content plus optional archive entries.
+**Returns:** Full meta.json content (projected) plus optional archive entries (most recent first).
+
+**Data source:** Direct filesystem read of `meta.json` and archive files.
 
 ## synth_trigger
 
 Manually trigger synthesis for a specific meta or next-stalest.
 
 **Parameters:**
-- `path?` — target `.meta/` path (omit for next-stalest)
+- `path?` — target `.meta/` or owner directory path (omit for next-stalest)
 
-**Returns:** Orchestration result with synthesis outcome.
+**Returns:** Synthesis outcome: count, per-meta results with error details if any.
+
+**Note:** Runs the full 3-step LLM cycle (architect → builder → critic). Can take several minutes. Uses the `GatewayExecutor` with `gatewayUrl`/`gatewayApiKey` from config.
 
 ## synth_preview
 
 Dry-run showing what inputs would be gathered without invoking LLM steps.
 
 **Parameters:**
-- `path?` — target `.meta/` path (omit for next-stalest)
+- `path?` — target `.meta/` or owner directory path (omit for next-stalest)
 
-**Returns:** Context package preview: scope files, delta files, child outputs, staleness info.
+**Returns:**
+- `target` — selected meta path
+- `ownerPath` — owner directory
+- `depth` — effective depth
+- `staleness` — time since last synthesis
+- `scopeFiles` — count + sample (first 20)
+- `deltaFiles` — count + sample (files changed since last synthesis)
+- `structureChanged` — whether file additions/removals detected
+- `steerChanged` — whether `_steer` differs from latest archive
+- `architectTriggered` — whether the architect step would run
+- `architectTriggerReasons` — human-readable list of triggers
+- `currentSteer` — current `_steer` value
+- `hasExistingContent` / `hasExistingFeedback` — previous state
+- `children` — child meta paths

--- a/packages/openclaw/guides/virtual-rules.md
+++ b/packages/openclaw/guides/virtual-rules.md
@@ -16,7 +16,7 @@ Indexes live `.meta/meta.json` files with extracted fields:
 - `synth_error_step`, `has_error`, `generated_at_unix`
 - Domain: `synth-meta`
 
-The rule renders `_content` as the document body for semantic search.
+The rule uses declarative `render` config to output `_content` as the document body for semantic search, with synthesis metadata as YAML frontmatter.
 
 ## Rule 2: synth-meta-archive
 
@@ -25,9 +25,20 @@ Indexes `.meta/archive/*.json` snapshots:
 - `synth_id`, `archived`, `archived_at`
 - Domain: `synth-archive`
 
+Renders archived `_content` as the document body.
+
 ## Rule 3: synth-config
 
 Indexes `jeeves-meta.config.json`:
 
 - Domain: `synth-config`
-- Rendered via `synth-config.hbs` template
+- Renders config fields as frontmatter, default prompts as body sections
+
+## Render Config (not templates)
+
+All three rules use the declarative `render` configuration rather than Handlebars templates. The `render` config specifies:
+
+- **`frontmatter`**: Array of field names to include as YAML frontmatter
+- **`body`**: Array of `{ path, heading, label }` objects defining Markdown body sections
+
+This approach is pure data — no template authoring required, and it works with virtual rules (which bypass the watcher's template engine).


### PR DESCRIPTION
Complete audit of all documentation against actual implementation. 12 files changed, 2 new guides added.

**Fixes (implementation drift):**
- \createSynthEngine()\ signature (3 args, not object)
- \engine.synthesize()\/\synthesizePath()\ (not \orchestrate()\)
- \HttpWatcherClient({ baseUrl })\ constructor
- \SynthSpawnOptions\ includes \model\ field
- \rchitectEvery\ field name (was \rchitectRefreshCycles\)
- \maxArchive\ default 20 (was 10)
- Missing config fields: \gatewayUrl\, \gatewayApiKey\, \maxLines\, \atchSize\
- Config resolution: \--config\ → env var → error (not hardcoded)
- \@file:\ resolution relative to config dir
- synth-config rule uses \ender\ config, not template

**New docs:**
- CLI Reference guide (10 commands)
- TOOLS.md Injection guide (3 output modes)

130 tests passing, all checks green.