### PR TITLE
feat: identify meta synthesis sessions by phase and entity path

### DIFF
--- a/packages/service/src/orchestrator/buildTask.ts
+++ b/packages/service/src/orchestrator/buildTask.ts
@@ -138,6 +138,8 @@ export function buildArchitectTask(
   config: MetaConfig,
 ): string {
   const sections = [
+    `# jeeves-meta · ARCHITECT · ${ctx.path}`,
+    '',
     meta._architect ?? config.defaultArchitect ?? DEFAULT_ARCHITECT_PROMPT,
     '',
     '## SCOPE',
@@ -185,6 +187,8 @@ export function buildBuilderTask(
   config: MetaConfig,
 ): string {
   const sections = [
+    `# jeeves-meta · BUILDER · ${ctx.path}`,
+    '',
     '## TASK BRIEF (from Architect)',
     meta._builder ?? '(No architect brief available)',
     '',
@@ -259,6 +263,8 @@ export function buildCriticTask(
   config: MetaConfig,
 ): string {
   const sections = [
+    `# jeeves-meta · CRITIC · ${ctx.path}`,
+    '',
     meta._critic ?? config.defaultCritic ?? DEFAULT_CRITIC_PROMPT,
     '',
     '## SYNTHESIS TO EVALUATE',

--- a/packages/service/src/orchestrator/synthesizeNode.ts
+++ b/packages/service/src/orchestrator/synthesizeNode.ts
@@ -117,6 +117,7 @@ export async function synthesizeNode(
       const architectResult = await executor.spawn(architectTask, {
         thinking: config.thinking,
         timeout: config.architectTimeout,
+        label: 'meta-architect',
       });
       builderBrief = parseArchitectOutput(architectResult.output);
       architectTokens = architectResult.tokens;
@@ -166,6 +167,7 @@ export async function synthesizeNode(
     const builderResult = await executor.spawn(builderTask, {
       thinking: config.thinking,
       timeout: config.builderTimeout,
+      label: 'meta-builder',
     });
     builderOutput = parseBuilderOutput(builderResult.output);
     builderTokens = builderResult.tokens;
@@ -220,6 +222,7 @@ export async function synthesizeNode(
     const criticResult = await executor.spawn(criticTask, {
       thinking: config.thinking,
       timeout: config.criticTimeout,
+      label: 'meta-critic',
     });
     feedback = parseCriticOutput(criticResult.output);
     criticTokens = criticResult.tokens;


### PR DESCRIPTION
## Summary
Each meta synthesis session now starts with an H1 header identifying the process and phase:

\\\
# jeeves-meta · ARCHITECT · J:/domains/meetings/2026-04-12
# jeeves-meta · BUILDER · J:/domains/meetings/2026-04-12
# jeeves-meta · CRITIC · J:/domains/meetings/2026-04-12
\\\

Session labels also now distinguish the phase: \meta-architect\, \meta-builder\, \meta-critic\ instead of the generic \jeeves-meta-synthesis\.

## Changes
- \uildTask.ts\: prepend H1 identification header to architect, builder, and critic task prompts
- \synthesizeNode.ts\: pass phase-specific \label\ to \executor.spawn()\

## Also includes (from prior merged PR #118)
- \GatewayExecutor.ts\: isolate gateway invoke session per synthesis cycle

## Testing
- npm test (374 pass)
- npm run typecheck
- npm run lint
- npm run build
