### PR TITLE
fix: standardise bind address, plugin configSchema naming, and defaults (#65)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8321,7 +8321,7 @@
     },
     "packages/openclaw": {
       "name": "@karmaniverous/jeeves-meta-openclaw",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@karmaniverous/jeeves": "^0.2.0"
@@ -8567,7 +8567,7 @@
     },
     "packages/service": {
       "name": "@karmaniverous/jeeves-meta",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@karmaniverous/jeeves": "^0.2.0",

--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -32,7 +32,7 @@ The plugin resolves settings via a three-step fallback chain: plugin config → 
 
 | Setting | Plugin Config Key | Env Var | Default |
 |---------|-------------------|---------|---------|
-| Service URL | `serviceUrl` | `JEEVES_META_URL` | `http://127.0.0.1:1938` |
+| Service URL | `apiUrl` | `JEEVES_META_URL` | `http://127.0.0.1:1938` |
 | Config Root | `configRoot` | `JEEVES_CONFIG_ROOT` | `j:/config` |
 
 ```json
@@ -42,7 +42,7 @@ The plugin resolves settings via a three-step fallback chain: plugin config → 
       "jeeves-meta-openclaw": {
         "enabled": true,
         "config": {
-          "serviceUrl": "http://127.0.0.1:1938",
+          "apiUrl": "http://127.0.0.1:1938",
           "configRoot": "j:/config"
         }
       }

--- a/packages/openclaw/guides/plugin-setup.md
+++ b/packages/openclaw/guides/plugin-setup.md
@@ -17,7 +17,7 @@ The plugin resolves settings via a three-step fallback chain: plugin config → 
 
 | Setting | Plugin Config Key | Env Var | Default |
 |---------|-------------------|---------|---------|
-| Service URL | `serviceUrl` | `JEEVES_META_URL` | `http://127.0.0.1:1938` |
+| Service URL | `apiUrl` | `JEEVES_META_URL` | `http://127.0.0.1:1938` |
 | Config Root | `configRoot` | `JEEVES_CONFIG_ROOT` | `j:/config` |
 
 ### Plugin Config
@@ -31,7 +31,7 @@ In your OpenClaw configuration (`openclaw.json` or equivalent):
       "jeeves-meta-openclaw": {
         "enabled": true,
         "config": {
-          "serviceUrl": "http://127.0.0.1:1938",
+          "apiUrl": "http://127.0.0.1:1938",
           "configRoot": "j:/config"
         }
       }

--- a/packages/openclaw/openclaw.plugin.json
+++ b/packages/openclaw/openclaw.plugin.json
@@ -9,9 +9,10 @@
   "configSchema": {
     "type": "object",
     "properties": {
-      "serviceUrl": {
+      "apiUrl": {
         "type": "string",
-        "description": "URL of the jeeves-meta HTTP service. Defaults to http://127.0.0.1:1938. Falls back to JEEVES_META_URL env var."
+        "description": "URL of the jeeves-meta HTTP service. Falls back to JEEVES_META_URL env var.",
+        "default": "http://127.0.0.1:1938"
       },
       "configRoot": {
         "type": "string",

--- a/packages/openclaw/skills/jeeves-meta/SKILL.md
+++ b/packages/openclaw/skills/jeeves-meta/SKILL.md
@@ -138,6 +138,7 @@ Key settings:
 | `skipUnchanged` | true | Skip candidates with no changes since last synthesis |
 | `thinking` | `low` | Thinking level for spawned LLM sessions |
 | `port` | 1938 | HTTP API listen port |
+| `host` | `127.0.0.1` | Bind address for the HTTP server |
 | `schedule` | `*/30 * * * *` | Cron expression for automatic synthesis scheduling |
 | `serverBaseUrl` | (optional) | Public base URL of the service (e.g. `http://myhost:1938`). When set, progress reports include clickable entity links. |
 | `reportChannel` | (optional) | Gateway channel target for progress messages (e.g. Slack channel ID) |
@@ -256,8 +257,8 @@ The following fields can be changed without restarting the service:
 - `logging.level` — log verbosity
 
 Edit the config file and save; the service detects changes via `fs.watchFile`.
-All other fields (including `metaProperty`, `port`, timeouts) require a service
-restart.
+All other fields (including `metaProperty`, `host`, `port`, timeouts) require a
+service restart.
 
 ### Progress Reporting
 
@@ -337,7 +338,7 @@ To uninstall: `npx @karmaniverous/jeeves-meta-openclaw uninstall`
       "jeeves-meta-openclaw": {
         "enabled": true,
         "config": {
-          "serviceUrl": "http://127.0.0.1:1938"
+          "apiUrl": "http://127.0.0.1:1938"
         }
       }
     }
@@ -432,11 +433,11 @@ stalest entity) in the agent's system prompt automatically.
 ### Service unreachable
 
 **Symptom:** TOOLS.md shows "ACTION REQUIRED: jeeves-meta service is unreachable"
-**Cause:** Meta service not running or wrong `serviceUrl` in plugin config
+**Cause:** Meta service not running or wrong `apiUrl` in plugin config
 **Fix:**
 1. Check if the service is running: `jeeves-meta service status` or `curl http://localhost:1938/status`
 2. If down, start it: `jeeves-meta service start` or `jeeves-meta start --config <path>`
-3. If running on a different port, update `serviceUrl` in plugin config
+3. If running on a different port, update `apiUrl` in plugin config
 
 ### Watcher unreachable
 

--- a/packages/openclaw/src/helpers.ts
+++ b/packages/openclaw/src/helpers.ts
@@ -13,7 +13,7 @@ export function getServiceUrl(api: PluginApi): string {
   return resolvePluginSetting(
     api,
     PLUGIN_ID,
-    'serviceUrl',
+    'apiUrl',
     'JEEVES_META_URL',
     'http://127.0.0.1:1938',
   );

--- a/packages/openclaw/src/index.ts
+++ b/packages/openclaw/src/index.ts
@@ -44,7 +44,7 @@ const PLUGIN_VERSION: string = (() => {
 
 /** Register all jeeves-meta tools with the OpenClaw plugin API. */
 export default function register(api: PluginApi): void {
-  const client = new MetaServiceClient({ serviceUrl: getServiceUrl(api) });
+  const client = new MetaServiceClient({ apiUrl: getServiceUrl(api) });
 
   registerMetaTools(api, client);
 

--- a/packages/openclaw/src/promptInjection.ts
+++ b/packages/openclaw/src/promptInjection.ts
@@ -37,7 +37,7 @@ export async function generateMetaMenu(
       '> **Troubleshooting:**',
       '> - Verify the service is installed: `npm list -g @karmaniverous/jeeves-meta`',
       '> - Check if running: `curl http://localhost:1938/status`',
-      '> - Verify `serviceUrl` in plugin config if using a non-default port',
+      '> - Verify `apiUrl` in plugin config if using a non-default port',
       '>',
       "> **Read the `jeeves-meta` skill's Bootstrapping section** for full setup guidance.",
     ].join('\n');

--- a/packages/openclaw/src/serviceClient.ts
+++ b/packages/openclaw/src/serviceClient.ts
@@ -54,14 +54,14 @@ export interface MetasResponse {
 /** Constructor config. */
 interface MetaServiceConfig {
   /** Base URL of the jeeves-meta service (e.g. http://127.0.0.1:1938). */
-  serviceUrl: string;
+  apiUrl: string;
 }
 
 export class MetaServiceClient {
   private readonly baseUrl: string;
 
   public constructor(config: MetaServiceConfig) {
-    this.baseUrl = config.serviceUrl.replace(/\/$/, '');
+    this.baseUrl = config.apiUrl.replace(/\/$/, '');
   }
 
   /** Return the base URL (for error reporting). */

--- a/packages/service/src/bootstrap.ts
+++ b/packages/service/src/bootstrap.ts
@@ -77,8 +77,8 @@ export async function startService(
 
   // Start HTTP server
   try {
-    await server.listen({ port: config.port, host: '0.0.0.0' });
-    logger.info({ port: config.port }, 'Service listening');
+    await server.listen({ port: config.port, host: config.host });
+    logger.info({ port: config.port, host: config.host }, 'Service listening');
   } catch (err) {
     logger.error(err, 'Failed to start service');
     process.exit(1);

--- a/packages/service/src/routes/config.test.ts
+++ b/packages/service/src/routes/config.test.ts
@@ -29,6 +29,7 @@ function makeDeps(overrides: Partial<RouteDeps> = {}): RouteDeps {
       metaProperty: {},
       metaArchiveProperty: {},
       port: 1938,
+      host: '127.0.0.1',
       schedule: '*/30 * * * *',
       watcherHealthIntervalMs: 60000,
       logging: { level: 'info' },

--- a/packages/service/src/scheduler/scheduler.test.ts
+++ b/packages/service/src/scheduler/scheduler.test.ts
@@ -36,6 +36,7 @@ function createTestConfig() {
     metaProperty: { _meta: 'current' },
     metaArchiveProperty: { _meta: 'archive' },
     port: 1938,
+    host: '127.0.0.1',
     schedule: '* * * * *',
     watcherHealthIntervalMs: 60000,
     logging: { level: 'info' },

--- a/packages/service/src/schema/config.ts
+++ b/packages/service/src/schema/config.ts
@@ -78,6 +78,9 @@ export const serviceConfigSchema = metaConfigSchema.extend({
   /** HTTP port for the service (default: 1938). */
   port: z.number().int().min(1).max(65535).default(1938),
 
+  /** Bind address for the HTTP server (default: 127.0.0.1). */
+  host: z.string().default('127.0.0.1'),
+
   /** Cron schedule for synthesis cycles (default: every 30 min). */
   schedule: z.string().default('*/30 * * * *'),
 


### PR DESCRIPTION
Closes #65

## Changes

### Service (`packages/service`)

1. **Add configurable `host` property** — New `host` field in `serviceConfigSchema` (Zod, default `'127.0.0.1'`). `bootstrap.ts` now reads `config.host` instead of hardcoded `'0.0.0.0'`.

2. **Change default bind from `0.0.0.0` to `127.0.0.1`** — Meta has no external consumers; only the local OpenClaw plugin and jeeves-server talk to it. Users who need external access can override via the new `host` config property.

### Plugin (`packages/openclaw`)

3. **Rename `serviceUrl` → `apiUrl`** — Aligns with jeeves-server, jeeves-watcher, and jeeves-runner plugins which all use `apiUrl`. Updated in:
   - `openclaw.plugin.json` (configSchema)
   - `helpers.ts` (resolvePluginSetting key)
   - `serviceClient.ts` (interface + constructor)
   - `index.ts` (client construction)
   - `promptInjection.ts` (troubleshooting text)

4. **Add `default` value to `apiUrl` in configSchema** — Machine-readable default `"http://127.0.0.1:1938"`, consistent with the other three plugins.

### Docs & Tests

- Updated all source docs: README, guides, SKILL.md
- Added `host` to SKILL.md config table and hot-reload docs
- Fixed test fixtures in `config.test.ts` and `scheduler.test.ts`

## Verification

- ✅ Build — clean (both packages)
- ✅ Typecheck — clean
- ✅ Lint — clean
- ✅ Tests — 234/234 passing
- ✅ Knip — clean
- ✅ Docs — 1 pre-existing warning only