### PR TITLE
fix(openclaw): use core resolveWorkspacePath from jeeves v0.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1172,9 +1172,9 @@
       }
     },
     "node_modules/@karmaniverous/jeeves": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@karmaniverous/jeeves/-/jeeves-0.1.3.tgz",
-      "integrity": "sha512-g0Xqrt1FTJMLxCzzAd+WFSdMEGy8gtKvH7lGzWtty1wCf205AlyXU8TkviVpjR0pE2kRawTfvA+5P1R/6A40Ag==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@karmaniverous/jeeves/-/jeeves-0.1.4.tgz",
+      "integrity": "sha512-5JXtZT9exkkNcwsL88dsNLhEf4h5sxbW30DG6un61eeBXajllXkFMvE33CKg6ZebV6laXsHowsmAUmpJC4xZrw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "commander": "^14.0.2",
@@ -8271,7 +8271,7 @@
       "version": "0.4.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@karmaniverous/jeeves": "^0.1.3"
+        "@karmaniverous/jeeves": "^0.1.4"
       },
       "bin": {
         "jeeves-meta-openclaw": "dist/cli.js"

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -119,6 +119,6 @@
     }
   },
   "dependencies": {
-    "@karmaniverous/jeeves": "^0.1.3"
+    "@karmaniverous/jeeves": "^0.1.4"
   }
 }

--- a/packages/openclaw/src/helpers.ts
+++ b/packages/openclaw/src/helpers.ts
@@ -10,6 +10,11 @@ export interface PluginApi {
     plugins?: {
       entries?: Record<string, { config?: Record<string, unknown> }>;
     };
+    agents?: {
+      defaults?: {
+        workspace?: string;
+      };
+    };
   };
   resolvePath?: (input: string) => string;
   registerTool(

--- a/packages/openclaw/src/index.ts
+++ b/packages/openclaw/src/index.ts
@@ -15,6 +15,7 @@ import {
   createAsyncContentCache,
   createComponentWriter,
   init,
+  resolveWorkspacePath,
 } from '@karmaniverous/jeeves';
 
 import { getConfigRoot, getServiceUrl, type PluginApi } from './helpers.js';
@@ -39,14 +40,6 @@ const PLUGIN_VERSION: string = (() => {
     return 'unknown';
   }
 })();
-
-/**
- * Resolve the workspace path from the OpenClaw plugin API.
- * Falls back to CWD if `api.resolvePath` is unavailable.
- */
-function resolveWorkspacePath(api: PluginApi): string {
-  return api.resolvePath ? api.resolvePath('.') : process.cwd();
-}
 
 /** Register all jeeves-meta tools with the OpenClaw plugin API. */
 export default function register(api: PluginApi): void {


### PR DESCRIPTION
Replaces local resolveWorkspacePath with core's three-step fallback. Fixes TOOLS.md being written to system32 when gateway runs as NSSM service.

Quality gates: build, 25 tests, typecheck, lint, knip — all green.