### PR TITLE
fix: use character-class glob escaping for Windows compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8852,7 +8852,7 @@
     },
     "packages/openclaw": {
       "name": "@karmaniverous/jeeves-meta-openclaw",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@karmaniverous/jeeves": "^0.3.0"
@@ -8879,7 +8879,7 @@
     },
     "packages/service": {
       "name": "@karmaniverous/jeeves-meta",
-      "version": "0.10.1",
+      "version": "0.11.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@karmaniverous/jeeves": "^0.3.0",

--- a/packages/service/src/escapeGlob.test.ts
+++ b/packages/service/src/escapeGlob.test.ts
@@ -3,27 +3,27 @@ import { describe, expect, it } from 'vitest';
 import { escapeGlob } from './escapeGlob.js';
 
 describe('escapeGlob', () => {
-  it('escapes parentheses', () => {
+  it('escapes parentheses with character classes', () => {
     expect(escapeGlob('project-jeeves-x (C0AMFV5SJKG)')).toBe(
-      'project-jeeves-x \\(C0AMFV5SJKG\\)',
+      'project-jeeves-x [(]C0AMFV5SJKG[)]',
     );
   });
 
   it('escapes square brackets', () => {
-    expect(escapeGlob('dir[0]')).toBe('dir\\[0\\]');
+    expect(escapeGlob('dir[0]')).toBe('dir[[]0[]]');
   });
 
   it('escapes curly braces', () => {
-    expect(escapeGlob('{a,b}')).toBe('\\{a,b\\}');
+    expect(escapeGlob('{a,b}')).toBe('[{]a,b[}]');
   });
 
   it('escapes asterisks and question marks', () => {
-    expect(escapeGlob('file*.txt')).toBe('file\\*.txt');
-    expect(escapeGlob('file?.txt')).toBe('file\\?.txt');
+    expect(escapeGlob('file*.txt')).toBe('file[*].txt');
+    expect(escapeGlob('file?.txt')).toBe('file[?].txt');
   });
 
   it('escapes exclamation marks', () => {
-    expect(escapeGlob('!negated')).toBe('\\!negated');
+    expect(escapeGlob('!negated')).toBe('[!]negated');
   });
 
   it('leaves normal paths unchanged', () => {
@@ -34,7 +34,7 @@ describe('escapeGlob', () => {
 
   it('handles full Slack channel path', () => {
     expect(escapeGlob('j:/domains/slack/project-jeeves-x (C0AMFV5SJKG)')).toBe(
-      'j:/domains/slack/project-jeeves-x \\(C0AMFV5SJKG\\)',
+      'j:/domains/slack/project-jeeves-x [(]C0AMFV5SJKG[)]',
     );
   });
 });

--- a/packages/service/src/escapeGlob.ts
+++ b/packages/service/src/escapeGlob.ts
@@ -10,11 +10,17 @@
  */
 
 /**
- * Escape glob metacharacters in a string.
+ * Escape glob metacharacters in a string using character-class wrapping.
+ *
+ * Backslash escaping (`\(`) does not work reliably on Windows where `\` is
+ * the path separator. Instead, each metacharacter is wrapped in a character
+ * class (e.g. `(` → `[(]`) which is universally supported by glob libraries.
+ *
+ * Square brackets themselves are escaped as `[[]` and `[]]`.
  *
  * @param s - Raw path string.
- * @returns String with glob metacharacters backslash-escaped.
+ * @returns String with glob metacharacters wrapped in character classes.
  */
 export function escapeGlob(s: string): string {
-  return s.replace(/[*?[\]{}()!]/g, '\\$&');
+  return s.replace(/[*?[\]{}()!]/g, (ch) => `[${ch}]`);
 }


### PR DESCRIPTION
Backslash escaping does not work on Windows where backslash is the path separator. Switches to character-class wrapping: ( becomes [(], ) becomes [)], etc. Verified against live watcher walk endpoint.