### PR TITLE
fix: architect markdown output enforcement + JSON unwrap fallback

### DIFF
--- a/packages/service/src/orchestrator/orchestrate.ts
+++ b/packages/service/src/orchestrator/orchestrate.ts
@@ -202,9 +202,6 @@ async function synthesizeNode(
   watcher: WatcherClient,
   onProgress?: ProgressCallback,
 ): Promise<OrchestrateResult> {
-  const architectPrompt = currentMeta._architect ?? config.defaultArchitect;
-  const criticPrompt = currentMeta._critic ?? config.defaultCritic;
-
   // Step 5-6: Steer change detection
   const latestArchive = readLatestArchive(node.metaPath);
   const steerChanged = hasSteerChanged(

--- a/packages/service/src/orchestrator/parseOutput.ts
+++ b/packages/service/src/orchestrator/parseOutput.ts
@@ -17,13 +17,47 @@ export interface BuilderOutput {
 }
 
 /**
- * Parse architect output. The architect returns a task brief as text.
+ * Parse architect output. The architect should return a plain Markdown task brief.
+ *
+ * If the architect wraps its output in JSON (despite prompt instructions),
+ * extract the text values and concatenate them as markdown.
  *
  * @param output - Raw subprocess output.
- * @returns The task brief string.
+ * @returns The task brief string as plain Markdown.
  */
 export function parseArchitectOutput(output: string): string {
-  return output.trim();
+  const trimmed = output.trim();
+
+  // If it looks like JSON, try to unwrap it
+  if (trimmed.startsWith('{')) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (typeof parsed === 'object' && parsed !== null) {
+        return extractTextFromJson(parsed as Record<string, unknown>);
+      }
+    } catch {
+      // Not valid JSON — treat as text
+    }
+  }
+
+  return trimmed;
+}
+
+/** Recursively extract string values from a JSON object into markdown. */
+function extractTextFromJson(obj: Record<string, unknown>): string {
+  const parts: string[] = [];
+  for (const [, value] of Object.entries(obj)) {
+    if (typeof value === 'string') {
+      parts.push(value);
+    } else if (
+      typeof value === 'object' &&
+      value !== null &&
+      !Array.isArray(value)
+    ) {
+      parts.push(extractTextFromJson(value as Record<string, unknown>));
+    }
+  }
+  return parts.join('\n\n');
 }
 
 /**

--- a/packages/service/src/rules/index.ts
+++ b/packages/service/src/rules/index.ts
@@ -92,7 +92,15 @@ function buildMetaRules(config: MetaConfig) {
         },
       ],
       render: {
-        frontmatter: ['meta_id', 'generated_at', '*', '!_*', '!json', '!file', '!has_error'],
+        frontmatter: [
+          'meta_id',
+          'generated_at',
+          '*',
+          '!_*',
+          '!json',
+          '!file',
+          '!has_error',
+        ],
         body: [{ path: 'json._content', heading: 1, label: 'Synthesis' }],
       },
       renderAs: 'md',


### PR DESCRIPTION
- Architect prompt now explicitly says 'Respond with ONLY plain Markdown. No JSON wrapping.'
- parseArchitectOutput defensively unwraps JSON if architect ignores the prompt
- Removed dead architectPrompt/criticPrompt locals from orchestrate.ts