### PR TITLE
fix: correct startCommand path in service descriptor

### DIFF
--- a/packages/service/src/descriptor.ts
+++ b/packages/service/src/descriptor.ts
@@ -49,7 +49,7 @@ export const metaDescriptor: JeevesComponentDescriptor =
     },
     startCommand: (configPath: string) => [
       'node',
-      'dist/cli.js',
+      'dist/cli/jeeves-meta/index.js',
       'start',
       '-c',
       configPath,


### PR DESCRIPTION
## Problem

The \startCommand\ in \packages/service/src/descriptor.ts\ referenced \dist/cli.js\, but the rollup output places the CLI entry point at \dist/cli/jeeves-meta/index.js\. The core SDK's \start\ command uses \startCommand\ to spawn itself, causing a \MODULE_NOT_FOUND\ error on startup.

This broke the v0.12.0 release — the service wouldn't start from a global install.

## Fix

Updated the path in \startCommand\ from \dist/cli.js\ to \dist/cli/jeeves-meta/index.js\.

## Quality gates
- build ✅
- typecheck ✅
- lint ✅
- test ✅ (351 pass)