### PR TITLE
chore: add release scripts to service package

### DIFF
--- a/packages/service/.env.local.template
+++ b/packages/service/.env.local.template
@@ -1,0 +1,13 @@
+# This file is a template for the .env.local. Add your Personal Access Token 
+# below to streamline the release process from your desktop! Just follow these 
+# steps: 
+# 
+# 1. Make a copy of this file and rename it to .env.local.
+#
+# 2. Create a Personal Access Token at https://github.com/settings/tokens and 
+#    enter it below.
+#
+# .env.local is gitignored and will NOT be persisted to your repo, but don't 
+# put any secrets in this template!
+
+GITHUB_TOKEN=

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -67,9 +67,43 @@
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "test": "vitest run",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "changelog": "auto-changelog",
+    "release": "dotenvx run -f .env.local -- release-it",
+    "release:pre": "dotenvx run -f .env.local -- release-it --no-git.requireBranch --github.prerelease --preRelease"
   },
   "bin": {
     "jeeves-meta": "./dist/cli/jeeves-meta/index.js"
+  },
+  "release-it": {
+    "git": {
+      "changelog": "npx auto-changelog --unreleased-only --stdout --template https://raw.githubusercontent.com/release-it/release-it/main/templates/changelog-compact.hbs",
+      "commitMessage": "chore: release @karmaniverous/jeeves-meta v${version}",
+      "tagName": "service/${version}",
+      "requireBranch": "main"
+    },
+    "github": {
+      "release": true
+    },
+    "hooks": {
+      "after:init": [
+        "npm run lint",
+        "npm run typecheck",
+        "npm run test",
+        "npm run build"
+      ],
+      "before:npm:release": [
+        "npx auto-changelog -p",
+        "git add -A"
+      ],
+      "after:release": [
+        "git switch -c release/service/${version}",
+        "git push -u origin release/service/${version}",
+        "git switch ${branchName}"
+      ]
+    },
+    "npm": {
+      "publish": true
+    }
   }
 }


### PR DESCRIPTION
Adds release-it configuration to the service package, matching the openclaw package pattern.

- \
pm run release\ / \
pm run release:pre\
- Git tag prefix: \service/\
- Quality gate hooks: lint → typecheck → test → build
- auto-changelog integration
- \.env.local.template\ for GitHub PAT