### PR TITLE
fix: normalize owner paths in /synthesize route (#120)

### DIFF
--- a/packages/service/src/routes/synthesize.test.ts
+++ b/packages/service/src/routes/synthesize.test.ts
@@ -134,6 +134,48 @@ describe('POST /synthesize', () => {
     expect(queue.depth).toBe(1);
   });
 
+  it('normalizes owner path to .meta path', async () => {
+    const logger = makeLogger();
+    const queue = new SynthesisQueue(logger);
+    const deps = makeDeps({ queue });
+    app = Fastify();
+    registerSynthesizeRoute(app, deps);
+    await app.ready();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/synthesize',
+      payload: { path: '/some/owner/dir' },
+    });
+
+    expect(res.statusCode).toBe(202);
+    const body = res.json<{ status: string; path: string }>();
+    expect(body.status).toBe('accepted');
+    expect(body.path).toMatch(/[/\\]some[/\\]owner[/\\]dir[/\\]\.meta$/);
+    expect(queue.depth).toBe(1);
+  });
+
+  it('preserves path already ending in .meta', async () => {
+    const logger = makeLogger();
+    const queue = new SynthesisQueue(logger);
+    const deps = makeDeps({ queue });
+    app = Fastify();
+    registerSynthesizeRoute(app, deps);
+    await app.ready();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/synthesize',
+      payload: { path: '/some/owner/dir/.meta' },
+    });
+
+    expect(res.statusCode).toBe(202);
+    const body = res.json<{ status: string; path: string }>();
+    expect(body.status).toBe('accepted');
+    expect(body.path).toBe('/some/owner/dir/.meta');
+    expect(queue.depth).toBe(1);
+  });
+
   it('returns queue position', async () => {
     const logger = makeLogger();
     const queue = new SynthesisQueue(logger);

--- a/packages/service/src/routes/synthesize.ts
+++ b/packages/service/src/routes/synthesize.ts
@@ -8,6 +8,7 @@ import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 
 import { listMetas } from '../discovery/index.js';
+import { resolveMetaDir } from '../lock.js';
 import { discoverStalestPath } from '../scheduling/index.js';
 import type { RouteDeps } from './index.js';
 
@@ -26,7 +27,7 @@ export function registerSynthesizeRoute(
 
     let targetPath: string;
     if (body.path) {
-      targetPath = body.path;
+      targetPath = resolveMetaDir(body.path);
     } else {
       // Discover stalest candidate
       let result;


### PR DESCRIPTION
Fixes #120

The \POST /synthesize\ route passed \ody.path\ directly to the queue without normalizing it through \esolveMetaDir()\. When callers sent an owner path (e.g. \j:/path/to/repo\) instead of a \.meta/\ path, \orchestrateOnce()\ would look for \meta.json\ at the wrong location (\epo/meta.json\ instead of \epo/.meta/meta.json\), fail the existence check, and return \{ synthesized: false }\ silently.

The scheduler was unaffected because \discoverStalestPath()\ already returns \.meta/\-suffixed paths.

### Changes

- **synthesize.ts**: Wrap \ody.path\ in \esolveMetaDir()\ before enqueueing
- **synthesize.test.ts**: Add tests for owner path normalization and \.meta\ pass-through

All 355 tests pass.