### PR TITLE
feat: add _disabled flag and meta_update tool (#123, #124)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ jeeves-meta service start|stop|status|install|remove
 
 ### As an OpenClaw plugin
 
-Install the plugin package. Eleven tools become available to the agent:
+Install the plugin package. Twelve tools become available to the agent:
 
 - `meta_status` — service health, version, uptime
 - `meta_config` — query service configuration with optional JSONPath
@@ -78,6 +78,7 @@ Install the plugin package. Eleven tools become available to the agent:
 - `meta_seed` — create `.meta/` directory for a new path (with optional cross-refs and steer)
 - `meta_unlock` — remove stale `.lock` from a meta entity
 - `meta_queue` — queue management: list pending, clear queue, abort current synthesis
+- `meta_update` — update user-settable reserved properties (`_steer`, `_emphasis`, `_depth`, `_crossRefs`, `_disabled`)
 
 ## Configuration
 

--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -4,7 +4,7 @@ OpenClaw plugin for [jeeves-meta](../service/). A thin HTTP client that register
 
 ## Features
 
-- **Eleven tools** — standard: `meta_status`, `meta_config`, `meta_config_apply`, `meta_service`; custom: `meta_list`, `meta_detail`, `meta_trigger`, `meta_preview`, `meta_seed`, `meta_unlock`, `meta_queue` (list/clear/abort)
+- **Twelve tools** — standard: `meta_status`, `meta_config`, `meta_config_apply`, `meta_service`; custom: `meta_list`, `meta_detail`, `meta_trigger`, `meta_preview`, `meta_seed`, `meta_unlock`, `meta_queue` (list/clear/abort), `meta_update`
 - **MetaServiceClient** — typed HTTP client delegating all operations to the running service
 - **TOOLS.md injection** — periodic refresh of entity stats via `ComponentWriter` from `@karmaniverous/jeeves` (73-second prime interval)
 - **Cleanup escalation** — passes `gatewayUrl` into `ComponentWriter` so managed-content cleanup can request a gateway session when needed
@@ -57,7 +57,7 @@ The `configRoot` setting tells `@karmaniverous/jeeves` core where to find the pl
 ## Documentation
 
 - **[Plugin Setup](guides/plugin-setup.md)** — installation, config, lifecycle
-- **[Tools Reference](guides/tools-reference.md)** — 11 tools: standard (meta_status, meta_config, meta_config_apply, meta_service) + custom (meta_list, meta_detail, meta_trigger, meta_preview, meta_seed, meta_unlock, meta_queue)
+- **[Tools Reference](guides/tools-reference.md)** — 12 tools: standard (meta_status, meta_config, meta_config_apply, meta_service) + custom (meta_list, meta_detail, meta_trigger, meta_preview, meta_seed, meta_unlock, meta_queue, meta_update)
 - **[Virtual Rules](guides/virtual-rules.md)** — watcher inference rules
 - **[TOOLS.md Injection](guides/tools-injection.md)** — dynamic prompt generation
 

--- a/packages/openclaw/guides/tools-reference.md
+++ b/packages/openclaw/guides/tools-reference.md
@@ -4,7 +4,7 @@ title: Tools Reference
 
 # Tools Reference
 
-All tools delegate to the jeeves-meta HTTP service. The plugin registers 11 tools: 4 standard (produced by `createPluginToolset()`) and 7 custom.
+All tools delegate to the jeeves-meta HTTP service. The plugin registers 12 tools: 4 standard (produced by `createPluginToolset()`) and 8 custom.
 
 ## Standard Tools
 
@@ -41,7 +41,7 @@ List metas with summary stats and per-meta projection.
 
 **Parameters:**
 - `pathPrefix` (string, optional) — filter by path prefix
-- `filter` (object, optional) — structured filter: `hasError`, `staleHours`, `neverSynthesized`, `locked`
+- `filter` (object, optional) — structured filter: `hasError`, `staleHours`, `neverSynthesized`, `locked`, `disabled`
 - `fields` (string[], optional) — fields to include per meta
 
 **Response:** `{ summary, metas }`
@@ -116,4 +116,16 @@ Queue management: list pending items, clear the queue, or abort current synthesi
 **Response (list):** `{ current, pending, state }`
 **Response (clear):** `{ cleared: <count> }`
 **Response (abort):** `{ status: "aborted", path }` or 404 if nothing running
+
+## meta_update
+
+Update user-settable reserved properties on a meta entity. Delegates to `PATCH /metas/:path`.
+
+**Parameters:**
+- `path` (string, required) — `.meta/` or owner directory path
+- `updates` (object, required) — properties to set. Supported: `_steer`, `_emphasis`, `_depth`, `_crossRefs`, `_disabled`. Set a value to `null` to remove the property.
+
+**Response:** `{ path, meta }` — the updated meta with large generated fields (`_architect`, `_builder`, `_critic`, `_content`, `_feedback`) excluded.
+
+Engine-managed properties (tokens, timestamps, errors, synthesis output) are rejected. Unknown keys fail validation (400). Missing meta paths return 404.
 

--- a/packages/openclaw/skills/jeeves-meta/SKILL.md
+++ b/packages/openclaw/skills/jeeves-meta/SKILL.md
@@ -19,12 +19,12 @@ registration health.
 
 ### meta_list
 List all `.meta/` directories with summary stats and per-meta projection.
-Supports filtering by path prefix, error status, staleness, and lock state.
-Use for engine health checks and finding stale knowledge.
+Supports filtering by path prefix, error status, staleness, lock state, and
+disabled status. Use for engine health checks and finding stale knowledge.
 
 **Parameters:**
 - `pathPrefix` (optional): Filter by path prefix (e.g. "github/")
-- `filter` (optional): Structured filter (`{ hasError: true }`, `{ staleHours: 24 }`)
+- `filter` (optional): Structured filter (`{ hasError: true }`, `{ staleHours: 24 }`, `{ disabled: true }`)
 - `fields` (optional): Property projection array
 
 ### meta_detail
@@ -86,6 +86,17 @@ filtering to extract specific settings. Sensitive fields (e.g.
 - `path` (optional): JSONPath expression (e.g. `$.schedule`). If omitted,
   returns the full sanitized config.
 
+### meta_update
+Update user-settable reserved properties on a meta entity. Use this to
+toggle `_disabled`, change `_steer`, adjust `_emphasis` or `_depth`, or
+modify `_crossRefs` — without editing `meta.json` directly on the filesystem.
+
+**Parameters:**
+- `path` (required): `.meta/` or owner directory path.
+- `updates` (required): Object with properties to set. Supported:
+  `_steer`, `_emphasis`, `_depth`, `_crossRefs`, `_disabled`.
+  Set a value to `null` to remove the property.
+
 ### meta_queue
 Queue management: list pending items, clear the queue, or abort current
 synthesis. The synthesis queue is single-threaded; use this tool to inspect
@@ -113,6 +124,9 @@ what's running, clear queued work, or abort a stuck synthesis.
 - **Checking queue state:** `meta_queue` with action `list`
 - **Clearing queued work:** `meta_queue` with action `clear`
 - **Aborting stuck synthesis:** `meta_queue` with action `abort`
+- **Disabling a meta:** `meta_update` with path and `updates: { _disabled: true }`
+- **Re-enabling a meta:** `meta_update` with path and `updates: { _disabled: null }`
+- **Changing steer via API:** `meta_update` with path and `updates: { _steer: "new focus" }`
 - **Reading synthesis output:** Use `watcher_search` filtered by the properties
   configured in `metaProperty` (e.g. `{ "domains": ["meta"] }` in production).
   The default properties are `{ _meta: "current" }` for live metas and
@@ -131,6 +145,10 @@ what's running, clear queued work, or abort a stuck synthesis.
 - **Staleness:** Time since last synthesis. Deeper metas (leaves) update more
   often than rollup metas (parents). Cross-ref freshness does NOT affect
   the referencing meta's staleness — each meta synthesizes independently.
+- **Disabled (`_disabled`):** Set `_disabled: true` on a meta to exclude it
+  from automatic staleness scheduling. The scheduler and auto-select both
+  skip disabled metas. Manual triggers (`meta_trigger` with explicit path)
+  still work. Use `meta_update` to toggle the flag.
 - **Three steps:** Architect crafts the task brief, Builder produces content,
   Critic evaluates quality. The feedback loop self-improves over cycles.
 - **Archives:** Each cycle creates a timestamped snapshot in `.meta/archive/`.
@@ -501,6 +519,7 @@ The service exposes these endpoints (default port 1938):
 | GET | `/status` | Service health, queue state, dependency checks |
 | GET | `/metas` | List metas with filtering and field projection |
 | GET | `/metas/:path` | Single meta detail with optional archive |
+| PATCH | `/metas/:path` | Update user-settable reserved properties |
 | GET | `/preview` | Dry-run next synthesis candidate |
 | POST | `/synthesize` | Enqueue synthesis (stalest or specific path) |
 | POST | `/synthesize/abort` | Abort the currently running synthesis |

--- a/packages/openclaw/src/customTools.ts
+++ b/packages/openclaw/src/customTools.ts
@@ -30,6 +30,7 @@ export function buildCustomTools(
     buildMetaSeedTool(client, baseUrl),
     buildMetaUnlockTool(client, baseUrl),
     buildMetaQueueTool(client, baseUrl),
+    buildMetaUpdateTool(client, baseUrl),
   ];
 }
 
@@ -61,12 +62,13 @@ function buildMetaListTool(
         filter: {
           type: 'object',
           description:
-            'Structured filter. Supported keys: hasError (boolean), staleHours (number), neverSynthesized (boolean), locked (boolean).',
+            'Structured filter. Supported keys: hasError (boolean), staleHours (number), neverSynthesized (boolean), locked (boolean), disabled (boolean).',
           properties: {
             hasError: { type: 'boolean' },
             staleHours: { type: 'number' },
             neverSynthesized: { type: 'boolean' },
             locked: { type: 'boolean' },
+            disabled: { type: 'boolean' },
           },
         },
         fields: {
@@ -85,6 +87,7 @@ function buildMetaListTool(
           staleHours: filter?.staleHours as number | undefined,
           neverSynthesized: filter?.neverSynthesized as boolean | undefined,
           locked: filter?.locked as boolean | undefined,
+          disabled: filter?.disabled as boolean | undefined,
           fields: params.fields as string[] | undefined,
         }),
       );
@@ -283,5 +286,49 @@ function buildMetaQueueTool(
           return ok({ error: `Unknown action: ${action}` });
       }
     },
+  };
+}
+
+function buildMetaUpdateTool(
+  client: MetaServiceClient,
+  baseUrl: string,
+): ToolDescriptor {
+  return {
+    name: 'meta_update',
+    description: 'Update user-settable reserved properties on a meta entity.',
+    parameters: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Path to the .meta/ directory or owner directory.',
+        },
+        updates: {
+          type: 'object',
+          description:
+            'Properties to set. Supported: _steer, _emphasis, _depth, _crossRefs, _disabled. Set to null to remove.',
+          properties: {
+            _steer: { type: ['string', 'null'] },
+            _emphasis: { type: ['number', 'null'] },
+            _depth: { type: ['number', 'null'] },
+            _crossRefs: {
+              oneOf: [
+                { type: 'array', items: { type: 'string' } },
+                { type: 'null' },
+              ],
+            },
+            _disabled: { type: ['boolean', 'null'] },
+          },
+        },
+      },
+      required: ['path', 'updates'],
+    },
+    execute: async (_id: string, params: Record<string, unknown>) =>
+      wrap(baseUrl, () =>
+        client.update(
+          params.path as string,
+          params.updates as Parameters<MetaServiceClient['update']>[1],
+        ),
+      ),
   };
 }

--- a/packages/openclaw/src/serviceClient.ts
+++ b/packages/openclaw/src/serviceClient.ts
@@ -113,6 +113,7 @@ export class MetaServiceClient {
     staleHours?: number;
     neverSynthesized?: boolean;
     locked?: boolean;
+    disabled?: boolean;
     fields?: string[];
   }): Promise<MetasResponse> {
     const qs = new URLSearchParams();
@@ -124,9 +125,30 @@ export class MetaServiceClient {
     if (params?.neverSynthesized !== undefined)
       qs.set('neverSynthesized', String(params.neverSynthesized));
     if (params?.locked !== undefined) qs.set('locked', String(params.locked));
+    if (params?.disabled !== undefined)
+      qs.set('disabled', String(params.disabled));
     if (params?.fields?.length) qs.set('fields', params.fields.join(','));
     const query = qs.toString();
     return this.get<MetasResponse>('/metas' + (query ? '?' + query : ''));
+  }
+
+  /** PATCH /metas/:path — update user-settable reserved properties. */
+  public async update(
+    metaPath: string,
+    updates: {
+      _steer?: string | null;
+      _emphasis?: number | null;
+      _depth?: number | null;
+      _crossRefs?: string[] | null;
+      _disabled?: boolean | null;
+    },
+  ): Promise<unknown> {
+    const encoded = encodeURIComponent(metaPath);
+    return fetchJson(`${this.baseUrl}/metas/${encoded}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(updates),
+    });
   }
 
   /** GET /metas/:path — detail for a single meta. */

--- a/packages/service/README.md
+++ b/packages/service/README.md
@@ -65,6 +65,7 @@ jeeves-meta service install --config /path/to/jeeves-meta/config.json
 | POST | `/config/apply` | Apply a config patch (merge or replace) |
 | GET | `/queue` | Current queue state (current, pending, stats) |
 | POST | `/queue/clear` | Remove all pending queue items |
+| PATCH | `/metas/:path` | Update user-settable reserved properties (`_steer`, `_emphasis`, `_depth`, `_crossRefs`, `_disabled`) |
 
 ## Configuration
 

--- a/packages/service/guides/concepts.md
+++ b/packages/service/guides/concepts.md
@@ -34,6 +34,8 @@ Cross-ref freshness does NOT affect the referencing meta's staleness. Each meta 
 
 A meta is stale when any file in its scope was modified after `_generatedAt`. The scheduler uses a weighted formula incorporating tree depth and per-meta emphasis to prioritize which meta to synthesize next.
 
+Set `_disabled: true` on a meta to exclude it from automatic staleness scheduling. Disabled metas are never selected by the scheduler or by the auto-select path of `POST /synthesize`, but manual triggers (`meta_trigger` with an explicit path, or `POST /synthesize` with an explicit path) still run them.
+
 ## Progressive Synthesis (`_state`)
 
 The builder can populate an opaque `_state` field in `meta.json` to carry forward intermediate progress across cycles. On timeout (`SpawnTimeoutError`), the service attempts to salvage any advanced `_state` from partial output — preserving progress even when the full synthesis fails.

--- a/packages/service/guides/scheduling.md
+++ b/packages/service/guides/scheduling.md
@@ -26,6 +26,10 @@ Each tick:
 4. Enqueue the stalest candidate (if none found, increase backoff and return)
 5. Check watcher uptime for restart detection → re-register virtual rules if needed (only runs when a candidate was found)
 
+## Disabled Metas
+
+Any meta with `_disabled: true` in its `meta.json` is excluded from automatic scheduling — the scheduler and the auto-select path of `POST /synthesize` both skip it. Manual triggers (`meta_trigger` with an explicit path or `POST /synthesize` with an explicit path) still run disabled metas on demand. Use `meta_update` (or `PATCH /metas/:path`) to toggle the flag.
+
 ## Adaptive Backoff
 
 When no stale candidates are found:

--- a/packages/service/src/discovery/computeSummary.test.ts
+++ b/packages/service/src/discovery/computeSummary.test.ts
@@ -22,6 +22,7 @@ function makeEntry(overrides: Partial<MetaEntry> = {}): MetaEntry {
     architectTokens: overrides.architectTokens ?? null,
     builderTokens: overrides.builderTokens ?? null,
     criticTokens: overrides.criticTokens ?? null,
+    disabled: overrides.disabled ?? false,
     children: overrides.children ?? 0,
     node: overrides.node ?? ({} as MetaEntry['node']),
     meta: overrides.meta ?? ({} as MetaEntry['meta']),
@@ -36,6 +37,7 @@ describe('computeSummary', () => {
     expect(summary.stale).toBe(0);
     expect(summary.errors).toBe(0);
     expect(summary.locked).toBe(0);
+    expect(summary.disabled).toBe(0);
     expect(summary.neverSynthesized).toBe(0);
     expect(summary.tokens.architect).toBe(0);
     expect(summary.tokens.builder).toBe(0);
@@ -198,5 +200,17 @@ describe('computeSummary', () => {
     const summary = computeSummary(entries, 0.5);
 
     expect(summary.locked).toBe(2);
+  });
+
+  it('counts disabled entries', () => {
+    const entries = [
+      makeEntry({ path: 'j:/a/.meta', disabled: true }),
+      makeEntry({ path: 'j:/b/.meta', disabled: false }),
+      makeEntry({ path: 'j:/c/.meta', disabled: true }),
+    ];
+
+    const summary = computeSummary(entries, 0.5);
+
+    expect(summary.disabled).toBe(2);
   });
 });

--- a/packages/service/src/discovery/computeSummary.ts
+++ b/packages/service/src/discovery/computeSummary.ts
@@ -22,6 +22,7 @@ export function computeSummary(
   let staleCount = 0;
   let errorCount = 0;
   let lockedCount = 0;
+  let disabledCount = 0;
   let neverSynthesizedCount = 0;
   let totalArchitectTokens = 0;
   let totalBuilderTokens = 0;
@@ -35,6 +36,7 @@ export function computeSummary(
     if (e.stalenessSeconds > 0) staleCount++;
     if (e.hasError) errorCount++;
     if (e.locked) lockedCount++;
+    if (e.disabled) disabledCount++;
     if (e.lastSynthesized === null) neverSynthesizedCount++;
 
     totalArchitectTokens += e.architectTokens ?? 0;
@@ -64,6 +66,7 @@ export function computeSummary(
     stale: staleCount,
     errors: errorCount,
     locked: lockedCount,
+    disabled: disabledCount,
     neverSynthesized: neverSynthesizedCount,
     tokens: {
       architect: totalArchitectTokens,

--- a/packages/service/src/discovery/listMetas.test.ts
+++ b/packages/service/src/discovery/listMetas.test.ts
@@ -223,6 +223,31 @@ describe('listMetas', () => {
     expect(result.tree.nodes.size).toBe(2);
   });
 
+  it('includes disabled meta in listing with disabled: true', async () => {
+    const enabled = join(testDir, 'enabled', '.meta');
+    const disabled = join(testDir, 'disabled', '.meta');
+
+    createMeta(enabled, {
+      _generatedAt: new Date(Date.now() - 3600_000).toISOString(),
+    });
+    createMeta(disabled, {
+      _generatedAt: new Date(Date.now() - 3600_000).toISOString(),
+      _disabled: true,
+    });
+
+    const watcher = mockWatcher([enabled, disabled]);
+    const result = await listMetas(makeConfig(), watcher);
+
+    expect(result.entries).toHaveLength(2);
+    const disabledEntry = result.entries.find((e) =>
+      e.path.includes('disabled'),
+    );
+    const enabledEntry = result.entries.find((e) => e.path.includes('enabled'));
+    expect(disabledEntry?.disabled).toBe(true);
+    expect(enabledEntry?.disabled).toBe(false);
+    expect(result.summary.disabled).toBe(1);
+  });
+
   it('tracks stalest and last synthesized correctly', async () => {
     const old = join(testDir, 'old', '.meta');
     const recent = join(testDir, 'recent', '.meta');

--- a/packages/service/src/discovery/listMetas.ts
+++ b/packages/service/src/discovery/listMetas.ts
@@ -35,6 +35,8 @@ export interface MetaEntry {
   hasError: boolean;
   /** Whether this meta is currently locked. */
   locked: boolean;
+  /** Whether this meta is disabled (skipped during staleness scheduling). */
+  disabled: boolean;
   /** Cumulative architect tokens, or null if never run. */
   architectTokens: number | null;
   /** Cumulative builder tokens, or null if never run. */
@@ -55,6 +57,7 @@ export interface MetaListSummary {
   stale: number;
   errors: number;
   locked: number;
+  disabled: number;
   neverSynthesized: number;
   tokens: {
     architect: number;
@@ -110,6 +113,7 @@ export async function listMetas(
     const emphasis = meta._emphasis ?? 1;
     const hasError = Boolean(meta._error);
     const locked = isLocked(normalizePath(node.metaPath));
+    const disabled = meta._disabled === true;
     const neverSynth = !meta._generatedAt;
 
     // Compute staleness
@@ -134,6 +138,7 @@ export async function listMetas(
       lastSynthesized: meta._generatedAt ?? null,
       hasError,
       locked,
+      disabled,
       architectTokens: archTokens > 0 ? archTokens : null,
       builderTokens: buildTokens > 0 ? buildTokens : null,
       criticTokens: critTokens > 0 ? critTokens : null,

--- a/packages/service/src/routes/index.ts
+++ b/packages/service/src/routes/index.ts
@@ -16,6 +16,7 @@ import type { ServiceConfig } from '../schema/config.js';
 import { registerConfigRoute } from './config.js';
 import { registerConfigApplyRoute } from './configApply.js';
 import { registerMetasRoutes } from './metas.js';
+import { registerMetasUpdateRoute } from './metasUpdate.js';
 import { registerPreviewRoute } from './preview.js';
 import { registerQueueRoutes } from './queue.js';
 import { registerSeedRoute } from './seed.js';
@@ -78,6 +79,7 @@ export function registerRoutes(app: FastifyInstance, deps: RouteDeps): void {
 
   registerStatusRoute(app, deps);
   registerMetasRoutes(app, deps);
+  registerMetasUpdateRoute(app, deps);
   registerSynthesizeRoute(app, deps);
   registerPreviewRoute(app, deps);
   registerSeedRoute(app, deps);

--- a/packages/service/src/routes/metas.test.ts
+++ b/packages/service/src/routes/metas.test.ts
@@ -327,11 +327,55 @@ describe('GET /metas — list with filters', () => {
       'lastSynthesized',
       'hasError',
       'locked',
+      'disabled',
       'architectTokens',
       'builderTokens',
       'criticTokens',
     ];
     expect(Object.keys(body.metas[0]).sort()).toEqual(expectedKeys.sort());
+  });
+
+  it('disabled filter works (true and false)', async () => {
+    const ownerActive = join(listRoot, 'active');
+    const ownerDisabled = join(listRoot, 'disabled-owner');
+    const pathActive = createMeta(ownerActive, {
+      _id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      _generatedAt: '2026-03-01T00:00:00Z',
+    });
+    const pathDisabled = createMeta(ownerDisabled, {
+      _id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      _generatedAt: '2026-03-01T00:00:00Z',
+      _disabled: true,
+    });
+    const watcher = makeWatcher([pathActive, pathDisabled]);
+    const deps = makeDeps({
+      watcher: watcher as unknown as RouteDeps['watcher'],
+    });
+    app = Fastify();
+    registerMetasRoutes(app, deps);
+    await app.ready();
+
+    const resTrue = await app.inject({
+      method: 'GET',
+      url: '/metas?disabled=true',
+    });
+    const bodyTrue = resTrue.json<{
+      metas: Array<{ disabled: boolean; path: string }>;
+    }>();
+    expect(bodyTrue.metas).toHaveLength(1);
+    expect(bodyTrue.metas[0]?.disabled).toBe(true);
+    expect(bodyTrue.metas[0]?.path).toContain('disabled-owner');
+
+    const resFalse = await app.inject({
+      method: 'GET',
+      url: '/metas?disabled=false',
+    });
+    const bodyFalse = resFalse.json<{
+      metas: Array<{ disabled: boolean; path: string }>;
+    }>();
+    expect(bodyFalse.metas).toHaveLength(1);
+    expect(bodyFalse.metas[0]?.disabled).toBe(false);
+    expect(bodyFalse.metas[0]?.path).toContain('active');
   });
 });
 

--- a/packages/service/src/routes/metas.ts
+++ b/packages/service/src/routes/metas.ts
@@ -41,6 +41,10 @@ const metasQuerySchema = z.object({
     .enum(['true', 'false'])
     .transform((v) => v === 'true')
     .optional(),
+  disabled: z
+    .enum(['true', 'false'])
+    .transform((v) => v === 'true')
+    .optional(),
   fields: z.string().optional(),
 });
 
@@ -80,6 +84,9 @@ export function registerMetasRoutes(
     if (query.locked !== undefined) {
       entries = entries.filter((e) => e.locked === query.locked);
     }
+    if (query.disabled !== undefined) {
+      entries = entries.filter((e) => e.disabled === query.disabled);
+    }
     if (typeof query.staleHours === 'number') {
       entries = entries.filter(
         (e) => e.stalenessSeconds >= query.staleHours! * 3600,
@@ -99,6 +106,7 @@ export function registerMetasRoutes(
       'lastSynthesized',
       'hasError',
       'locked',
+      'disabled',
       'architectTokens',
       'builderTokens',
       'criticTokens',
@@ -117,6 +125,7 @@ export function registerMetasRoutes(
         lastSynthesized: e.lastSynthesized,
         hasError: e.hasError,
         locked: e.locked,
+        disabled: e.disabled,
         architectTokens: e.architectTokens,
         builderTokens: e.builderTokens,
         criticTokens: e.criticTokens,

--- a/packages/service/src/routes/metasUpdate.test.ts
+++ b/packages/service/src/routes/metasUpdate.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Tests for PATCH /metas/:path — update user-settable reserved properties.
+ *
+ * @module routes/metasUpdate.test
+ */
+
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import Fastify, { type FastifyInstance } from 'fastify';
+import type { Logger } from 'pino';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { WatcherClient } from '../interfaces/index.js';
+import { normalizePath } from '../normalizePath.js';
+import type { RouteDeps } from './index.js';
+import { registerMetasUpdateRoute } from './metasUpdate.js';
+
+const root = join(
+  tmpdir(),
+  `jeeves-meta-metas-update-${Date.now().toString()}`,
+);
+
+function makeDeps(overrides: Partial<RouteDeps> = {}): RouteDeps {
+  return {
+    config: {
+      watcherUrl: 'http://localhost:3456',
+      gatewayUrl: 'http://127.0.0.1:18789',
+      depthWeight: 1,
+      architectEvery: 10,
+      maxArchive: 20,
+      maxLines: 500,
+      architectTimeout: 120,
+      builderTimeout: 600,
+      criticTimeout: 300,
+      thinking: 'low',
+      defaultArchitect: 'arch',
+      defaultCritic: 'crit',
+      skipUnchanged: true,
+      metaProperty: {},
+      metaArchiveProperty: {},
+      port: 1938,
+      schedule: '*/30 * * * *',
+      watcherHealthIntervalMs: 60000,
+      logging: { level: 'info' },
+      autoSeed: [],
+    },
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    } as unknown as Logger,
+    queue: {} as RouteDeps['queue'],
+    watcher: {} as RouteDeps['watcher'],
+    scheduler: null,
+    stats: {
+      totalSyntheses: 0,
+      totalTokens: 0,
+      totalErrors: 0,
+      lastCycleDurationMs: null,
+      lastCycleAt: null,
+    },
+    ...overrides,
+  };
+}
+
+function makeWatcher(metaJsonPaths: string[]): WatcherClient {
+  return {
+    walk: vi.fn().mockResolvedValue(metaJsonPaths),
+    registerRules: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMeta(
+  ownerDir: string,
+  meta: Record<string, unknown> = {},
+): { metaJsonPath: string; metaDir: string } {
+  const metaDir = join(ownerDir, '.meta');
+  mkdirSync(metaDir, { recursive: true });
+  const metaJsonPath = join(metaDir, 'meta.json');
+  writeFileSync(
+    metaJsonPath,
+    JSON.stringify({
+      _id: '550e8400-e29b-41d4-a716-446655440099',
+      ...meta,
+    }),
+  );
+  return { metaJsonPath, metaDir };
+}
+
+function readMeta(metaDir: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(metaDir, 'meta.json'), 'utf8')) as Record<
+    string,
+    unknown
+  >;
+}
+
+describe('PATCH /metas/:path', () => {
+  let app: FastifyInstance;
+
+  afterEach(async () => {
+    await app.close();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('updates _disabled: true', async () => {
+    const owner = join(root, 'disableMe');
+    const { metaJsonPath, metaDir } = createMeta(owner);
+
+    const watcher = makeWatcher([metaJsonPath]);
+    const deps = makeDeps({
+      watcher: watcher as unknown as RouteDeps['watcher'],
+    });
+    app = Fastify();
+    registerMetasUpdateRoute(app, deps);
+    await app.ready();
+
+    const encoded = encodeURIComponent(normalizePath(owner));
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/metas/${encoded}`,
+      payload: { _disabled: true },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ path: string; meta: Record<string, unknown> }>();
+    expect(body.meta._disabled).toBe(true);
+
+    // Verify disk
+    const disk = readMeta(metaDir);
+    expect(disk._disabled).toBe(true);
+  });
+
+  it('updates _steer', async () => {
+    const owner = join(root, 'steerMe');
+    const { metaJsonPath, metaDir } = createMeta(owner);
+    const watcher = makeWatcher([metaJsonPath]);
+    const deps = makeDeps({
+      watcher: watcher as unknown as RouteDeps['watcher'],
+    });
+    app = Fastify();
+    registerMetasUpdateRoute(app, deps);
+    await app.ready();
+
+    const encoded = encodeURIComponent(normalizePath(owner));
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/metas/${encoded}`,
+      payload: { _steer: 'Focus on API shape' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ meta: Record<string, unknown> }>();
+    expect(body.meta._steer).toBe('Focus on API shape');
+    expect(readMeta(metaDir)._steer).toBe('Focus on API shape');
+  });
+
+  it('removes a property when value is null', async () => {
+    const owner = join(root, 'removeSteer');
+    const { metaJsonPath, metaDir } = createMeta(owner, {
+      _steer: 'old steer',
+    });
+    const watcher = makeWatcher([metaJsonPath]);
+    const deps = makeDeps({
+      watcher: watcher as unknown as RouteDeps['watcher'],
+    });
+    app = Fastify();
+    registerMetasUpdateRoute(app, deps);
+    await app.ready();
+
+    const encoded = encodeURIComponent(normalizePath(owner));
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/metas/${encoded}`,
+      payload: { _steer: null },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ meta: Record<string, unknown> }>();
+    expect(body.meta).not.toHaveProperty('_steer');
+    expect(readMeta(metaDir)).not.toHaveProperty('_steer');
+  });
+
+  it('rejects engine-managed properties (strict validation)', async () => {
+    const owner = join(root, 'strict');
+    const { metaJsonPath } = createMeta(owner);
+    const watcher = makeWatcher([metaJsonPath]);
+    const deps = makeDeps({
+      watcher: watcher as unknown as RouteDeps['watcher'],
+    });
+    app = Fastify();
+    registerMetasUpdateRoute(app, deps);
+    await app.ready();
+
+    const encoded = encodeURIComponent(normalizePath(owner));
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/metas/${encoded}`,
+      payload: { _content: 'forbidden' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    const body = res.json<{ error: string }>();
+    expect(body.error).toBe('BAD_REQUEST');
+  });
+
+  it('returns 404 for unknown path', async () => {
+    const watcher = makeWatcher([]);
+    const deps = makeDeps({
+      watcher: watcher as unknown as RouteDeps['watcher'],
+    });
+    app = Fastify();
+    registerMetasUpdateRoute(app, deps);
+    await app.ready();
+
+    const encoded = encodeURIComponent('j:/does/not/exist');
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/metas/${encoded}`,
+      payload: { _disabled: true },
+    });
+
+    expect(res.statusCode).toBe(404);
+    const body = res.json<{ error: string }>();
+    expect(body.error).toBe('NOT_FOUND');
+  });
+
+  it('returns the updated meta, excluding large generated fields', async () => {
+    const owner = join(root, 'projection');
+    const { metaJsonPath } = createMeta(owner, {
+      _architect: 'ARCH PROMPT',
+      _builder: 'BUILD PROMPT',
+      _critic: 'CRIT PROMPT',
+      _content: 'GENERATED CONTENT',
+      _feedback: 'FEEDBACK',
+      _steer: 'old',
+    });
+    const watcher = makeWatcher([metaJsonPath]);
+    const deps = makeDeps({
+      watcher: watcher as unknown as RouteDeps['watcher'],
+    });
+    app = Fastify();
+    registerMetasUpdateRoute(app, deps);
+    await app.ready();
+
+    const encoded = encodeURIComponent(normalizePath(owner));
+    const res = await app.inject({
+      method: 'PATCH',
+      url: `/metas/${encoded}`,
+      payload: { _steer: 'new' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ path: string; meta: Record<string, unknown> }>();
+    expect(body.meta._steer).toBe('new');
+    expect(body.meta).not.toHaveProperty('_architect');
+    expect(body.meta).not.toHaveProperty('_builder');
+    expect(body.meta).not.toHaveProperty('_critic');
+    expect(body.meta).not.toHaveProperty('_content');
+    expect(body.meta).not.toHaveProperty('_feedback');
+  });
+});

--- a/packages/service/src/routes/metasUpdate.ts
+++ b/packages/service/src/routes/metasUpdate.ts
@@ -7,14 +7,15 @@
  * @module routes/metasUpdate
  */
 
-import { readFile, writeFile } from 'node:fs/promises';
+import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 
-import { findNode, listMetas } from '../discovery/index.js';
+import { resolveMetaDir } from '../lock.js';
 import { normalizePath } from '../normalizePath.js';
+import { readMetaJson } from '../readMetaJson.js';
 import type { RouteDeps } from './index.js';
 
 const updateBodySchema = z
@@ -31,11 +32,11 @@ export function registerMetasUpdateRoute(
   app: FastifyInstance,
   deps: RouteDeps,
 ): void {
+  void deps; // Signature matches other route registrars; deps unused for direct-read route
+
   app.patch<{ Params: { path: string } }>(
     '/metas/:path',
     async (request, reply) => {
-      const { config, watcher } = deps;
-
       const parseResult = updateBodySchema.safeParse(request.body);
       if (!parseResult.success) {
         return reply.status(400).send({
@@ -46,21 +47,19 @@ export function registerMetasUpdateRoute(
       const updates = parseResult.data;
 
       const targetPath = normalizePath(decodeURIComponent(request.params.path));
-      const result = await listMetas(config, watcher);
-      const targetNode = findNode(result.tree, targetPath);
+      const metaDir = resolveMetaDir(targetPath);
 
-      if (!targetNode) {
+      let meta: Record<string, unknown>;
+      try {
+        meta = (await readMetaJson(metaDir)) as Record<string, unknown>;
+      } catch {
         return reply.status(404).send({
           error: 'NOT_FOUND',
           message: 'Meta path not found: ' + targetPath,
         });
       }
 
-      const metaJsonPath = join(targetNode.metaPath, 'meta.json');
-      const meta = JSON.parse(await readFile(metaJsonPath, 'utf8')) as Record<
-        string,
-        unknown
-      >;
+      const metaJsonPath = join(metaDir, 'meta.json');
 
       const KEYS = [
         '_steer',
@@ -101,7 +100,7 @@ export function registerMetasUpdateRoute(
       }
 
       return reply.send({
-        path: targetNode.metaPath,
+        path: metaDir,
         meta: projected,
       });
     },

--- a/packages/service/src/routes/metasUpdate.ts
+++ b/packages/service/src/routes/metasUpdate.ts
@@ -1,0 +1,109 @@
+/**
+ * PATCH /metas/:path — update user-settable reserved properties on a meta.
+ *
+ * Supported fields: _steer, _emphasis, _depth, _crossRefs, _disabled.
+ * Set a field to null to remove it. Unknown keys are rejected.
+ *
+ * @module routes/metasUpdate
+ */
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+
+import { findNode, listMetas } from '../discovery/index.js';
+import { normalizePath } from '../normalizePath.js';
+import type { RouteDeps } from './index.js';
+
+const updateBodySchema = z
+  .object({
+    _steer: z.union([z.string(), z.null()]).optional(),
+    _emphasis: z.union([z.number().min(0), z.null()]).optional(),
+    _depth: z.union([z.number(), z.null()]).optional(),
+    _crossRefs: z.union([z.array(z.string()), z.null()]).optional(),
+    _disabled: z.union([z.boolean(), z.null()]).optional(),
+  })
+  .strict();
+
+export function registerMetasUpdateRoute(
+  app: FastifyInstance,
+  deps: RouteDeps,
+): void {
+  app.patch<{ Params: { path: string } }>(
+    '/metas/:path',
+    async (request, reply) => {
+      const { config, watcher } = deps;
+
+      const parseResult = updateBodySchema.safeParse(request.body);
+      if (!parseResult.success) {
+        return reply.status(400).send({
+          error: 'BAD_REQUEST',
+          message: parseResult.error.message,
+        });
+      }
+      const updates = parseResult.data;
+
+      const targetPath = normalizePath(decodeURIComponent(request.params.path));
+      const result = await listMetas(config, watcher);
+      const targetNode = findNode(result.tree, targetPath);
+
+      if (!targetNode) {
+        return reply.status(404).send({
+          error: 'NOT_FOUND',
+          message: 'Meta path not found: ' + targetPath,
+        });
+      }
+
+      const metaJsonPath = join(targetNode.metaPath, 'meta.json');
+      const meta = JSON.parse(await readFile(metaJsonPath, 'utf8')) as Record<
+        string,
+        unknown
+      >;
+
+      const KEYS = [
+        '_steer',
+        '_emphasis',
+        '_depth',
+        '_crossRefs',
+        '_disabled',
+      ] as const;
+      const toDelete = new Set<string>();
+      const toSet: Record<string, unknown> = {};
+      for (const key of KEYS) {
+        const value = updates[key];
+        if (value === null) {
+          toDelete.add(key);
+        } else if (value !== undefined) {
+          toSet[key] = value;
+        }
+      }
+      const updated: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(meta)) {
+        if (!toDelete.has(k)) updated[k] = v;
+      }
+      Object.assign(updated, toSet);
+
+      await writeFile(metaJsonPath, JSON.stringify(updated, null, 2) + '\n');
+
+      // Project the response — exclude the same large fields as the detail route.
+      const defaultExclude = new Set([
+        '_architect',
+        '_builder',
+        '_critic',
+        '_content',
+        '_feedback',
+      ]);
+      const projected: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(updated)) {
+        if (!defaultExclude.has(k)) projected[k] = v;
+      }
+
+      return reply.send({
+        path: targetNode.metaPath,
+        meta: projected,
+      });
+    },
+  );
+}

--- a/packages/service/src/routes/synthesize.test.ts
+++ b/packages/service/src/routes/synthesize.test.ts
@@ -261,6 +261,49 @@ describe('POST /synthesize', () => {
     expect(body.path).toContain('stale');
   });
 
+  it('skips disabled metas during auto-select but honors explicit path', async () => {
+    const ownerStale = join(synthRoot, 'disabled-stale');
+    const metaJsonPath = createMeta(ownerStale, {
+      _id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+      _generatedAt: new Date(Date.now() - 86400_000).toISOString(),
+      _disabled: true,
+    });
+    const watcher = makeWatcher([metaJsonPath]);
+    const logger = makeLogger();
+    const queue = new SynthesisQueue(logger);
+
+    const deps = makeDeps({
+      queue,
+      watcher: watcher as unknown as RouteDeps['watcher'],
+    });
+    app = Fastify();
+    registerSynthesizeRoute(app, deps);
+    await app.ready();
+
+    // Auto-select: disabled meta must be skipped.
+    const resAuto = await app.inject({
+      method: 'POST',
+      url: '/synthesize',
+      payload: {},
+    });
+    expect(resAuto.statusCode).toBe(200);
+    const bodyAuto = resAuto.json<{ status: string }>();
+    expect(bodyAuto.status).toBe('skipped');
+    expect(queue.depth).toBe(0);
+
+    // Explicit path: manual trigger still works on disabled metas.
+    const resExplicit = await app.inject({
+      method: 'POST',
+      url: '/synthesize',
+      payload: { path: ownerStale },
+    });
+    expect(resExplicit.statusCode).toBe(202);
+    const bodyExplicit = resExplicit.json<{ status: string; path: string }>();
+    expect(bodyExplicit.status).toBe('accepted');
+    expect(bodyExplicit.path).toContain('disabled-stale');
+    expect(queue.depth).toBe(1);
+  });
+
   it('returns 503 when watcher unreachable and no path provided', async () => {
     const watcher: WatcherClient = {
       walk: vi.fn().mockRejectedValue(new Error('connection refused')),

--- a/packages/service/src/routes/synthesize.ts
+++ b/packages/service/src/routes/synthesize.ts
@@ -40,7 +40,7 @@ export function registerSynthesizeRoute(
         });
       }
       const stale = result.entries
-        .filter((e) => e.stalenessSeconds > 0)
+        .filter((e) => e.stalenessSeconds > 0 && !e.disabled)
         .map((e) => ({
           node: e.node,
           meta: e.meta,

--- a/packages/service/src/scheduler/index.ts
+++ b/packages/service/src/scheduler/index.ts
@@ -196,7 +196,7 @@ export class Scheduler {
     try {
       const result = await listMetas(this.config, this.watcher);
       const stale = result.entries
-        .filter((e) => e.stalenessSeconds > 0)
+        .filter((e) => e.stalenessSeconds > 0 && !e.disabled)
         .map((e) => ({
           node: e.node,
           meta: e.meta,

--- a/packages/service/src/schema/meta.test.ts
+++ b/packages/service/src/schema/meta.test.ts
@@ -148,4 +148,30 @@ describe('metaJsonSchema', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it('accepts _disabled: true', () => {
+    const result = metaJsonSchema.safeParse({
+      _id: '550e8400-e29b-41d4-a716-446655440000',
+      _disabled: true,
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?._disabled).toBe(true);
+  });
+
+  it('accepts _disabled: false', () => {
+    const result = metaJsonSchema.safeParse({
+      _id: '550e8400-e29b-41d4-a716-446655440000',
+      _disabled: false,
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?._disabled).toBe(false);
+  });
+
+  it('accepts meta without _disabled (optional)', () => {
+    const result = metaJsonSchema.safeParse({
+      _id: '550e8400-e29b-41d4-a716-446655440000',
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?._disabled).toBeUndefined();
+  });
 });

--- a/packages/service/src/schema/meta.ts
+++ b/packages/service/src/schema/meta.ts
@@ -111,6 +111,9 @@ export const metaJsonSchema = z
      * Cleared on successful cycle.
      */
     _error: metaErrorSchema.optional(),
+
+    /** When true, this meta is skipped during staleness scheduling. Manual trigger still works. */
+    _disabled: z.boolean().optional(),
   })
   .loose();
 


### PR DESCRIPTION
## Summary

Implements two related features:

### #123 — _disabled flag for meta entities
- Added _disabled: z.boolean().optional() to metaJsonSchema
- Scheduler and synthesize auto-select both filter out _disabled: true entries
- Manual triggers (explicit path) still work on disabled metas
- meta_list supports disabled filter; summary includes disabled count
- meta_detail surfaces _disabled naturally from meta.json

### #124 — PATCH /metas/:path endpoint and meta_update plugin tool
- New PATCH route accepts user-settable reserved properties: _steer, _emphasis, _depth, _crossRefs, _disabled
- Null values delete the property; unknown keys are rejected (strict validation)
- New meta_update plugin tool wraps the endpoint
- Service client updated with update() method and disabled filter param

### Docs
- Concepts guide: documented _disabled under Staleness
- Scheduling guide: new 'Disabled Metas' section
- Tools reference: updated meta_list filter docs, added meta_update section

### Tests (7 new, 368 total — all pass)
- Schema: accepts _disabled true/false/absent
- Discovery: disabled meta surfaced in listing; disabled count in summary
- Routes: disabled filter on GET /metas; disabled in default projection
- Synthesize: auto-select skips disabled; explicit path still works
- PATCH: updates fields, null removes, rejects unknown keys, 404 for missing

Closes #123, closes #124