### PR TITLE
feat: integrate core 0.4.5 — descriptor.run + start recursion fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1322,9 +1322,9 @@
       }
     },
     "node_modules/@karmaniverous/jeeves": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@karmaniverous/jeeves/-/jeeves-0.4.4.tgz",
-      "integrity": "sha512-xmhOJvXl7HdYcGCaQmGA6k1BHKb5gIfseI+vMeIxEZbYw4rn11RJF26XbJHRVuR7inLuAVhHzoMv2NovhBW1Rw==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@karmaniverous/jeeves/-/jeeves-0.4.5.tgz",
+      "integrity": "sha512-jkq4vcBnx6dkbYFcHcfaq362fYriyr9+IQTlImn2h54NzfODfXxBukwt5o70Wfu4vo5BhrlQp0H2zkCTRQtE0Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "commander": "^14.0.3",
@@ -3132,6 +3132,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -9230,7 +9231,7 @@
       "version": "0.8.3",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@karmaniverous/jeeves": "^0.4.4"
+        "@karmaniverous/jeeves": "^0.4.5"
       },
       "bin": {
         "jeeves-meta-openclaw": "dist/cli.js"
@@ -9301,7 +9302,7 @@
       "version": "0.11.3",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@karmaniverous/jeeves": "^0.4.4",
+        "@karmaniverous/jeeves": "^0.4.5",
         "commander": "^14",
         "croner": "^10",
         "fastify": "^5.8",

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -120,6 +120,6 @@
     }
   },
   "dependencies": {
-    "@karmaniverous/jeeves": "^0.4.4"
+    "@karmaniverous/jeeves": "^0.4.5"
   }
 }

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -41,7 +41,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@karmaniverous/jeeves": "^0.4.4",
+    "@karmaniverous/jeeves": "^0.4.5",
     "commander": "^14",
     "croner": "^10",
     "fastify": "^5.8",

--- a/packages/service/src/descriptor.ts
+++ b/packages/service/src/descriptor.ts
@@ -12,6 +12,7 @@ import {
   jeevesComponentDescriptorSchema,
 } from '@karmaniverous/jeeves';
 
+import { startService } from './bootstrap.js';
 import {
   applyHotReloadedConfig,
   RESTART_REQUIRED_FIELDS,
@@ -46,6 +47,10 @@ export const metaDescriptor: JeevesComponentDescriptor =
       const parsed = serviceConfigSchema.parse(merged);
       applyHotReloadedConfig(parsed);
       return Promise.resolve();
+    },
+    run: async (configPath: string) => {
+      const config = loadServiceConfig(configPath);
+      await startService(config, configPath);
     },
     startCommand: (configPath: string) => [
       'node',


### PR DESCRIPTION
## Summary

Integrates core SDK v0.4.5 which replaces the recursive spawn in the \start\ command with a direct \descriptor.run()\ callback (fixes [karmaniverous/jeeves#51](https://github.com/karmaniverous/jeeves/issues/51)).

## Changes

- Bump \@karmaniverous/jeeves\ to \^0.4.5\ in both \packages/service\ and \packages/openclaw\
- Add \un\ callback to the service descriptor: loads config via \loadServiceConfig()\ and calls \startService()\ inline
- The \start\ CLI command now runs the service in-process instead of spawning a child process

## Quality gates
- build ✅
- typecheck ✅
- lint ✅
- test ✅ (351 pass)