### PR TITLE
fix: exclude .meta/ from isStale() mtime check

### DIFF
--- a/packages/service/src/scheduling/scheduling.test.ts
+++ b/packages/service/src/scheduling/scheduling.test.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from 'node:fs';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -212,6 +212,77 @@ describe('isStale', () => {
     const meta = makeMeta({ _generatedAt: '2099-01-01T00:00:00Z' });
     const result = await isStale('.', meta, mockWatcher([file]));
     expect(result).toBe(false);
+  });
+
+  it('excludes .meta/ files from staleness check (forward slash)', async () => {
+    // Create real .meta/ files so statSync can read their mtimes
+    const base = join(tmpdir(), `meta-fwd-${String(Date.now())}`);
+    const metaDir = join(base, '.meta');
+    const archiveDir = join(metaDir, 'archive');
+    mkdirSync(archiveDir, { recursive: true });
+    const metaFile = join(metaDir, 'meta.json');
+    const archiveFile = join(archiveDir, 'snap.json');
+    writeFileSync(metaFile, '{}');
+    writeFileSync(archiveFile, '{}');
+
+    // Files were just created so their mtime is "now", but they live under .meta/
+    const meta = makeMeta({ _generatedAt: '2000-01-01T00:00:00Z' });
+    // Use forward-slash paths as watcher normalizes to forward slashes
+    const result = await isStale(
+      base.replace(/\\/g, '/'),
+      meta,
+      mockWatcher([
+        metaFile.replace(/\\/g, '/'),
+        archiveFile.replace(/\\/g, '/'),
+      ]),
+    );
+    expect(result).toBe(false);
+  });
+
+  it('excludes .meta/ files from staleness check (backslash)', async () => {
+    // Create real .meta/ files with backslash paths (Windows-style)
+    const base = join(tmpdir(), `meta-back-${String(Date.now())}`);
+    const metaDir = join(base, '.meta');
+    const archiveDir = join(metaDir, 'archive');
+    mkdirSync(archiveDir, { recursive: true });
+    const metaFile = join(metaDir, 'meta.json');
+    const archiveFile = join(archiveDir, 'snap.json');
+    writeFileSync(metaFile, '{}');
+    writeFileSync(archiveFile, '{}');
+
+    const meta = makeMeta({ _generatedAt: '2000-01-01T00:00:00Z' });
+    // Use backslash paths as they appear on Windows
+    const result = await isStale(
+      base.replace(/\//g, '\\'),
+      meta,
+      mockWatcher([
+        metaFile.replace(/\//g, '\\'),
+        archiveFile.replace(/\//g, '\\'),
+      ]),
+    );
+    expect(result).toBe(false);
+  });
+
+  it('still detects staleness for non-.meta/ files alongside .meta/ files', async () => {
+    // Create a real non-.meta file AND a real .meta file
+    const base = join(tmpdir(), `meta-mix-${String(Date.now())}`);
+    const metaDir = join(base, '.meta');
+    mkdirSync(metaDir, { recursive: true });
+    const metaFile = join(metaDir, 'meta.json');
+    const realFile = join(base, 'data.txt');
+    writeFileSync(metaFile, '{}');
+    writeFileSync(realFile, 'content');
+
+    const meta = makeMeta({ _generatedAt: '2000-01-01T00:00:00Z' });
+    const result = await isStale(
+      base.replace(/\\/g, '/'),
+      meta,
+      mockWatcher([
+        metaFile.replace(/\\/g, '/'),
+        realFile.replace(/\\/g, '/'), // real non-.meta file with recent mtime
+      ]),
+    );
+    expect(result).toBe(true);
   });
 });
 

--- a/packages/service/src/scheduling/staleness.ts
+++ b/packages/service/src/scheduling/staleness.ts
@@ -32,7 +32,13 @@ export async function isStale(
   if (!meta._generatedAt) return true; // Never synthesized = stale
 
   const files = await watcher.walk([`${escapeGlob(scopePrefix)}/**`]);
-  return hasModifiedAfter(files, new Date(meta._generatedAt).getTime());
+
+  // Exclude .meta/ subtree — synthesis outputs must not trigger staleness.
+  // Handle both forward and back slashes for cross-platform compatibility.
+  const metaSep = /[/\\]\.meta(?:[/\\]|$)/;
+  const filtered = files.filter((f) => !metaSep.test(f));
+
+  return hasModifiedAfter(filtered, new Date(meta._generatedAt).getTime());
 }
 
 /** Maximum staleness for never-synthesized metas (1 year in seconds). */


### PR DESCRIPTION
Fixes #95.

## Problem

\isStale()\ in \scheduling/staleness.ts\ passed raw \watcher.walk()\ output (including \.meta/meta.json\ and \.meta/archive/*\) to \hasModifiedAfter()\. After synthesis, these freshly-written files had mtimes ~1-2ms after \_generatedAt\, causing every entity to immediately report as stale and trigger a wasted re-synthesis.

## Fix

Filter out \.meta/\ subtree files after the walk, before checking mtimes. Uses a regex (\/[/\\\\]\\.meta(?:[/\\\\]|\$)/\) that handles both forward and backslash separators.

## Tests

Added 3 tests verifying:
- \.meta/\ files with forward slashes are excluded
- \.meta/\ files with backslashes are excluded
- Non-\.meta/\ files still correctly trigger staleness

All quality gates green (typecheck, lint, 354 tests).