### PR TITLE
fix(service): unique session labels per synthesis cycle

### DIFF
--- a/packages/service/src/executor/GatewayExecutor.ts
+++ b/packages/service/src/executor/GatewayExecutor.ts
@@ -162,10 +162,14 @@ export class GatewayExecutor implements MetaExecutor {
       '\n\n' +
       'Reply with ONLY the file path you wrote to. No other text.';
 
-    // Step 1: Spawn the sub-agent session
+    // Step 1: Spawn the sub-agent session (unique label per cycle to avoid
+    // "label already in use" errors — gateway labels persist after session completion)
+    const labelBase = options?.label ?? 'jeeves-meta-synthesis';
+    const label = labelBase + '-' + outputId.slice(0, 8);
+
     const spawnResult = await this.invoke('sessions_spawn', {
       task: taskWithOutput,
-      label: options?.label ?? 'jeeves-meta-synthesis',
+      label,
       runTimeoutSeconds: timeoutSeconds,
       ...(options?.thinking ? { thinking: options.thinking } : {}),
       ...(options?.model ? { model: options.model } : {}),


### PR DESCRIPTION
Fixes repeated label-already-in-use errors in gateway logs.

Root cause: GatewayExecutor.spawn() used a fixed label (jeeves-meta-synthesis) for every session. Gateway labels persist after session completion, so the second cycle always collided.

Fix: Append a UUID fragment to the label: jeeves-meta-synthesis-a7f3c2e1. Each cycle gets a unique label. Labels remain human-readable for debugging.

Quality gates: build, 183 tests, typecheck, lint, knip — all green.