### PR TITLE
fix: filter watcher scan to meta.json files only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ context/
 .stan/imports/
 
 docs/
+*.tgz

--- a/packages/lib/src/discovery/discoverMetas.test.ts
+++ b/packages/lib/src/discovery/discoverMetas.test.ts
@@ -37,7 +37,10 @@ describe('buildMetaFilter', () => {
   it('builds filter from first domain in metaProperty', () => {
     const filter = buildMetaFilter(config);
     expect(filter).toEqual({
-      must: [{ key: 'domains', match: { value: 'meta' } }],
+      must: [
+        { key: 'domains', match: { value: 'meta' } },
+        { key: 'file_path', match: { text: 'meta.json' } },
+      ],
     });
   });
 
@@ -48,7 +51,10 @@ describe('buildMetaFilter', () => {
     } as SynthConfig;
     const filter = buildMetaFilter(custom);
     expect(filter).toEqual({
-      must: [{ key: 'domains', match: { value: 'synth-meta' } }],
+      must: [
+        { key: 'domains', match: { value: 'synth-meta' } },
+        { key: 'file_path', match: { text: 'meta.json' } },
+      ],
     });
   });
 });
@@ -86,7 +92,12 @@ describe('discoverMetas', () => {
     await discoverMetas(config, watcher);
     expect(scan).toHaveBeenCalledWith(
       expect.objectContaining({
-        filter: { must: [{ key: 'domains', match: { value: 'meta' } }] },
+        filter: {
+          must: [
+            { key: 'domains', match: { value: 'meta' } },
+            { key: 'file_path', match: { text: 'meta.json' } },
+          ],
+        },
       }),
     );
   });

--- a/packages/lib/src/discovery/discoverMetas.ts
+++ b/packages/lib/src/discovery/discoverMetas.ts
@@ -25,6 +25,10 @@ export function buildMetaFilter(config: SynthConfig): Record<string, unknown> {
         key: 'domains',
         match: { value: config.metaProperty.domains[0] },
       },
+      {
+        key: 'file_path',
+        match: { text: 'meta.json' },
+      },
     ],
   };
 }
@@ -50,17 +54,16 @@ export async function discoverMetas(
     fields: ['file_path'],
   });
 
-  // Deduplicate by file_path (multi-chunk files)
+  // Deduplicate by .meta/ directory path (handles multi-chunk files)
   const seen = new Set<string>();
   const metaPaths: string[] = [];
 
   for (const sf of scanFiles) {
     const fp = normalizePath(sf.file_path);
-    if (seen.has(fp)) continue;
-    seen.add(fp);
-
     // Derive .meta/ directory from file_path (strip /meta.json)
     const metaPath = fp.replace(/\/meta\.json$/, '');
+    if (seen.has(metaPath)) continue;
+    seen.add(metaPath);
     metaPaths.push(metaPath);
   }
 


### PR DESCRIPTION
Adds file_path text match for meta.json to buildMetaFilter(), preventing non-meta.json files inside .meta/ dirs from creating bogus meta paths during discovery. Also adds *.tgz to .gitignore and deduplicates by .meta/ directory path instead of full file_path.