### PR TITLE
fix: MinimalLogger.warn signature in verify.ts

### DIFF
--- a/packages/service/src/rules/verify.test.ts
+++ b/packages/service/src/rules/verify.test.ts
@@ -52,6 +52,7 @@ describe('verifyRuleApplication', () => {
 
     expect(count).toBe(0);
     expect(logger.warn).toHaveBeenCalledWith(
+      { count: 0 },
       expect.stringContaining('no .meta/meta.json files found'),
     );
   });

--- a/packages/service/src/rules/verify.ts
+++ b/packages/service/src/rules/verify.ts
@@ -31,6 +31,7 @@ export async function verifyRuleApplication(
 
     if (metaPaths.length === 0) {
       logger.warn(
+        { count: 0 },
         'Post-registration verification: no .meta/meta.json files found via watcher walk. ' +
           'Virtual rules may not be applied to indexed files. ' +
           'If metas exist, a path-scoped reindex may be needed.',


### PR DESCRIPTION
Fixes typecheck failure on main introduced when PR #75 merged without the signature fix.

\logger.warn()\ in \erify.ts\ was called with a single string argument but \MinimalLogger.warn\ requires \(obj: Record<string, unknown>, msg: string)\. Added the missing object argument.

Also updates the corresponding test expectation.