### PR TITLE
fix: plugin descriptor + StatusResponse alignment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9228,7 +9228,7 @@
     },
     "packages/openclaw": {
       "name": "@karmaniverous/jeeves-meta-openclaw",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@karmaniverous/jeeves": "^0.4.6"
@@ -9299,7 +9299,7 @@
     },
     "packages/service": {
       "name": "@karmaniverous/jeeves-meta",
-      "version": "0.12.2",
+      "version": "0.12.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@karmaniverous/jeeves": "^0.4.6",

--- a/packages/openclaw/src/index.ts
+++ b/packages/openclaw/src/index.ts
@@ -74,6 +74,13 @@ export default function register(api: PluginApi): void {
         '-c',
         configPath,
       ],
+      // Plugin-side descriptor is only used by ComponentWriter for managed
+      // content. The real run callback lives in the service descriptor.
+      run: () => {
+        return Promise.reject(
+          new Error('run() is not available on the plugin-side descriptor'),
+        );
+      },
       sectionId: 'Meta',
       refreshIntervalSeconds: 73,
       generateToolsContent: getContent,

--- a/packages/openclaw/src/promptInjection.test.ts
+++ b/packages/openclaw/src/promptInjection.test.ts
@@ -18,11 +18,14 @@ function mockClient(overrides?: {
   metasOverrides?: Partial<MetasResponse>;
 }): MetaServiceClient {
   const defaultStatus: StatusResponse = {
+    name: 'jeeves-meta',
     uptime: 3600,
-    status: 'idle',
-    dependencies: {
-      watcher: { status: 'ok', rulesRegistered: true },
-      gateway: { status: 'ok' },
+    status: 'healthy',
+    health: {
+      dependencies: {
+        watcher: { status: 'ok', rulesRegistered: true },
+        gateway: { status: 'ok' },
+      },
     },
   };
 
@@ -61,9 +64,11 @@ describe('generateMetaMenu', () => {
   it('shows warning when rulesRegistered is false', async () => {
     const client = mockClient({
       statusOverrides: {
-        dependencies: {
-          watcher: { status: 'ok', rulesRegistered: false },
-          gateway: { status: 'ok' },
+        health: {
+          dependencies: {
+            watcher: { status: 'ok', rulesRegistered: false },
+            gateway: { status: 'ok' },
+          },
         },
       },
     });
@@ -80,9 +85,11 @@ describe('generateMetaMenu', () => {
   it('shows watcher status warning when watcher is down', async () => {
     const client = mockClient({
       statusOverrides: {
-        dependencies: {
-          watcher: { status: 'unreachable', rulesRegistered: false },
-          gateway: { status: 'ok' },
+        health: {
+          dependencies: {
+            watcher: { status: 'unreachable', rulesRegistered: false },
+            gateway: { status: 'ok' },
+          },
         },
       },
     });
@@ -94,13 +101,15 @@ describe('generateMetaMenu', () => {
   it('shows indexing message when watcher is indexing', async () => {
     const client = mockClient({
       statusOverrides: {
-        dependencies: {
-          watcher: {
-            status: 'indexing',
-            rulesRegistered: true,
-            indexing: true,
+        health: {
+          dependencies: {
+            watcher: {
+              status: 'indexing',
+              rulesRegistered: true,
+              indexing: true,
+            },
+            gateway: { status: 'ok' },
           },
-          gateway: { status: 'ok' },
         },
       },
     });
@@ -143,9 +152,11 @@ describe('generateMetaMenu', () => {
   it('shows gateway warning when gateway is unreachable', async () => {
     const client = mockClient({
       statusOverrides: {
-        dependencies: {
-          watcher: { status: 'ok', rulesRegistered: true },
-          gateway: { status: 'unreachable' },
+        health: {
+          dependencies: {
+            watcher: { status: 'ok', rulesRegistered: true },
+            gateway: { status: 'unreachable' },
+          },
         },
       },
     });

--- a/packages/openclaw/src/promptInjection.ts
+++ b/packages/openclaw/src/promptInjection.ts
@@ -64,27 +64,29 @@ export async function generateMetaMenu(
     : 'n/a';
 
   // Service status + dependency health
+  // The core SDK's createStatusHandler nests getHealth() under `health`.
+  const { dependencies } = status.health;
   const depLines: string[] = [];
-  if (status.dependencies.watcher.status === 'indexing') {
+  if (dependencies.watcher.status === 'indexing') {
     depLines.push(
       '> ⏳ **Watcher indexing**: Initial filesystem scan in progress. Synthesis will resume when complete.',
     );
   } else if (
-    status.dependencies.watcher.status !== 'ok' &&
-    status.dependencies.watcher.status !== 'indexing'
+    dependencies.watcher.status !== 'ok' &&
+    dependencies.watcher.status !== 'indexing'
   ) {
-    depLines.push('> ⚠️ **Watcher**: ' + status.dependencies.watcher.status);
+    depLines.push('> ⚠️ **Watcher**: ' + dependencies.watcher.status);
   }
   if (
-    status.dependencies.watcher.rulesRegistered === false &&
-    status.dependencies.watcher.status === 'ok'
+    dependencies.watcher.rulesRegistered === false &&
+    dependencies.watcher.status === 'ok'
   ) {
     depLines.push(
       '> ⚠️ **Watcher rules not registered**: Meta files may not render properly in search/server.',
     );
   }
-  if (status.dependencies.gateway.status !== 'ok') {
-    depLines.push('> ⚠️ **Gateway**: ' + status.dependencies.gateway.status);
+  if (dependencies.gateway.status !== 'ok') {
+    depLines.push('> ⚠️ **Gateway**: ' + dependencies.gateway.status);
   }
 
   return [

--- a/packages/openclaw/src/serviceClient.ts
+++ b/packages/openclaw/src/serviceClient.ts
@@ -8,22 +8,40 @@
  * @module serviceClient
  */
 
-/** Service status response from GET /status. */
+/** Watcher dependency health within the status response. */
+export interface WatcherDepHealth {
+  status: string;
+  rulesRegistered?: boolean;
+  indexing?: boolean;
+}
+
+/** Gateway dependency health within the status response. */
+export interface GatewayDepHealth {
+  status: string;
+}
+
+/**
+ * Service status response from GET /status.
+ *
+ * The jeeves-core `createStatusHandler` wraps `getHealth()` output under
+ * a top-level `health` key. Dependency info lives at `health.dependencies`.
+ */
 export interface StatusResponse {
+  /** Service name. */
+  name: string;
   /** Service uptime in seconds. */
   uptime: number;
-  /** Current service status (idle, synthesizing, stopping, degraded). */
+  /** Overall status (healthy, degraded, unhealthy). */
   status: string;
   /** Service version. */
   version?: string;
-  /** Dependency health. */
-  dependencies: {
-    watcher: {
-      status: string;
-      rulesRegistered?: boolean;
-      indexing?: boolean;
+  /** Component-specific health details from getHealth(). */
+  health: {
+    dependencies: {
+      watcher: WatcherDepHealth;
+      gateway: GatewayDepHealth;
     };
-    gateway: { status: string };
+    [key: string]: unknown;
   };
 }
 


### PR DESCRIPTION
Fixes #97 and #98.

**#97 — StatusResponse interface mismatches /status API shape:**
- \StatusResponse\ declared \dependencies\ at top level
- Actual \GET /status\ (via core \createStatusHandler\) nests under \health\
- Updated interface, \generateMetaMenu\, and all promptInjection tests

**#98 — Missing required \un\ property in descriptor:**
- jeeves-core now requires \un()\ in the component descriptor schema
- Added a stub (matching watcher plugin pattern) — the real \un\ callback lives in the service descriptor, not the plugin-side one

**Quality checks:** build ✓ | typecheck ✓ | lint ✓ | 333/333 tests ✓