### PR TITLE
fix: upgrade core to ^0.3.0 + remove redundant TOOLS.md tool catalogue (#67)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1196,13 +1196,12 @@
       }
     },
     "node_modules/@karmaniverous/jeeves": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@karmaniverous/jeeves/-/jeeves-0.2.0.tgz",
-      "integrity": "sha512-o3wM1h04ayoaXs6hB1dYklqsEm/stM43e67zdEosUqkAiFwCLuOPwodB2bDaklZpYGxb9hcpPnF6rRyaMFwpPA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@karmaniverous/jeeves/-/jeeves-0.3.0.tgz",
+      "integrity": "sha512-yb9BxKi+AOUdEsOOGqupyLzS9fbiQU1Pmzk5Cv/mFLpZoOui3xB6v3G4KBSbuWCuCHh5VKR6pviuzflFSGqX3w==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "commander": "^14.0.2",
-        "handlebars": "^4.7.8",
         "jsonpath-plus": "^10.4.0",
         "package-directory": "^8.2.0",
         "proper-lockfile": "^4.1.2",
@@ -5353,6 +5352,7 @@
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
       "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
@@ -6325,6 +6325,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6370,6 +6371,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/netmask": {
@@ -7481,6 +7483,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -7810,6 +7813,7 @@
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
       "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
@@ -8154,6 +8158,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {
@@ -8321,10 +8326,10 @@
     },
     "packages/openclaw": {
       "name": "@karmaniverous/jeeves-meta-openclaw",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@karmaniverous/jeeves": "^0.2.0"
+        "@karmaniverous/jeeves": "^0.3.0"
       },
       "bin": {
         "jeeves-meta-openclaw": "dist/cli.js"
@@ -8567,10 +8572,10 @@
     },
     "packages/service": {
       "name": "@karmaniverous/jeeves-meta",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@karmaniverous/jeeves": "^0.2.0",
+        "@karmaniverous/jeeves": "^0.3.0",
         "commander": "^14",
         "croner": "^10",
         "fastify": "^5.8",

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -119,6 +119,6 @@
     }
   },
   "dependencies": {
-    "@karmaniverous/jeeves": "^0.2.0"
+    "@karmaniverous/jeeves": "^0.3.0"
   }
 }

--- a/packages/openclaw/src/index.ts
+++ b/packages/openclaw/src/index.ts
@@ -26,7 +26,6 @@ import {
   createPluginCommands,
   createServiceCommands,
 } from './serviceCommands.js';
-import { renderToolsTable } from './toolMeta.js';
 import { registerMetaTools } from './tools.js';
 
 /** Plugin version derived from package.json. */
@@ -57,7 +56,7 @@ export default function register(api: PluginApi): void {
     fetch: async () => generateMetaMenu(client),
     placeholder:
       'The jeeves-meta synthesis engine is initializing...\n\n' +
-      renderToolsTable(),
+      'Read the `jeeves-meta` skill for usage guidance, configuration, and troubleshooting.',
   });
 
   const writer = createComponentWriter({

--- a/packages/openclaw/src/promptInjection.test.ts
+++ b/packages/openclaw/src/promptInjection.test.ts
@@ -55,7 +55,7 @@ describe('generateMetaMenu', () => {
     const client = mockClient();
     const menu = await generateMetaMenu(client);
     expect(menu).toContain('10 meta entities');
-    expect(menu).toContain('meta_list');
+    expect(menu).toContain('jeeves-meta');
   });
 
   it('shows warning when rulesRegistered is false', async () => {
@@ -154,15 +154,12 @@ describe('generateMetaMenu', () => {
     expect(menu).toContain('**Gateway**: unreachable');
   });
 
-  it('includes all 7 tools in healthy state output', async () => {
+  it('does not include tool catalogue in healthy state output', async () => {
     const client = mockClient();
     const menu = await generateMetaMenu(client);
-    expect(menu).toContain('meta_list');
-    expect(menu).toContain('meta_detail');
-    expect(menu).toContain('meta_trigger');
-    expect(menu).toContain('meta_preview');
-    expect(menu).toContain('meta_seed');
-    expect(menu).toContain('meta_unlock');
-    expect(menu).toContain('meta_config');
+    // Tool catalogue was removed (issue #67) — tool definitions are
+    // already in the system prompt via OpenClaw's native tool injection.
+    expect(menu).not.toContain('| Tool |');
+    expect(menu).toContain('jeeves-meta');
   });
 });

--- a/packages/openclaw/src/promptInjection.ts
+++ b/packages/openclaw/src/promptInjection.ts
@@ -12,7 +12,6 @@ import type {
   MetasResponse,
   StatusResponse,
 } from './serviceClient.js';
-import { renderToolsTable } from './toolMeta.js';
 
 /**
  * Generate the Meta menu Markdown for TOOLS.md.
@@ -119,6 +118,6 @@ export async function generateMetaMenu(
     '| Last synthesized | ' + lastSynthDisplay + ' |',
     ...(depLines.length > 0 ? ['', '### Dependencies', ...depLines] : []),
     '',
-    renderToolsTable(),
+    'Read the `jeeves-meta` skill for usage guidance, configuration, and troubleshooting.',
   ].join('\n');
 }

--- a/packages/openclaw/src/toolMeta.ts
+++ b/packages/openclaw/src/toolMeta.ts
@@ -50,36 +50,3 @@ export const META_TOOLS: readonly ToolMeta[] = [
       'Query service configuration with optional JSONPath expression.',
   },
 ] as const;
-
-/**
- * Render the tools table for TOOLS.md injection.
- *
- * Produces a Markdown table with short descriptions suitable for
- * both the placeholder and the live menu.
- */
-export function renderToolsTable(): string {
-  const shortDesc: Record<string, string> = {
-    meta_list: 'List metas with summary stats and per-meta projection',
-    meta_detail: 'Full detail for a single meta with optional archive history',
-    meta_trigger:
-      'Manually trigger synthesis for a specific meta or next-stalest',
-    meta_preview:
-      'Dry-run: show what inputs would be gathered without running LLM',
-    meta_seed: 'Create .meta/ directory and initial meta.json for a path',
-    meta_unlock: 'Remove stale .lock from a stuck meta entity',
-    meta_config: 'Query service configuration with optional JSONPath',
-  };
-
-  const rows = META_TOOLS.map(
-    (t) => `| \`${t.name}\` | ${shortDesc[t.name] ?? t.description} |`,
-  );
-
-  return [
-    '### Tools',
-    '| Tool | Description |',
-    '|------|-------------|',
-    ...rows,
-    '',
-    'Read the `jeeves-meta` skill for usage guidance, configuration, and troubleshooting.',
-  ].join('\n');
-}

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -41,7 +41,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@karmaniverous/jeeves": "^0.2.0",
+    "@karmaniverous/jeeves": "^0.3.0",
     "commander": "^14",
     "croner": "^10",
     "fastify": "^5.8",


### PR DESCRIPTION
Closes #67

## Summary

- Upgraded `@karmaniverous/jeeves` to `^0.3.0` in both `packages/service` and `packages/openclaw`.
- Removed the redundant Meta tool catalogue from the Meta TOOLS.md managed section.
  - Tools are already injected by OpenClaw with full signatures; the table was pure duplication/token burn.
  - Meta section now focuses on operational context: entity summary + dependency warnings.

## Changes

- `packages/openclaw/src/promptInjection.ts`: remove tools table from live menu output
- `packages/openclaw/src/index.ts`: remove tools table from placeholder output
- `packages/openclaw/src/toolMeta.ts`: remove unused `renderToolsTable()` (kept `META_TOOLS` as source of truth)
- `packages/openclaw/src/promptInjection.test.ts`: update assertions

## Verification

- build ✅
- typecheck ✅
- lint ✅
- tests ✅
- knip ✅
- docs ✅ (1 pre-existing warning only)