### PR TITLE
docs: update documentation for v0.10.0

### DIFF
--- a/packages/openclaw/guides/tools-reference.md
+++ b/packages/openclaw/guides/tools-reference.md
@@ -57,8 +57,9 @@ Create a `.meta/` directory with a skeleton `meta.json` for a new entity path.
 **Parameters:**
 - `path` (string, required) — owner directory path
 - `crossRefs` (string, optional) — JSON array of cross-ref owner paths (e.g. `'["j:/path/a","j:/path/b"]'`). Written as `_crossRefs` in the initial `meta.json`.
+- `steer` (string, optional) — steering prompt written as `_steer` in the initial `meta.json`
 
-**Response:** `{ path, _id }` (201 Created) or 409 Conflict if already exists
+**Response:** `{ path, _id }` (201 Created) or 409 Conflict if already exists. Supports optional `steer` and `crossRefs` in the seed request.
 
 ## meta_unlock
 

--- a/packages/openclaw/skills/jeeves-meta/SKILL.md
+++ b/packages/openclaw/skills/jeeves-meta/SKILL.md
@@ -66,6 +66,8 @@ aggregate context from other metas.
 - `crossRefs` (optional): JSON array of cross-ref owner paths
   (e.g. `'["j:/path/a","j:/path/b"]'`). Written as `_crossRefs` in the
   initial `meta.json`.
+- `steer` (optional): Steering prompt string. Written as `_steer` in the
+  initial `meta.json`.
 
 ### meta_unlock
 Remove a stale `.lock` file from a meta entity. Locks are created during
@@ -160,19 +162,19 @@ Key settings:
 
 ### Meta Discovery
 
-Discovery is entirely watcher-based. The engine:
+Discovery is entirely filesystem-based (no Qdrant dependency). The engine:
 
 1. **Registers virtual inference rules** at service startup. These rules match
    file paths (`**/.meta/meta.json` and `**/.meta/archive/*.json`) and apply
    the configured `metaProperty`/`metaArchiveProperty` values as watcher
    metadata on those indexed points.
 
-2. **Queries the watcher** via `buildMetaFilter(config)`, which constructs a
-   Qdrant filter from the key-value pairs in `metaProperty`. For example:
-   - Default `{ _meta: "current" }` → filter on `_meta: "current"`
-   - Configured `{ domains: ["meta"] }` → filter on `domains: "meta"`
+2. **Discovers metas** via `watcher.walk(["**/.meta/meta.json"])` — a filesystem
+   walk provided by the watcher's `POST /walk` endpoint. This enumerates all
+   `.meta/meta.json` files under watched paths without using Qdrant or any
+   vector database queries.
 
-3. **Deduplicates** scan results by `.meta/` directory path and builds the
+3. **Deduplicates** results by `.meta/` directory path and builds the
    ownership tree.
 
 **Important:** If you change `metaProperty` or `metaArchiveProperty` in config,
@@ -254,6 +256,52 @@ etc. as needed.
    chokidar file watching)
 5. The entity appears in `meta_list` on the next query
 
+**Note:** `_id` is optional in `meta.json`. A minimal stub of just `{}` or
+`{ "_steer": "..." }` is valid — a UUID will be auto-generated on first
+synthesis. The `meta_seed` tool and auto-seed always generate `_id` at
+creation time.
+
+### Auto-Seed Policy
+
+The `autoSeed` config field enables declarative, config-driven `.meta/`
+creation. It is an array of policy rules, each with the shape:
+
+```json
+{ "match": "<glob>", "steer": "<optional prompt>", "crossRefs": ["<optional paths>"] }
+```
+
+- **`match`** (required) — a glob pattern compatible with `watcher.walk()`.
+  The watcher walks all watched paths matching this glob and returns file
+  paths. Parent directories of matched files become seed candidates.
+- **`steer`** (optional) — steering prompt written as `_steer` in the
+  seeded `meta.json`.
+- **`crossRefs`** (optional) — array of cross-ref owner paths written as
+  `_crossRefs` in the seeded `meta.json`.
+
+**Evaluation order:** Rules are processed in array order. If multiple rules
+match the same directory, the last match wins for `steer` and `crossRefs`.
+
+**Behavior:**
+- Auto-seed runs at the start of each scheduler tick, before candidate
+  discovery. Directories that already have a `.meta/` subdirectory are
+  skipped.
+- Empty directories (no files matching any glob) will not be seeded — the
+  watcher walk only returns actual file paths, and parent directories are
+  derived from those.
+- The `autoSeed` field hot-reloads with all other non-restart-required
+  config fields.
+
+**Example:**
+
+```json
+{
+  "autoSeed": [
+    { "match": "domains/meetings/*/**", "steer": "Summarize this meeting." },
+    { "match": "domains/github/**/*.md", "steer": "Summarize this repository." }
+  ]
+}
+```
+
 ### Adding Cross-Reference Metas
 
 For metas that aggregate context from other metas (e.g. an organizational
@@ -283,14 +331,22 @@ across physically distributed data.
 
 ### Config Hot-Reload
 
-The following fields can be changed without restarting the service:
-- `schedule` — cron expression
-- `reportChannel` — progress reporting target
-- `logging.level` — log verbosity
+All config fields hot-reload without restarting the service **except** these
+restart-required fields:
+
+- `port` — HTTP listen port
+- `host` — bind address
+- `watcherUrl` — watcher service URL
+- `gatewayUrl` — OpenClaw gateway URL
+- `gatewayApiKey` — gateway authentication key
+- `defaultArchitect` — architect system prompt
+- `defaultCritic` — critic system prompt
 
 Edit the config file and save; the service detects changes via `fs.watchFile`.
-All other fields (including `metaProperty`, `host`, `port`, timeouts) require a
-service restart.
+When a restart-required field changes, the service logs a warning but the
+change does not take effect until restart. All other fields (including
+`schedule`, `reportChannel`, `metaProperty`, timeouts, `autoSeed`,
+`logging.level`, etc.) are applied immediately.
 
 ### Progress Reporting
 

--- a/packages/service/README.md
+++ b/packages/service/README.md
@@ -16,7 +16,8 @@ HTTP service for the Jeeves knowledge synthesis engine. Provides a Fastify API, 
 - **Virtual rule registration** — registers 3 watcher inference rules at startup with retry
 - **Progress reporting** — real-time synthesis events via gateway channel messages
 - **Graceful shutdown** — stop scheduler, release locks, close server
-- **Config hot-reload** — schedule, reportChannel, log level reload without restart
+- **Config hot-reload** — all synthesis parameters reload without restart; restart-required fields (port, host, URLs) warn on change
+- **Auto-seed policy** — config-driven declarative `.meta/` creation via `autoSeed` rules
 - **Token tracking** — per-step counts with exponential moving averages
 - **CLI** — `status`, `list`, `detail`, `preview`, `synthesize`, `seed`, `unlock`, `config`, `service` commands
 - **Zod schemas** — validated meta.json and config with open schema support

--- a/packages/service/guides/configuration.md
+++ b/packages/service/guides/configuration.md
@@ -28,22 +28,28 @@ The service reads a JSON config file specified via `--config` flag or `JEEVES_ME
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `port` | integer | `1938` | HTTP listen port |
+| `host` | string | `127.0.0.1` | HTTP bind address |
 | `schedule` | string | `*/30 * * * *` | Cron expression for synthesis scheduling |
 | `reportChannel` | string | — | Gateway channel target for progress messages |
 | `watcherHealthIntervalMs` | number | `60000` | Periodic watcher health check interval in ms. 0 = disabled. |
 | `serverBaseUrl` | string | — | Base URL for entity links in progress reports (e.g. `http://myserver:1938`) |
+| `autoSeed` | array | `[]` | Auto-seed policy rules. Each rule: `{ match: string, steer?: string, crossRefs?: string[] }`. Glob patterns matched against `watcher.walk()` results. Rules evaluated in order; last match wins for steer/crossRefs. |
 | `logging.level` | string | `"info"` | Log level (trace/debug/info/warn/error) |
 | `logging.file` | string | — | Log file path |
 
 ## Hot-Reload
 
-The following fields are hot-reloadable (no service restart required):
-- `schedule` — cron expression
-- `reportChannel` — progress reporting target
-- `watcherHealthIntervalMs` — watcher health check interval
-- `logging.level` — log verbosity
+All config fields hot-reload without a service restart **except** these restart-required fields:
 
-All other fields require a service restart.
+- `port` — HTTP listen port
+- `host` — bind address
+- `watcherUrl` — watcher service URL
+- `gatewayUrl` — OpenClaw gateway URL
+- `gatewayApiKey` — gateway authentication key
+- `defaultArchitect` — architect system prompt
+- `defaultCritic` — critic system prompt
+
+When a restart-required field changes, the service logs a warning but the change does not take effect until restart. All other fields (including `schedule`, `reportChannel`, `autoSeed`, timeouts, `metaProperty`, `logging.level`, etc.) are applied immediately on config file save.
 
 ## Environment Variables
 

--- a/packages/service/guides/scheduling.md
+++ b/packages/service/guides/scheduling.md
@@ -16,10 +16,11 @@ effectiveStaleness = actualStaleness × (normalizedDepth + 1) ^ (depthWeight × 
 The built-in croner scheduler runs on the configured cron expression (default: every 30 minutes).
 
 Each tick:
-1. Discover all metas via watcher `/walk` endpoint
-2. Compute effective staleness for each
-3. Enqueue the stalest candidate (if none found, increase backoff and return)
-4. Check watcher uptime for restart detection → re-register virtual rules if needed (only runs when a candidate was found)
+1. **Auto-seed** — if `autoSeed` rules are configured, walk for matching directories via the watcher and seed any that lack a `.meta/` directory
+2. Discover all metas via watcher `/walk` endpoint
+3. Compute effective staleness for each
+4. Enqueue the stalest candidate (if none found, increase backoff and return)
+5. Check watcher uptime for restart detection → re-register virtual rules if needed (only runs when a candidate was found)
 
 ## Adaptive Backoff
 


### PR DESCRIPTION
Updates all documentation to reflect v0.10.0 features merged in PR #74.

**10 gaps fixed:**
1. SKILL.md — added autoSeed documentation
2. SKILL.md — added _id auto-generation note
3. SKILL.md — updated config hot-reload section (all fields except 7 restart-required)
4. SKILL.md — added steer param to meta_seed tool
5. SKILL.md — fixed meta discovery section (was referencing nonexistent buildMetaFilter/Qdrant)
6. Configuration guide — added host and autoSeed fields
7. Configuration guide — fixed hot-reload section
8. Scheduling guide — added auto-seed step to scheduler tick
9. Service README — updated features (hot-reload, auto-seed)
10. Tools reference — added steer param to meta_seed