### PR TITLE
fix: use path.posix.dirname on normalized paths for Linux compatibility

### DIFF
--- a/packages/service/src/discovery/buildMinimalNode.ts
+++ b/packages/service/src/discovery/buildMinimalNode.ts
@@ -8,7 +8,7 @@
  * @module discovery/buildMinimalNode
  */
 
-import { dirname } from 'node:path';
+import { posix } from 'node:path';
 
 import { escapeGlob } from '../escapeGlob.js';
 import type { WatcherClient } from '../interfaces/index.js';
@@ -30,7 +30,7 @@ export async function buildMinimalNode(
   watcher: WatcherClient,
 ): Promise<MetaNode> {
   const normalized = normalizePath(metaPath);
-  const ownerPath = normalizePath(dirname(metaPath));
+  const ownerPath = posix.dirname(normalized);
 
   // Find child metas using watcher walk.
   // We include only *direct* children (nearest descendants in the ownership tree)
@@ -40,11 +40,11 @@ export async function buildMinimalNode(
   ]);
 
   const candidateMetaPaths = [
-    ...new Set(rawMetaJsonPaths.map((p) => normalizePath(dirname(p)))),
+    ...new Set(rawMetaJsonPaths.map((p) => posix.dirname(normalizePath(p)))),
   ].filter((p) => p !== normalized);
 
   const candidates = candidateMetaPaths
-    .map((mp) => ({ metaPath: mp, ownerPath: normalizePath(dirname(mp)) }))
+    .map((mp) => ({ metaPath: mp, ownerPath: posix.dirname(mp) }))
     .sort((a, b) => a.ownerPath.length - b.ownerPath.length);
 
   const directChildren: Array<{ metaPath: string; ownerPath: string }> = [];


### PR DESCRIPTION
## Problem

The Linux Compatibility CI workflow (Node 24) fails with:

\\\
FAIL src/discovery/buildMinimalNode.test.ts > buildMinimalNode > normalizes backslash paths
AssertionError: expected '.' to be 'j:/domains/github/karmaniverous/.meta'
\\\

\path.dirname()\ on a Windows-style path like \j:/domains/github/karmaniverous/.meta/meta.json\ returns \.\ on Linux because the POSIX path module does not understand Windows drive letters.

## Fix

In \uildMinimalNode.ts\, normalize paths to forward slashes via \
ormalizePath()\ *first*, then use \path.posix.dirname()\ instead of the platform-native \path.dirname()\. \path.posix.dirname\ correctly handles forward-slash paths on all platforms.

### Changes
- Replace \import { dirname } from 'node:path'\ with \import { posix } from 'node:path'\
- Normalize the input \metaPath\ first, then derive \ownerPath\ via \posix.dirname(normalized)\
- Apply the same pattern inside the walk result processing: normalize each raw path before \posix.dirname\

All 306 tests pass. ESLint clean. TypeScript clean.