### PR TITLE
refactor: use package-directory for version resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5185,6 +5185,18 @@
         "node": ">=20"
       }
     },
+    "node_modules/find-up-simple": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/formatly": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/formatly/-/formatly-0.3.0.tgz",
@@ -6702,6 +6714,21 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/package-directory": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/package-directory/-/package-directory-8.2.0.tgz",
+      "integrity": "sha512-qJSu5Mo6tHmRxCy2KCYYKYgcfBdUpy9dwReaZD/xwf608AUk/MoRtIOWzgDtUeGeC7n/55yC3MI1Q+MbSoektw==",
+      "license": "MIT",
+      "dependencies": {
+        "find-up-simple": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -8420,7 +8447,7 @@
     },
     "packages/openclaw": {
       "name": "@karmaniverous/jeeves-meta-openclaw",
-      "version": "0.1.5",
+      "version": "0.2.0",
       "license": "BSD-3-Clause",
       "bin": {
         "jeeves-meta-openclaw": "dist/cli.js"
@@ -8442,12 +8469,13 @@
     },
     "packages/service": {
       "name": "@karmaniverous/jeeves-meta",
-      "version": "0.3.3",
+      "version": "0.4.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "commander": "^14",
         "croner": "^10",
         "fastify": "^5.7",
+        "package-directory": "^8.2.0",
         "pino": "^10",
         "zod": "^4.3"
       },

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -44,6 +44,7 @@
     "commander": "^14",
     "croner": "^10",
     "fastify": "^5.7",
+    "package-directory": "^8.2.0",
     "pino": "^10",
     "zod": "^4.3"
   },

--- a/packages/service/src/constants.ts
+++ b/packages/service/src/constants.ts
@@ -8,6 +8,8 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { packageDirectorySync } from 'package-directory';
+
 /** Default HTTP port for the jeeves-meta service. */
 export const DEFAULT_PORT = 1938;
 
@@ -21,19 +23,12 @@ export const SERVICE_NAME = 'jeeves-meta';
 export const SERVICE_VERSION: string = (() => {
   try {
     const dir = dirname(fileURLToPath(import.meta.url));
-    // Walk up to find package.json (works from src/ or dist/)
-    for (const candidate of [
-      resolve(dir, '..', 'package.json'),
-      resolve(dir, '..', '..', 'package.json'),
-    ]) {
-      try {
-        const pkg = JSON.parse(readFileSync(candidate, 'utf8')) as {
-          version?: string;
-        };
-        if (pkg.version) return pkg.version;
-      } catch {
-        // try next candidate
-      }
+    const root = packageDirectorySync({ cwd: dir });
+    if (root) {
+      const pkg = JSON.parse(
+        readFileSync(resolve(root, 'package.json'), 'utf8'),
+      ) as { version?: string };
+      if (pkg.version) return pkg.version;
     }
     return 'unknown';
   } catch {


### PR DESCRIPTION
Replace hand-rolled 5-level directory walk with packageDirectorySync from package-directory.

Fixes the 'unknown' version in /status when running from bundled CLI (dist/cli/jeeves-meta/).