### PR TITLE
fix: correct prompt file paths for rollup bundle (fixes #107)

### DIFF
--- a/packages/service/src/prompts/index.ts
+++ b/packages/service/src/prompts/index.ts
@@ -11,10 +11,15 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const promptDir = dirname(fileURLToPath(import.meta.url));
+import { packageDirectorySync } from 'package-directory';
+
+const packageRoot = packageDirectorySync({
+  cwd: fileURLToPath(import.meta.url),
+});
+const promptDir = join(packageRoot!, 'dist', 'prompts');
 
 /** Built-in default architect prompt. */
 export const DEFAULT_ARCHITECT_PROMPT = readFileSync(


### PR DESCRIPTION
## Problem

Service crashes on startup with \ENOENT: no such file or directory, open '...dist/architect.md'\.

## Root Cause

\src/prompts/index.ts\ uses \dirname(import.meta.url)\ to locate prompt files. In source, this resolves to \src/prompts/\ where the \.md\ files live alongside the module. After rollup bundles into \dist/index.js\, \dirname\ resolves to \dist/\, but the prompt files are copied to \dist/prompts/\ by rollup-plugin-copy.

## Fix

Normalize the prompt directory so \prompts/architect.md\ resolves correctly in both source (\src/prompts/\ → parent \src/\ + \prompts/\) and bundled (\dist/\ + \prompts/\) contexts.

Fixes #107