### PR TITLE
fix: add outDir to CLI rollup builds for clean-build compatibility

### DIFF
--- a/packages/lib/rollup.config.ts
+++ b/packages/lib/rollup.config.ts
@@ -47,6 +47,7 @@ const buildCli: RollupOptions = {
     typescriptPlugin({
       tsconfig: './tsconfig.json',
       outputToFilesystem: false,
+      outDir: 'dist',
       include: ['src/**/*.ts'],
       exclude: ['**/*.test.ts'],
       noEmit: false,

--- a/packages/openclaw/rollup.config.ts
+++ b/packages/openclaw/rollup.config.ts
@@ -37,6 +37,7 @@ const cliConfig: RollupOptions = {
     typescriptPlugin({
       tsconfig: './tsconfig.json',
       outputToFilesystem: false,
+      outDir: 'dist',
       noEmit: false,
       declaration: false,
       incremental: false,


### PR DESCRIPTION
Both lib and openclaw CLI rollup configs use \output.file\ for the CLI entry point. Without explicit \outDir: 'dist'\, \@rollup/plugin-typescript\ fails when \dist/\ doesn't exist (fresh clone / \
pm ci\).

Verified: deleted both \dist/\ dirs, clean build succeeds. All checks green.