### PR TITLE
feat: phase-state machine (v0.15.0 / v0.12.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Knowledge synthesis engine for the Jeeves platform. Transforms raw data archives
 
 ## Overview
 
-jeeves-meta is an HTTP service that discovers `.meta/` directories via the jeeves-watcher filesystem walk endpoint (`POST /walk`), builds an ownership tree, and schedules synthesis cycles based on weighted staleness. Each cycle:
+jeeves-meta is an HTTP service that discovers `.meta/` directories via the jeeves-watcher filesystem walk endpoint (`POST /walk`), builds an ownership tree, and schedules synthesis using a **phase-state machine**. Each meta tracks its three phases independently, and the scheduler picks one phase per tick across the entire corpus (critic > builder > architect priority). The three phases:
 
 1. **Architect** — analyzes data shape and crafts a task brief with search strategies
 2. **Builder** — executes the brief, queries the semantic index, and produces a synthesis
 3. **Critic** — spot-checks claims, evaluates against steering prompts, and provides feedback
 
-Results are written to `.meta/meta.json` files with full archive history, enabling self-improving feedback loops.
+Results are written to `.meta/meta.json` files with full archive history, enabling self-improving feedback loops. Failed phases are surgically retried without re-running the full pipeline.
 
 Metas can declare explicit cross-references (`_crossRefs`) to other metas, forming a heterarchical mesh that enables organizational views across source domains.
 
@@ -26,7 +26,7 @@ Metas can declare explicit cross-references (`_crossRefs`) to other metas, formi
 ![Service Architecture](diagrams/assets/service-architecture.png)
 
 - **jeeves-meta service** runs as a standalone HTTP service (NSSM/systemd/launchd)
-- **Built-in scheduler** (croner-based) discovers stale candidates and enqueues them
+- **Built-in scheduler** (croner-based) discovers stale candidates via phase-state machine and enqueues one phase per tick
 - **GatewayExecutor** spawns LLM sessions via the OpenClaw gateway `/tools/invoke` endpoint
 - **jeeves-watcher** provides filesystem enumeration (`POST /walk`) and hosts virtual inference rules
 - **OpenClaw plugin** is a thin HTTP client — all logic lives in the service

--- a/packages/openclaw/CHANGELOG.md
+++ b/packages/openclaw/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file. Dates are displayed in UTC.
 
+#### [0.12.0](https://github.com/karmaniverous/jeeves-meta/compare/0.11.0...0.12.0)
+
+- feat: phase-aware tool descriptions for meta_list, meta_detail, meta_preview, meta_trigger, meta_queue
+- feat: TOOLS.md injection includes phase-state summary, failed-phase alerts, and next-phase indicator
+- feat: meta_queue tool documents three-layer queue model (current/overrides/automatic)
+- docs: update SKILL.md with phase-state machine awareness, troubleshooting, and operational monitoring
+- docs: update tools-injection guide with phase-state content
+
+**Migration notes:**
+- Requires @karmaniverous/jeeves-meta ≥ 0.15.0 (phase-state machine)
+- All tool response changes are **additive** (new fields only) — no breaking changes
+- TOOLS.md injection now shows phase-state summary and next-phase indicator when data is available
+
 #### [0.11.0](https://github.com/karmaniverous/jeeves-meta/compare/openclaw/0.10.7...0.11.0)
 
 - feat: add _disabled flag and meta_update tool (#123, #124) [`#125`](https://github.com/karmaniverous/jeeves-meta/pull/125)

--- a/packages/openclaw/README.md
+++ b/packages/openclaw/README.md
@@ -6,7 +6,8 @@ OpenClaw plugin for [jeeves-meta](../service/). A thin HTTP client that register
 
 - **Twelve tools** — standard: `meta_status`, `meta_config`, `meta_config_apply`, `meta_service`; custom: `meta_list`, `meta_detail`, `meta_trigger`, `meta_preview`, `meta_seed`, `meta_unlock`, `meta_queue` (list/clear/abort), `meta_update`
 - **MetaServiceClient** — typed HTTP client delegating all operations to the running service
-- **TOOLS.md injection** — periodic refresh of entity stats via `ComponentWriter` from `@karmaniverous/jeeves` (73-second prime interval)
+- **TOOLS.md injection** — periodic refresh of entity stats, phase-state summary, failed-phase alerts, and next-phase indicator via `ComponentWriter` from `@karmaniverous/jeeves` (73-second prime interval)
+- **Phase-state awareness** — tools expose per-meta `_phaseState`, `owedPhase`, and phase-state summary from the service's phase-state machine
 - **Cleanup escalation** — passes `gatewayUrl` into `ComponentWriter` so managed-content cleanup can request a gateway session when needed
 - **Dependency health** — shows warnings when watcher/gateway are degraded
 - **Consumer skill** — `SKILL.md` for agent integration

--- a/packages/openclaw/guides/tools-injection.md
+++ b/packages/openclaw/guides/tools-injection.md
@@ -10,6 +10,9 @@ The plugin uses `ComponentWriter` from `@karmaniverous/jeeves` to periodically w
 
 The injected section includes:
 - Entity summary table (total, stale, errors, never synthesized, stalest, last synthesized)
+- **Phase-state summary** — aggregate counts of fresh, pending, running, and failed phases across the corpus (when phase-state data is available)
+- **Failed-phase alerts** — lists metas with failed phases (up to 10) with their path and failed phase name
+- **Next-phase indicator** — shows the next candidate path, phase, priority band, and staleness
 - Dependency health warnings (watcher/gateway status, rules registration state)
 - Skill reference pointer
 

--- a/packages/openclaw/skills/jeeves-meta/SKILL.md
+++ b/packages/openclaw/skills/jeeves-meta/SKILL.md
@@ -541,7 +541,7 @@ The service exposes these endpoints (default port 1938):
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/status` | Service health, queue state, dependency checks |
+| GET | `/status` | Service health, queue state, dependency checks, phase-state summary |
 | GET | `/metas` | List metas with filtering and field projection |
 | GET | `/metas/:path` | Single meta detail with optional archive |
 | PATCH | `/metas/:path` | Update user-settable reserved properties |
@@ -552,8 +552,8 @@ The service exposes these endpoints (default port 1938):
 | POST | `/unlock` | Remove `.lock` file from a meta entity |
 | GET | `/config` | Query sanitized config with optional JSONPath (`?path=$.schedule`) |
 | POST | `/config/apply` | Apply a config patch (merge or replace) |
-| GET | `/queue` | Current queue state (current, pending, stats) |
-| POST | `/queue/clear` | Remove all pending queue items |
+| GET | `/queue` | Queue state: current (with phase), overrides, automatic, pending |
+| POST | `/queue/clear` | Remove all override queue entries |
 
 All endpoints return JSON. The OpenClaw plugin tools are thin wrappers
 around these endpoints.
@@ -698,8 +698,10 @@ not yet indexed new files
 - All prompts are compiled as Handlebars templates. Avoid using `{{` in prompt
   overrides unless you intend template variable resolution. Escape with `\{{`
   for literal double-braces.
-- The synthesis queue is single-threaded: one synthesis at a time. HTTP-triggered
-  syntheses get priority over scheduler-triggered ones.
+- The synthesis queue is single-threaded with three layers: `current` (the
+  running phase), `overrides` (explicitly triggered entries, highest priority),
+  and `automatic` (scheduler-computed candidates). Override entries are
+  processed before automatic candidates.
 - The scheduler uses adaptive backoff: if no stale candidates are found, it
   doubles the skip interval (max 4×). Backoff resets after any successful
   phase execution (not just full-cycle completion).

--- a/packages/openclaw/skills/jeeves-meta/SKILL.md
+++ b/packages/openclaw/skills/jeeves-meta/SKILL.md
@@ -685,8 +685,9 @@ not yet indexed new files
 
 ## Gotchas
 
-- `meta_trigger` runs a full LLM cycle (3 subprocess calls). It can take
-  several minutes.
+- `meta_trigger` enqueues a single phase (not all three). A full cycle
+  requires three separate ticks (one per phase). Use `meta_detail` to
+  check `_phaseState` for progress.
 - A locked meta (another synthesis in progress) will be skipped silently.
 - First-run quality is lower — the feedback loop needs 2-3 cycles to calibrate.
 - Changing `metaProperty` requires both a meta service restart AND a watcher reindex.
@@ -700,6 +701,7 @@ not yet indexed new files
 - The synthesis queue is single-threaded: one synthesis at a time. HTTP-triggered
   syntheses get priority over scheduler-triggered ones.
 - The scheduler uses adaptive backoff: if no stale candidates are found, it
-  doubles the skip interval (max 4×). Backoff resets after a successful synthesis.
+  doubles the skip interval (max 4×). Backoff resets after any successful
+  phase execution (not just full-cycle completion).
 - All CLI commands except `start` require the service to be running (they call
   the HTTP API).

--- a/packages/openclaw/skills/jeeves-meta/SKILL.md
+++ b/packages/openclaw/skills/jeeves-meta/SKILL.md
@@ -172,6 +172,17 @@ compatibility.
   (e.g. phased analysis, incremental refinement). On builder timeout, the
   engine attempts to recover partial output — if `_state` advanced, it saves
   the new state without overwriting existing content.
+- **Phase-state machine (`_phaseState`):** Each meta tracks its three phases
+  independently: `{ architect: <state>, builder: <state>, critic: <state> }`.
+  States are `fresh`, `stale`, `pending`, `running`, or `failed`. The
+  scheduler picks the single highest-priority owed phase across all metas
+  each tick (critic > builder > architect, with staleness tiebreaking).
+  Failed phases are automatically retried on the next tick (promoted from
+  `failed` → `pending`). Only the failed phase reruns — upstream/downstream
+  phases are untouched (surgical retries). A full cycle completes only when
+  all three phases are `fresh`, at which point the archive snapshot is taken
+  and `_synthesisCount` increments. Legacy metas without `_phaseState` have
+  their state derived automatically from existing fields on first load.
 
 ## Configuration
 
@@ -567,15 +578,22 @@ The `start` command uses `--config`/`-c` instead (port is read from the config f
 Recommended periodic checks:
 - **Errors:** `meta_list` with `filter: { hasError: true }` — investigate
   and retry with `meta_trigger`
+- **Failed phases:** The TOOLS.md injection shows a "Failed:" alert listing
+  metas with failed phases. Failed phases auto-retry on the next scheduler
+  tick. Use `meta_detail` to inspect the `_phaseState` and `_error` fields.
 - **Stuck locks:** `meta_list` with `filter: { locked: true }` — locks
   older than 30 minutes indicate a crashed synthesis; use `jeeves-meta unlock`
 - **Stale knowledge:** `meta_list` with `filter: { staleHours: 48 }` — check
   if the scheduler is running and the watcher is up
+- **Phase health:** `/status` includes `phaseStateSummary` with aggregate
+  counts per phase (`fresh`, `stale`, `pending`, `running`, `failed`) and
+  `nextPhase` showing the next candidate.
 - **Service health:** `/status` endpoint (via `meta_list` summary or direct
   HTTP) includes dependency status for watcher and gateway
 
 The TOOLS.md injection surfaces the most critical stats (entity count, errors,
-stalest entity) in the agent's system prompt automatically.
+stalest entity, phase summary, failed-phase alerts, next-phase indicator) in
+the agent's system prompt automatically.
 
 ## Troubleshooting
 
@@ -636,18 +654,22 @@ progressive work is not lost on timeout — only the content update is skipped.
 3. Check if the LLM provider is slow or rate-limited
 4. Check scope size: large scopes with many files take longer
 
-### LLM errors in synthesis steps
+### LLM errors in synthesis phases
 
-**Symptom:** `meta_detail` shows `_error` field with step/code/message
+**Symptom:** `meta_detail` shows `_error` field with step/code/message, and
+`_phaseState` shows `failed` for one or more phases.
 **Cause:** Subprocess failed (API error, malformed output, rate limit)
 **Fix:**
 1. Check error details: `meta_detail <path>` — `_error.step` tells you
-   which step failed
-2. Architect failure with existing `_builder`: engine reuses cached brief
+   which phase failed; `_phaseState` shows the exact state of each phase
+2. Failed phases are **automatically retried** on the next scheduler tick
+   (promoted from `failed` → `pending`). Only the failed phase reruns —
+   other phases are untouched (surgical retry).
+3. Architect failure with existing `_builder`: engine reuses cached brief
    (self-healing)
-3. Architect failure without `_builder` (first run): retry with `meta_trigger`
-4. Builder failure: meta stays stale, retried next cycle automatically
-5. Critic failure: content saved without feedback, not critical
+4. Architect failure without `_builder` (first run): retry with `meta_trigger`
+5. Builder failure: meta stays stale, retried next tick automatically
+6. Critic failure: content saved without feedback, not critical
 
 ### Discovery returns wrong/stale results
 

--- a/packages/openclaw/skills/jeeves-meta/SKILL.md
+++ b/packages/openclaw/skills/jeeves-meta/SKILL.md
@@ -7,6 +7,12 @@ jeeves-meta is the Jeeves platform's knowledge synthesis engine. It discovers
 gathers context from co-located source files, and uses a three-step LLM process
 (architect, builder, critic) to produce structured synthesis artifacts.
 
+Each meta entity carries a **phase-state machine** (`_phaseState`) tracking
+the state of each phase independently: `fresh`, `stale`, `pending`, `running`,
+or `failed`. The scheduler picks **one phase per tick** across the entire
+corpus (critic > builder > architect priority), enabling surgical retries of
+failed phases without re-running the full pipeline.
+
 **Requires:** jeeves-watcher ≥ 0.10.0 (provides `POST /walk` and auto
 rules-reindex on registration).
 
@@ -21,6 +27,8 @@ registration health.
 List all `.meta/` directories with summary stats and per-meta projection.
 Supports filtering by path prefix, error status, staleness, lock state, and
 disabled status. Use for engine health checks and finding stale knowledge.
+Each meta entry includes `phaseState` (`{ architect, builder, critic }`)
+showing the per-phase state.
 
 **Parameters:**
 - `pathPrefix` (optional): Filter by path prefix (e.g. "github/")
@@ -28,7 +36,8 @@ disabled status. Use for engine health checks and finding stale knowledge.
 - `fields` (optional): Property projection array
 
 ### meta_detail
-Full detail for a single meta, with optional archive history.
+Full detail for a single meta, with optional archive history. Includes
+`_phaseState` showing the per-phase state machine status.
 
 **Parameters:**
 - `path` (required): `.meta/` or owner directory path
@@ -36,20 +45,22 @@ Full detail for a single meta, with optional archive history.
 - `includeArchive` (optional): false, true, or number (N most recent)
 
 ### meta_preview
-Dry-run for the next synthesis cycle. Shows scope files, delta files,
-architect trigger reasons, steer status, and structure changes — without
-running any LLM calls. Use before `meta_trigger` to understand what
-will happen.
+Dry-run for the next synthesis candidate. Shows scope files, delta files,
+architect trigger reasons, steer status, structure changes, and the
+phase that would execute next — without running any LLM calls. Includes
+`phaseState` and `owedPhase` (the phase that would run). Use before
+`meta_trigger` to understand what will happen.
 
 **Parameters:**
 - `path` (optional): Specific `.meta/` or owner directory path. If omitted,
   previews the stalest candidate.
 
 ### meta_trigger
-Enqueue a synthesis cycle for a specific meta or the next-stalest candidate.
+Enqueue a synthesis for a specific meta or the next-stalest candidate.
 The synthesis runs asynchronously in the service queue; the tool returns
-immediately with the queue position. The full cycle (architect → builder →
-critic) runs in the background.
+immediately with the queue position. Only one phase runs per tick (the
+owed phase). Includes `owedPhase` in the response showing which phase
+will execute.
 
 **Parameters:**
 - `path` (optional): Specific `.meta/` or owner directory path. If omitted,
@@ -99,14 +110,17 @@ modify `_crossRefs` — without editing `meta.json` directly on the filesystem.
 
 ### meta_queue
 Queue management: list pending items, clear the queue, or abort current
-synthesis. The synthesis queue is single-threaded; use this tool to inspect
-what's running, clear queued work, or abort a stuck synthesis.
+synthesis. The queue has three layers: `current` (the running phase),
+`overrides` (explicitly triggered entries), and `automatic` (scheduler-
+computed candidates). The `pending` and `state` fields provide legacy
+compatibility.
 
 **Parameters:**
 - `action` (required): One of `list`, `clear`, `abort`.
-  - `list`: Show current queue state (current synthesis, pending items).
-  - `clear`: Remove all pending queue items.
-  - `abort`: Stop the currently running synthesis and release its lock.
+  - `list`: Show current queue state (current with phase, overrides,
+    automatic candidates, pending items).
+  - `clear`: Remove all override queue entries.
+  - `abort`: Stop the currently running phase and release its lock.
 
 ## When to Use
 

--- a/packages/openclaw/src/customTools.ts
+++ b/packages/openclaw/src/customTools.ts
@@ -51,7 +51,7 @@ function buildMetaListTool(
   return {
     name: 'meta_list',
     description:
-      'List metas with summary stats and per-meta projection. Replaces meta_status + meta_entities.',
+      'List metas with summary stats and per-meta projection. Response includes _phaseState and owedPhase per meta.',
     parameters: {
       type: 'object',
       properties: {
@@ -102,7 +102,7 @@ function buildMetaDetailTool(
   return {
     name: 'meta_detail',
     description:
-      'Full detail for a single meta, with optional archive history.',
+      'Full detail for a single meta, with optional archive history. Response includes _phaseState and owedPhase.',
     parameters: {
       type: 'object',
       properties: {
@@ -140,7 +140,7 @@ function buildMetaPreviewTool(
   return {
     name: 'meta_preview',
     description:
-      'Dry-run: show what inputs would be gathered for the next synthesis cycle without running LLM.',
+      'Dry-run preview of next synthesis. Returns owedPhase, priorityBand, phaseState, stalenessInputs, and architectInvalidators.',
     parameters: {
       type: 'object',
       properties: {
@@ -163,7 +163,7 @@ function buildMetaTriggerTool(
   return {
     name: 'meta_trigger',
     description:
-      'Manually trigger synthesis for a specific meta or the next-stalest candidate.',
+      'Trigger synthesis. Path-targeted creates an override queue entry; returns owedPhase. Fully-fresh metas return status:skipped.',
     parameters: {
       type: 'object',
       properties: {
@@ -260,7 +260,7 @@ function buildMetaQueueTool(
   return {
     name: 'meta_queue',
     description:
-      'Queue management: list pending items, clear the queue, or abort current synthesis.',
+      'Queue management. list: 3-layer model (current with phase, overrides, automatic, pending). clear: removes overrides only. abort: returns {status,path,phase} or {status:idle}.',
     parameters: {
       type: 'object',
       properties: {

--- a/packages/openclaw/src/promptInjection.test.ts
+++ b/packages/openclaw/src/promptInjection.test.ts
@@ -172,4 +172,119 @@ describe('generateMetaMenu', () => {
     expect(menu).not.toContain('| Tool |');
     expect(menu).toContain('jeeves-meta');
   });
+
+  // ── Phase-state TOOLS.md additions (Task #18c) ──
+
+  it('includes phase-state summary when phaseStateSummary is present', async () => {
+    const client = mockClient({
+      statusOverrides: {
+        health: {
+          phaseStateSummary: {
+            architect: {
+              fresh: 8,
+              stale: 0,
+              pending: 2,
+              running: 0,
+              failed: 0,
+            },
+            builder: { fresh: 7, stale: 1, pending: 1, running: 1, failed: 0 },
+            critic: { fresh: 9, stale: 0, pending: 0, running: 0, failed: 1 },
+          },
+          nextPhase: null,
+          dependencies: {
+            watcher: { status: 'ok', rulesRegistered: true },
+            gateway: { status: 'ok' },
+          },
+        },
+      },
+    });
+    const menu = await generateMetaMenu(client);
+    expect(menu).toContain('Phases:');
+    expect(menu).toContain('fresh');
+    expect(menu).toContain('pending');
+  });
+
+  it('includes failed-phase alert when metas have failed phases', async () => {
+    const client = mockClient({
+      statusOverrides: {
+        health: {
+          phaseStateSummary: {
+            architect: {
+              fresh: 10,
+              stale: 0,
+              pending: 0,
+              running: 0,
+              failed: 0,
+            },
+            builder: { fresh: 9, stale: 0, pending: 0, running: 0, failed: 1 },
+            critic: { fresh: 10, stale: 0, pending: 0, running: 0, failed: 0 },
+          },
+          nextPhase: null,
+          dependencies: {
+            watcher: { status: 'ok', rulesRegistered: true },
+            gateway: { status: 'ok' },
+          },
+        },
+      },
+      metasOverrides: {
+        metas: [
+          {
+            stalenessSeconds: 100,
+            path: 'j:/domains/test/.meta',
+            phaseState: {
+              architect: 'fresh',
+              builder: 'failed',
+              critic: 'stale',
+            },
+          },
+        ],
+      },
+    });
+    const menu = await generateMetaMenu(client);
+    expect(menu).toContain('Failed:');
+    expect(menu).toContain('j:/domains/test/.meta (builder)');
+  });
+
+  it('includes next-phase indicator when nextPhase is present', async () => {
+    const client = mockClient({
+      statusOverrides: {
+        health: {
+          phaseStateSummary: {
+            architect: {
+              fresh: 10,
+              stale: 0,
+              pending: 0,
+              running: 0,
+              failed: 0,
+            },
+            builder: { fresh: 10, stale: 0, pending: 0, running: 0, failed: 0 },
+            critic: { fresh: 10, stale: 0, pending: 0, running: 0, failed: 0 },
+          },
+          nextPhase: {
+            path: 'j:/domains/email/.meta',
+            phase: 'architect',
+            band: 3,
+            staleness: 172800,
+          },
+          dependencies: {
+            watcher: { status: 'ok', rulesRegistered: true },
+            gateway: { status: 'ok' },
+          },
+        },
+      },
+    });
+    const menu = await generateMetaMenu(client);
+    expect(menu).toContain('Next:');
+    expect(menu).toContain('j:/domains/email/.meta');
+    expect(menu).toContain('architect');
+    expect(menu).toContain('band 3');
+  });
+
+  it('omits phase sections when no phaseStateSummary in health', async () => {
+    const client = mockClient();
+    const menu = await generateMetaMenu(client);
+    expect(menu).not.toContain('Phase State');
+    expect(menu).not.toContain('Failed:');
+    expect(menu).not.toContain('Next:');
+  });
 });

--- a/packages/openclaw/src/promptInjection.ts
+++ b/packages/openclaw/src/promptInjection.ts
@@ -89,6 +89,73 @@ export async function generateMetaMenu(
     depLines.push('> ⚠️ **Gateway**: ' + dependencies.gateway.status);
   }
 
+  // Phase-state summary from /status health
+  const phaseLines: string[] = [];
+  const phaseSummary = status.health.phaseStateSummary as
+    | Record<string, Record<string, number>>
+    | undefined;
+  if (phaseSummary) {
+    // Aggregate counts across all phases
+    const totals: Record<string, number> = {};
+    for (const phase of ['architect', 'builder', 'critic']) {
+      const counts = phaseSummary[phase];
+      for (const [state, count] of Object.entries(counts)) {
+        if (count > 0) {
+          totals[state] = (totals[state] ?? 0) + count;
+        }
+      }
+    }
+    const parts: string[] = [];
+    for (const state of ['fresh', 'pending', 'running', 'failed']) {
+      if (totals[state]) {
+        parts.push(totals[state].toString() + ' ' + state);
+      }
+    }
+    if (parts.length > 0) {
+      phaseLines.push('Phases: ' + parts.join(', '));
+    }
+
+    // Failed-phase alert
+    const failedParts: string[] = [];
+    for (const item of metas.metas) {
+      const ps = item.phaseState as Record<string, string> | undefined;
+      if (!ps) continue;
+      for (const phase of ['architect', 'builder', 'critic']) {
+        if (ps[phase] === 'failed') {
+          const p = item.path as string;
+          failedParts.push(p + ' (' + phase + ')');
+        }
+      }
+    }
+    if (failedParts.length > 0) {
+      phaseLines.push(
+        '> Failed: ' +
+          failedParts.slice(0, 10).join(', ') +
+          (failedParts.length > 10
+            ? ' (+' + (failedParts.length - 10).toString() + ' more)'
+            : ''),
+      );
+    }
+  }
+
+  // Next-phase indicator from /status health
+  const nextPhase = status.health.nextPhase as
+    | { path: string; phase: string; band: number; staleness: number }
+    | undefined;
+  if (nextPhase) {
+    phaseLines.push(
+      'Next: ' +
+        nextPhase.path +
+        ' → ' +
+        nextPhase.phase +
+        ' (band ' +
+        nextPhase.band.toString() +
+        ', staleness ' +
+        formatAge(nextPhase.staleness) +
+        ')',
+    );
+  }
+
   return [
     'The jeeves-meta synthesis engine manages ' +
       summary.total.toString() +
@@ -103,6 +170,7 @@ export async function generateMetaMenu(
     '| Never synthesized | ' + summary.neverSynthesized.toString() + ' |',
     '| Stalest | ' + stalestDisplay + ' |',
     '| Last synthesized | ' + lastSynthDisplay + ' |',
+    ...(phaseLines.length > 0 ? ['', '### Phase State', ...phaseLines] : []),
     ...(depLines.length > 0 ? ['', '### Dependencies', ...depLines] : []),
     '',
     'Read the `jeeves-meta` skill for usage guidance, configuration, and troubleshooting.',

--- a/packages/service/CHANGELOG.md
+++ b/packages/service/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file. Dates are displayed in UTC.
 
+#### [0.15.0](https://github.com/karmaniverous/jeeves-meta/compare/0.14.0...0.15.0)
+
+- feat: add phase-state machine foundation — per-meta `_phaseState` tracking `{ architect, builder, critic }` × `{ fresh, stale, pending, running, failed }`
+- feat: phase-addressable scheduling — scheduler picks one phase per tick across entire corpus (critic > builder > architect priority)
+- feat: three-layer synthesis queue — `current` (running phase) + `overrides` (explicit triggers) + `automatic` (scheduler candidates)
+- feat: surgical retry of failed phases without re-running the full pipeline
+- feat: auto-retry — failed phases promoted `failed` → `pending` on each scheduler tick
+- feat: full-cycle completion — archive snapshot + `_synthesisCount` increment only when all three phases are `fresh`
+- feat: adaptive backoff resets on any successful phase execution
+- feat: `derivePhaseState()` backward compatibility for legacy metas without `_phaseState`
+- feat: `phaseStateSummary` and `nextPhase` in GET /status health response
+- feat: phase-aware GET /queue with three-layer model
+- feat: phase-aware POST /synthesize/abort response
+- docs: update guides for phase-state machine, scheduling, orchestration, concepts
+
+**Migration notes:**
+- `_phaseState` is auto-derived from existing fields on first load — no manual migration needed
+- All API response changes are **additive** (new fields only) — no breaking changes
+- GET /queue now returns `{ current, overrides, automatic, pending, state }` — `pending` and `state` fields are retained for backward compatibility
+- POST /queue/clear now removes only override entries (not legacy queue items)
+
 #### [0.14.0](https://github.com/karmaniverous/jeeves-meta/compare/service/0.13.11...0.14.0)
 
 - feat: add _disabled flag and meta_update tool (#123, #124) [`#125`](https://github.com/karmaniverous/jeeves-meta/pull/125)

--- a/packages/service/README.md
+++ b/packages/service/README.md
@@ -5,9 +5,10 @@ HTTP service for the Jeeves knowledge synthesis engine. Provides a Fastify API, 
 ## Features
 
 - **Fastify HTTP API** — `/status`, `/metas`, `/preview`, `/synthesize`, `/synthesize/abort`, `/seed`, `/unlock`, `/config`, `/config/apply`, `/queue`, `/queue/clear`
-- **Built-in scheduler** — croner-based cron with adaptive backoff
-- **Synthesis queue** — single-threaded, priority-aware, deduplicated
-- **Three-step orchestration** — architect, builder, critic with conditional re-architecture
+- **Phase-state machine** — per-meta `_phaseState` tracking `{ architect, builder, critic }` × `{ fresh, stale, pending, running, failed }`
+- **Built-in scheduler** — croner-based cron with adaptive backoff; picks one phase per tick across entire corpus
+- **Three-layer synthesis queue** — `current` (running phase) + `overrides` (explicit triggers) + `automatic` (scheduler candidates)
+- **Three-phase orchestration** — architect, builder, critic with surgical retry of failed phases
 - **Discovery via watcher** — filesystem-based meta discovery via `/walk` endpoint (no Qdrant dependency)
 - **Ownership tree** — hierarchical scoping with child meta rollup
 - **Cross-meta references** — `_crossRefs` declares relationships to other metas; referenced `_content` included as architect/builder context
@@ -53,7 +54,7 @@ jeeves-meta service install --config /path/to/jeeves-meta/config.json
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/status` | Service health, queue state, dependency checks |
+| GET | `/status` | Service health, queue state, dependency checks, phase-state summary |
 | GET | `/metas` | List metas with filtering and field projection |
 | GET | `/metas/:path` | Single meta detail with optional archive |
 | GET | `/preview` | Dry-run: preview inputs for next synthesis |
@@ -63,8 +64,8 @@ jeeves-meta service install --config /path/to/jeeves-meta/config.json
 | POST | `/unlock` | Remove `.lock` file from a meta entity |
 | GET | `/config` | Query sanitized config with optional JSONPath (`?path=$.schedule`) |
 | POST | `/config/apply` | Apply a config patch (merge or replace) |
-| GET | `/queue` | Current queue state (current, pending, stats) |
-| POST | `/queue/clear` | Remove all pending queue items |
+| GET | `/queue` | Queue state: current (with phase), overrides, automatic, pending |
+| POST | `/queue/clear` | Remove all override queue entries |
 | PATCH | `/metas/:path` | Update user-settable reserved properties (`_steer`, `_emphasis`, `_depth`, `_crossRefs`, `_disabled`) |
 
 ## Configuration

--- a/packages/service/guides/concepts.md
+++ b/packages/service/guides/concepts.md
@@ -15,12 +15,23 @@ A `.meta/` directory co-located with source content. Contains:
 
 Meta entities form a hierarchy based on filesystem nesting. A `.meta/` directory **owns** its parent directory and all descendants, except subtrees that contain their own `.meta/`. Child meta syntheses are consumed as rollup inputs by parent metas.
 
-## Synthesis Cycle
+## Synthesis Phases
 
-A three-step LLM pipeline:
+A three-phase LLM pipeline managed by a per-meta phase-state machine:
 1. **Architect** — analyzes scope structure, crafts a task brief (conditional: runs on structure change, steer change, or periodic refresh)
 2. **Builder** — executes the brief, produces `_content` + structured fields
 3. **Critic** — evaluates the synthesis, provides `_feedback` for the next cycle
+
+## Phase-State Machine (`_phaseState`)
+
+Each meta tracks its three phases independently via `_phaseState: { architect, builder, critic }`. Each phase can be in one of five states: `fresh`, `stale`, `pending`, `running`, or `failed`.
+
+The scheduler selects **one phase per tick** across the entire corpus, prioritizing by band (critic > builder > architect) and weighted staleness within each band. This enables:
+
+- **Surgical retries** — only the failed phase reruns; upstream/downstream untouched
+- **Auto-retry** — failed phases are promoted `failed` → `pending` on each tick
+- **Full-cycle completion** — archive snapshot + `_synthesisCount` increment only when all three phases are `fresh`
+- **Backward compatibility** — `derivePhaseState()` reconstructs the state from legacy fields on first load
 
 ## Cross-Meta References (`_crossRefs`)
 

--- a/packages/service/guides/orchestration.md
+++ b/packages/service/guides/orchestration.md
@@ -4,40 +4,44 @@ title: Orchestration
 
 # Orchestration
 
-The `orchestrate()` function runs a single synthesis cycle in 13 steps:
+The `orchestratePhase()` function runs **one phase per tick** using the phase-state machine:
 
 1. **Discover** — walk watcher filesystem for `.meta/meta.json` files (no Qdrant dependency)
 2. **Read** — parse `meta.json` for each discovered path
-3. **Build tree** — construct the ownership tree from valid paths
-4. **Select candidate** — rank by effective staleness, acquire lock on winner
-5. **Compute context** — scope files, delta files, child meta outputs, previous content/feedback
-6. **Structure hash** — SHA-256 of sorted scope file listing (computed from context)
-7. **Steer detection** — compare current `_steer` vs latest archive
-8. **Architect** (conditional) — runs if: no cached builder, structure changed, steer changed, or periodic refresh
-9. **Builder** — executes the architect's brief, produces `_content` + structured fields
-10. **Critic** — evaluates the synthesis, produces `_feedback`
-11. **Merge & finalize** — stage result in `.lock`, copy to `meta.json`
-12. **Archive & prune** — create timestamped archive snapshot, prune beyond `maxArchive`
-13. **Release lock** — delete `.lock` file (in `finally` block)
+3. **Derive phase state** — `derivePhaseState()` reconstructs `_phaseState` from legacy fields on first load
+4. **Auto-retry** — failed phases are promoted from `failed` → `pending`
+5. **Select candidate** — `selectPhaseCandidate()` picks the highest-priority owed phase across the corpus (critic > builder > architect, weighted staleness tiebreak)
+6. **Execute phase** — run exactly one of `runArchitect`, `runBuilder`, or `runCritic`
+7. **Persist** — lock-staged write of updated `_phaseState` and phase output
+8. **Archive** (on full-cycle only) — when all three phases are `fresh`, create snapshot and prune
+
+### Phase-State Machine
+
+Each meta carries `_phaseState: { architect, builder, critic }` where each value is one of: `fresh`, `stale`, `pending`, `running`, `failed`.
+
+**Key transitions:**
+- File change detected → `architect: stale` (cascade: `builder: pending`, `critic: pending`)
+- Architect success → `architect: fresh` (cascade: `builder: pending` if was stale)
+- Builder success → `builder: fresh`, `critic: pending`
+- Critic success → `critic: fresh`; if all three fresh → full-cycle complete (archive + increment `_synthesisCount`)
+- Any phase failure → that phase: `failed`; other phases untouched (surgical retry)
+- Next tick → `failed` phases promoted to `pending` for auto-retry
 
 ### Module Structure
 
-The orchestration pipeline is split into focused modules following SOLID/DRY principles:
-
 | Module | Responsibility |
 |--------|---------------|
-| `orchestrate.ts` | Discovery, staleness ranking, lock management, delegates to `synthesizeNode` |
-| `synthesizeNode.ts` | Single-node architect → builder → critic pipeline |
-| `finalizeCycle.ts` | Lock-staged writes: `.lock` → `meta.json` → archive → prune |
-| `timeoutRecovery.ts` | `SpawnTimeoutError` recovery with partial `_state` salvage |
+| `orchestratePhase.ts` | Per-tick driver: discover → derive → select → execute one phase |
+| `runPhase.ts` | Per-phase executors: `runArchitect`, `runBuilder`, `runCritic` |
+| `synthesizeNode.ts` | Legacy single-node full pipeline (retained for compatibility) |
+| `finalizeCycle.ts` | Legacy lock-staged writes |
 
 ### Error Handling
 
-- **Architect failure with cached builder**: continues with existing `_builder`
-- **Architect failure without cached builder**: cycle ends, error recorded
-- **Builder failure**: cycle ends, error recorded
-- **Builder timeout (`SpawnTimeoutError`)**: attempts to salvage advanced `_state` from partial output via `timeoutRecovery`; if `_state` progressed, it is persisted (state-only finalize) and the cycle is recorded as a partial success
-- **Critic failure**: synthesis is preserved, error attached
+- **Phase failure**: the phase transitions to `failed`; other phases are untouched
+- **Auto-retry**: failed phases are promoted to `pending` on the next scheduler tick
+- **Architect failure with cached builder**: engine can still run builder on next tick
+- **Builder timeout (`SpawnTimeoutError`)**: attempts to salvage advanced `_state` from partial output; if `_state` progressed, it is persisted alongside the `failed` phase state
 - **Errors never block the queue**: logged, reported, queue advances
 
 ### Lock Staging ("Never Write Worse")

--- a/packages/service/guides/scheduling.md
+++ b/packages/service/guides/scheduling.md
@@ -15,16 +15,31 @@ effectiveStaleness = actualStaleness × (normalizedDepth + 1) ^ (depthWeight × 
 - **depthWeight**: config exponent (default 0.5). Set to 0 for pure staleness ordering
 - **emphasis**: per-meta `_emphasis` multiplier (default 1). Higher = updates more often
 
-## Scheduler Behavior
+## Phase-Addressable Scheduling
+
+The scheduler uses the phase-state machine to select **one phase per tick** across the entire corpus, instead of enqueuing full synthesis cycles.
+
+### Priority Bands
+
+Phases are prioritized by band:
+1. **Critic** (band 1) — highest priority (finishing work)
+2. **Builder** (band 2) — middle priority
+3. **Architect** (band 3) — lowest priority (starting new work)
+
+Within each band, candidates are ranked by weighted staleness. The single highest-priority owed phase is selected per tick.
+
+### Scheduler Behavior
 
 The built-in croner scheduler runs on the configured cron expression (default: every 30 minutes).
 
 Each tick:
 1. **Auto-seed** — if `autoSeed` rules are configured, walk for matching directories via the watcher and seed any that lack a `.meta/` directory
 2. Discover all metas via watcher `/walk` endpoint
-3. Compute effective staleness for each
-4. Enqueue the stalest candidate (if none found, increase backoff and return)
-5. Check watcher uptime for restart detection → re-register virtual rules if needed (only runs when a candidate was found)
+3. **Derive phase state** — reconstruct `_phaseState` for legacy metas without it
+4. **Auto-retry** — promote `failed` → `pending` for all failed phases
+5. **Select phase candidate** — pick the highest-priority owed phase (critic > builder > architect, staleness tiebreak)
+6. Enqueue the selected phase (if no candidates, increase backoff and return)
+7. Check watcher uptime for restart detection → re-register virtual rules if needed
 
 ## Disabled Metas
 
@@ -35,13 +50,20 @@ Any meta with `_disabled: true` in its `meta.json` is excluded from automatic sc
 When no stale candidates are found:
 - Backoff multiplier doubles (max 4×)
 - Subsequent ticks are skipped based on `tickCount % backoffMultiplier`
-- Backoff resets to 1× after a successful synthesis
+- Backoff resets to 1× after **any successful phase execution** (not just full-cycle completion)
 
-## Queue Processing
+## Queue Processing (Three-Layer Model)
 
-The synthesis queue is single-threaded:
-- One synthesis runs at a time
-- Priority items (HTTP-triggered) go to the front
-- Duplicate paths are rejected (returns current position)
+The synthesis queue has three layers:
+1. **Current** — the currently running phase (path + phase + startedAt)
+2. **Overrides** — explicitly triggered entries (via HTTP/tools), processed with highest priority
+3. **Automatic** — scheduler-computed candidates, processed after overrides
+
+Key behaviors:
+- Single-threaded: one phase runs at a time
+- Override entries are processed before automatic candidates
+- Duplicate paths in overrides are rejected
+- `POST /queue/clear` removes only override entries
 - Errors are logged but don't block subsequent items
+- Legacy `pending` and `state` fields remain for backward compatibility
 

--- a/packages/service/src/bootstrap.ts
+++ b/packages/service/src/bootstrap.ts
@@ -17,7 +17,7 @@ import { listMetas } from './discovery/index.js';
 import { GatewayExecutor } from './executor/index.js';
 import { cleanupStaleLocks } from './lock.js';
 import { createLogger } from './logger/index.js';
-import { orchestrate } from './orchestrator/index.js';
+import { orchestratePhase } from './orchestrator/index.js';
 import { type ProgressPhase, ProgressReporter } from './progress/index.js';
 import { SynthesisQueue } from './queue/index.js';
 import type { RouteDeps, ServiceStats } from './routes/index.js';
@@ -103,10 +103,9 @@ export async function startService(
   // Progress reporter — uses shared config reference so hot-reload propagates
   const progress = new ProgressReporter(config, logger);
 
-  // Wire queue processing — synthesize one meta per dequeue
+  // Wire queue processing — execute one phase per dequeue (phase-state machine)
   const synthesizeFn = async (path: string): Promise<void> => {
     const startMs = Date.now();
-    let cycleTokens: number | undefined = 0;
     // Strip .meta suffix for human-readable progress reporting
     const ownerPath = path.replace(/\/?\.meta\/?$/, '');
     await progress.report({
@@ -115,7 +114,7 @@ export async function startService(
     });
 
     try {
-      const results = await orchestrate(
+      const result = await orchestratePhase(
         config,
         executor,
         watcher,
@@ -125,11 +124,7 @@ export async function startService(
           if (evt.type === 'phase_complete') {
             if (evt.tokens !== undefined) {
               stats.totalTokens += evt.tokens;
-              if (cycleTokens !== undefined) {
-                cycleTokens += evt.tokens;
-              }
             } else {
-              cycleTokens = undefined;
               logger.warn(
                 { path: ownerPath, phase: evt.phase },
                 'Token count unavailable (session lookup may have timed out)',
@@ -140,13 +135,14 @@ export async function startService(
         },
         logger,
       );
-      // orchestrate() always returns exactly one result
-      const result = results[0];
+
       const durationMs = Date.now() - startMs;
 
-      if (!result.synthesized) {
-        // Entity was skipped (e.g. empty scope) — no progress to report.
-        logger.debug({ path: ownerPath }, 'Synthesis skipped');
+      if (!result.executed) {
+        logger.debug(
+          { path: ownerPath },
+          'Phase skipped (fully fresh or locked)',
+        );
         return;
       }
 
@@ -155,20 +151,25 @@ export async function startService(
       stats.lastCycleDurationMs = durationMs;
       stats.lastCycleAt = new Date().toISOString();
 
-      if (result.error) {
+      const phaseResult = result.phaseResult;
+      if (phaseResult?.error) {
         stats.totalErrors++;
         await progress.report({
           type: 'error',
           path: ownerPath,
-          phase: result.error.step as ProgressPhase,
-          error: result.error.message,
+          phase: phaseResult.error.step as ProgressPhase,
+          error: phaseResult.error.message,
         });
       } else {
+        // Task #9: Reset backoff on ANY successful phase execution
         scheduler.resetBackoff();
+      }
+
+      // Emit synthesis_complete only on full-cycle completion
+      if (result.cycleComplete) {
         await progress.report({
           type: 'synthesis_complete',
           path: ownerPath,
-          tokens: cycleTokens,
           durationMs,
         });
       }

--- a/packages/service/src/bootstrap.ts
+++ b/packages/service/src/bootstrap.ts
@@ -120,6 +120,10 @@ export async function startService(
         watcher,
         path,
         async (evt) => {
+          // Wire current-phase tracking for GET /queue and POST /synthesize/abort
+          if (evt.type === 'phase_start' && evt.phase) {
+            queue.setCurrentPhase(ownerPath, evt.phase);
+          }
           // Track token stats from phase completions
           if (evt.type === 'phase_complete') {
             if (evt.tokens !== undefined) {

--- a/packages/service/src/executor/GatewayExecutor.ts
+++ b/packages/service/src/executor/GatewayExecutor.ts
@@ -158,6 +158,11 @@ export class GatewayExecutor implements MetaExecutor {
     }
   }
 
+  /** Whether this executor has been aborted by the operator. */
+  get aborted(): boolean {
+    return this.controller.signal.aborted;
+  }
+
   /** Abort the currently running spawn, if any. */
   abort(): void {
     this.controller.abort();

--- a/packages/service/src/index.ts
+++ b/packages/service/src/index.ts
@@ -96,11 +96,18 @@ export {
   mergeAndWrite,
   type MergeOptions,
   orchestrate,
+  orchestratePhase,
+  type OrchestratePhaseResult,
   type OrchestrateResult,
   parseArchitectOutput,
   parseBuilderOutput,
   parseCriticOutput,
+  type PhaseProgressCallback,
+  type PhaseResult,
   type ProgressCallback,
+  runArchitect,
+  runBuilder,
+  runCritic,
 } from './orchestrator/index.js';
 
 // ── Progress ──

--- a/packages/service/src/interfaces/MetaExecutor.ts
+++ b/packages/service/src/interfaces/MetaExecutor.ts
@@ -40,4 +40,11 @@ export interface MetaExecutor {
    * @returns The subprocess result with output and optional token count.
    */
   spawn(task: string, options?: MetaSpawnOptions): Promise<MetaSpawnResult>;
+
+  /**
+   * Whether the executor has been aborted by the operator.
+   * When true, runPhase catch blocks should skip persisting _error
+   * because the abort route has already written the correct state.
+   */
+  readonly aborted?: boolean;
 }

--- a/packages/service/src/orchestrator/index.ts
+++ b/packages/service/src/orchestrator/index.ts
@@ -22,14 +22,14 @@ export {
   type PhaseProgressCallback,
 } from './orchestratePhase.js';
 export {
-  type PhaseResult,
-  runArchitect,
-  runBuilder,
-  runCritic,
-} from './runPhase.js';
-export {
   type BuilderOutput,
   parseArchitectOutput,
   parseBuilderOutput,
   parseCriticOutput,
 } from './parseOutput.js';
+export {
+  type PhaseResult,
+  runArchitect,
+  runBuilder,
+  runCritic,
+} from './runPhase.js';

--- a/packages/service/src/orchestrator/index.ts
+++ b/packages/service/src/orchestrator/index.ts
@@ -17,6 +17,17 @@ export {
   type ProgressCallback,
 } from './orchestrate.js';
 export {
+  orchestratePhase,
+  type OrchestratePhaseResult,
+  type PhaseProgressCallback,
+} from './orchestratePhase.js';
+export {
+  type PhaseResult,
+  runArchitect,
+  runBuilder,
+  runCritic,
+} from './runPhase.js';
+export {
   type BuilderOutput,
   parseArchitectOutput,
   parseBuilderOutput,

--- a/packages/service/src/orchestrator/merge.ts
+++ b/packages/service/src/orchestrator/merge.ts
@@ -13,7 +13,7 @@ import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { computeEma } from '../ema.js';
-import type { MetaError } from '../schema/index.js';
+import type { MetaError, PhaseState } from '../schema/index.js';
 import { type MetaJson, metaJsonSchema } from '../schema/index.js';
 import type { BuilderOutput } from './parseOutput.js';
 
@@ -54,6 +54,8 @@ export interface MergeOptions {
    * Used for timeout recovery where state advanced but content did not.
    */
   stateOnly?: boolean;
+  /** Phase state record to persist. */
+  phaseState?: PhaseState;
 }
 
 /**
@@ -115,6 +117,9 @@ export async function mergeAndWrite(options: MergeOptions): Promise<MetaJson> {
     // Error handling
     _error: options.error ?? undefined,
 
+    // Phase state machine
+    _phaseState: options.phaseState,
+
     // Spread structured fields from builder
     ...options.builderOutput?.fields,
   };
@@ -134,6 +139,7 @@ export async function mergeAndWrite(options: MergeOptions): Promise<MetaJson> {
   if (merged._error === undefined) delete merged._error;
   if (merged._content === undefined) delete merged._content;
   if (merged._feedback === undefined) delete merged._feedback;
+  if (merged._phaseState === undefined) delete merged._phaseState;
 
   // Validate
   const result = metaJsonSchema.safeParse(merged);

--- a/packages/service/src/orchestrator/orchestratePhase.ts
+++ b/packages/service/src/orchestrator/orchestratePhase.ts
@@ -9,9 +9,6 @@
  * @module orchestrator/orchestratePhase
  */
 
-import { copyFile, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
-
 import { buildMinimalNode } from '../discovery/buildMinimalNode.js';
 import { listMetas } from '../discovery/index.js';
 import { getScopeFiles, getScopePrefix } from '../discovery/scope.js';
@@ -38,6 +35,7 @@ import type {
 } from '../schema/index.js';
 import { computeStructureHash } from '../structureHash.js';
 import {
+  persistPhaseState,
   type PhaseResult,
   runArchitect,
   runBuilder,
@@ -149,12 +147,16 @@ export async function orchestratePhase(
         watcher,
       );
       if (!verifiedStale) {
-        const freshMeta = await readMetaJson(winner.node.metaPath);
-        freshMeta._generatedAt = new Date().toISOString();
-        const lockPath = join(winner.node.metaPath, '.lock');
-        const metaJsonPath = join(winner.node.metaPath, 'meta.json');
-        await writeFile(lockPath, JSON.stringify(freshMeta, null, 2) + '\n');
-        await copyFile(lockPath, metaJsonPath);
+        await persistPhaseState(
+          {
+            metaPath: winner.node.metaPath,
+            current: currentMeta,
+            config,
+            structureHash,
+          },
+          phaseState,
+          { _generatedAt: new Date().toISOString() },
+        );
         logger?.debug(
           { path: winner.node.ownerPath },
           'Skipped unchanged meta, bumped _generatedAt',

--- a/packages/service/src/orchestrator/orchestratePhase.ts
+++ b/packages/service/src/orchestrator/orchestratePhase.ts
@@ -1,0 +1,299 @@
+/**
+ * Phase-aware orchestration entry point.
+ *
+ * Replaces the old staleness-based orchestrate() with phase-state-machine
+ * scheduling: each tick discovers all metas, computes invalidation,
+ * auto-retries failed phases, selects the best phase candidate, and
+ * executes exactly one phase.
+ *
+ * @module orchestrator/orchestratePhase
+ */
+
+import { buildMinimalNode } from '../discovery/buildMinimalNode.js';
+import { listMetas } from '../discovery/index.js';
+import { getScopeFiles } from '../discovery/scope.js';
+import type { MetaNode } from '../discovery/types.js';
+import type { MetaExecutor, WatcherClient } from '../interfaces/index.js';
+import { acquireLock, releaseLock } from '../lock.js';
+import type { MinimalLogger } from '../logger/index.js';
+import { normalizePath } from '../normalizePath.js';
+import {
+  derivePhaseState,
+  getOwedPhase,
+  retryPhase,
+  selectPhaseCandidate,
+} from '../phaseState/index.js';
+import type { ProgressEvent } from '../progress/index.js';
+import { readMetaJson } from '../readMetaJson.js';
+import type {
+  MetaConfig,
+  MetaJson,
+  PhaseName,
+  PhaseState,
+} from '../schema/index.js';
+import { computeStructureHash } from '../structureHash.js';
+import {
+  type PhaseResult,
+  runArchitect,
+  runBuilder,
+  runCritic,
+} from './runPhase.js';
+
+/** Callback for synthesis progress events. */
+export type PhaseProgressCallback = (
+  event: ProgressEvent,
+) => void | Promise<void>;
+
+/** Result of a single phase-aware orchestration tick. */
+export interface OrchestratePhaseResult {
+  /** Whether a phase was executed. */
+  executed: boolean;
+  /** Path to the meta that was selected. */
+  metaPath?: string;
+  /** Which phase was run. */
+  phase?: PhaseName;
+  /** The phase result (if executed). */
+  phaseResult?: PhaseResult;
+  /** Whether a full synthesis cycle completed (all phases fresh). */
+  cycleComplete?: boolean;
+}
+
+/**
+ * Run a single phase-aware orchestration tick.
+ *
+ * When targetPath is provided (override entry), runs the owed phase for
+ * that specific meta. Otherwise, discovers all metas, computes invalidation,
+ * and selects the best phase candidate corpus-wide.
+ */
+export async function orchestratePhase(
+  config: MetaConfig,
+  executor: MetaExecutor,
+  watcher: WatcherClient,
+  targetPath?: string,
+  onProgress?: PhaseProgressCallback,
+  logger?: MinimalLogger,
+): Promise<OrchestratePhaseResult> {
+  // ── Targeted path (override entry) ──
+  if (targetPath) {
+    return orchestrateTargeted(
+      config,
+      executor,
+      watcher,
+      targetPath,
+      onProgress,
+      logger,
+    );
+  }
+
+  // ── Corpus-wide discovery + phase selection ──
+  let metaResult;
+  try {
+    metaResult = await listMetas(config, watcher);
+  } catch (err) {
+    logger?.warn({ err }, 'Failed to list metas for phase selection');
+    return { executed: false };
+  }
+
+  if (metaResult.entries.length === 0) return { executed: false };
+
+  // Build candidates with phase state (including invalidation + auto-retry)
+  const candidates = [];
+  for (const entry of metaResult.entries) {
+    let ps = derivePhaseState(entry.meta);
+
+    // Auto-retry failed phases: failed → pending on each tick
+    // (spec §8: "retry on the next eligible tick")
+    for (const phase of ['architect', 'builder', 'critic'] as const) {
+      if (ps[phase] === 'failed') {
+        ps = retryPhase(ps, phase);
+      }
+    }
+
+    candidates.push({
+      node: entry.node,
+      meta: entry.meta,
+      phaseState: ps,
+      actualStaleness: entry.stalenessSeconds,
+      locked: entry.locked,
+      disabled: entry.disabled,
+    });
+  }
+
+  // Select best phase candidate
+  const winner = selectPhaseCandidate(candidates, config.depthWeight);
+  if (!winner) {
+    return { executed: false };
+  }
+
+  // Acquire lock
+  if (!acquireLock(winner.node.metaPath)) {
+    logger?.debug(
+      { path: winner.node.metaPath },
+      'Selected candidate is locked, skipping',
+    );
+    return { executed: false };
+  }
+
+  try {
+    // Re-read meta under lock for freshness
+    const currentMeta = await readMetaJson(winner.node.metaPath);
+    let phaseState = derivePhaseState(currentMeta);
+
+    // Re-apply auto-retry under lock
+    for (const phase of ['architect', 'builder', 'critic'] as const) {
+      if (phaseState[phase] === 'failed') {
+        phaseState = retryPhase(phaseState, phase);
+      }
+    }
+
+    const owedPhase = getOwedPhase(phaseState);
+    if (!owedPhase || phaseState[owedPhase] !== 'pending') {
+      // Nothing to do (race: became fresh between selection and lock)
+      return { executed: false };
+    }
+
+    // Compute structure hash for the phase
+    const { scopeFiles } = await getScopeFiles(winner.node, watcher);
+    const structureHash = computeStructureHash(scopeFiles);
+
+    return await executePhase(
+      winner.node,
+      currentMeta,
+      phaseState,
+      owedPhase,
+      config,
+      executor,
+      watcher,
+      structureHash,
+      onProgress,
+      logger,
+    );
+  } finally {
+    releaseLock(winner.node.metaPath);
+  }
+}
+
+/**
+ * Orchestrate a targeted (override) meta path.
+ * Resolves the owed phase at execution time (not enqueue time).
+ */
+async function orchestrateTargeted(
+  config: MetaConfig,
+  executor: MetaExecutor,
+  watcher: WatcherClient,
+  targetPath: string,
+  onProgress?: PhaseProgressCallback,
+  logger?: MinimalLogger,
+): Promise<OrchestratePhaseResult> {
+  const normalizedTarget = normalizePath(targetPath);
+  const node = await buildMinimalNode(normalizedTarget, watcher);
+
+  if (!acquireLock(node.metaPath)) {
+    return { executed: false };
+  }
+
+  try {
+    const currentMeta = await readMetaJson(normalizedTarget);
+    let phaseState = derivePhaseState(currentMeta);
+
+    // Auto-retry failed phases for targeted triggers too
+    for (const phase of ['architect', 'builder', 'critic'] as const) {
+      if (phaseState[phase] === 'failed') {
+        phaseState = retryPhase(phaseState, phase);
+      }
+    }
+
+    const owedPhase = getOwedPhase(phaseState);
+    if (!owedPhase) {
+      // Fully fresh — override is a no-op (silently dropped per spec)
+      return { executed: false, metaPath: normalizedTarget };
+    }
+
+    // Compute structure hash
+    const { scopeFiles } = await getScopeFiles(node, watcher);
+    const structureHash = computeStructureHash(scopeFiles);
+
+    return await executePhase(
+      node,
+      currentMeta,
+      phaseState,
+      owedPhase,
+      config,
+      executor,
+      watcher,
+      structureHash,
+      onProgress,
+      logger,
+    );
+  } finally {
+    releaseLock(node.metaPath);
+  }
+}
+
+/**
+ * Execute exactly one phase on a meta.
+ */
+async function executePhase(
+  node: MetaNode,
+  currentMeta: MetaJson,
+  phaseState: PhaseState,
+  phase: PhaseName,
+  config: MetaConfig,
+  executor: MetaExecutor,
+  watcher: WatcherClient,
+  structureHash: string,
+  onProgress?: PhaseProgressCallback,
+  logger?: MinimalLogger,
+): Promise<OrchestratePhaseResult> {
+  let result: PhaseResult;
+
+  switch (phase) {
+    case 'architect':
+      result = await runArchitect(
+        node,
+        currentMeta,
+        phaseState,
+        config,
+        executor,
+        watcher,
+        structureHash,
+        onProgress,
+        logger,
+      );
+      break;
+    case 'builder':
+      result = await runBuilder(
+        node,
+        currentMeta,
+        phaseState,
+        config,
+        executor,
+        watcher,
+        structureHash,
+        onProgress,
+        logger,
+      );
+      break;
+    case 'critic':
+      result = await runCritic(
+        node,
+        currentMeta,
+        phaseState,
+        config,
+        executor,
+        watcher,
+        structureHash,
+        onProgress,
+        logger,
+      );
+      break;
+  }
+
+  return {
+    executed: true,
+    metaPath: node.metaPath,
+    phase,
+    phaseResult: result,
+    cycleComplete: result.cycleComplete,
+  };
+}

--- a/packages/service/src/orchestrator/orchestratePhase.ts
+++ b/packages/service/src/orchestrator/orchestratePhase.ts
@@ -21,9 +21,10 @@ import { acquireLock, releaseLock } from '../lock.js';
 import type { MinimalLogger } from '../logger/index.js';
 import { normalizePath } from '../normalizePath.js';
 import {
+  buildPhaseCandidates,
   derivePhaseState,
   getOwedPhase,
-  retryPhase,
+  retryAllFailed,
   selectPhaseCandidate,
 } from '../phaseState/index.js';
 import type { ProgressEvent } from '../progress/index.js';
@@ -42,6 +43,13 @@ import {
   runBuilder,
   runCritic,
 } from './runPhase.js';
+
+/** Phase runner dispatch map — avoids repeating the same switch/case. */
+const phaseRunners = {
+  architect: runArchitect,
+  builder: runBuilder,
+  critic: runCritic,
+} as const;
 
 /** Callback for synthesis progress events. */
 export type PhaseProgressCallback = (
@@ -101,27 +109,7 @@ export async function orchestratePhase(
   if (metaResult.entries.length === 0) return { executed: false };
 
   // Build candidates with phase state (including invalidation + auto-retry)
-  const candidates = [];
-  for (const entry of metaResult.entries) {
-    let ps = derivePhaseState(entry.meta);
-
-    // Auto-retry failed phases: failed → pending on each tick
-    // (spec §8: "retry on the next eligible tick")
-    for (const phase of ['architect', 'builder', 'critic'] as const) {
-      if (ps[phase] === 'failed') {
-        ps = retryPhase(ps, phase);
-      }
-    }
-
-    candidates.push({
-      node: entry.node,
-      meta: entry.meta,
-      phaseState: ps,
-      actualStaleness: entry.stalenessSeconds,
-      locked: entry.locked,
-      disabled: entry.disabled,
-    });
-  }
+  const candidates = buildPhaseCandidates(metaResult.entries);
 
   // Select best phase candidate
   const winner = selectPhaseCandidate(candidates, config.depthWeight);
@@ -141,14 +129,7 @@ export async function orchestratePhase(
   try {
     // Re-read meta under lock for freshness
     const currentMeta = await readMetaJson(winner.node.metaPath);
-    let phaseState = derivePhaseState(currentMeta);
-
-    // Re-apply auto-retry under lock
-    for (const phase of ['architect', 'builder', 'critic'] as const) {
-      if (phaseState[phase] === 'failed') {
-        phaseState = retryPhase(phaseState, phase);
-      }
-    }
+    const phaseState = retryAllFailed(derivePhaseState(currentMeta));
 
     const owedPhase = getOwedPhase(phaseState);
     if (!owedPhase || phaseState[owedPhase] !== 'pending') {
@@ -220,14 +201,7 @@ async function orchestrateTargeted(
 
   try {
     const currentMeta = await readMetaJson(normalizedTarget);
-    let phaseState = derivePhaseState(currentMeta);
-
-    // Auto-retry failed phases for targeted triggers too
-    for (const phase of ['architect', 'builder', 'critic'] as const) {
-      if (phaseState[phase] === 'failed') {
-        phaseState = retryPhase(phaseState, phase);
-      }
-    }
+    const phaseState = retryAllFailed(derivePhaseState(currentMeta));
 
     const owedPhase = getOwedPhase(phaseState);
     if (!owedPhase) {
@@ -271,49 +245,17 @@ async function executePhase(
   onProgress?: PhaseProgressCallback,
   logger?: MinimalLogger,
 ): Promise<OrchestratePhaseResult> {
-  let result: PhaseResult;
-
-  switch (phase) {
-    case 'architect':
-      result = await runArchitect(
-        node,
-        currentMeta,
-        phaseState,
-        config,
-        executor,
-        watcher,
-        structureHash,
-        onProgress,
-        logger,
-      );
-      break;
-    case 'builder':
-      result = await runBuilder(
-        node,
-        currentMeta,
-        phaseState,
-        config,
-        executor,
-        watcher,
-        structureHash,
-        onProgress,
-        logger,
-      );
-      break;
-    case 'critic':
-      result = await runCritic(
-        node,
-        currentMeta,
-        phaseState,
-        config,
-        executor,
-        watcher,
-        structureHash,
-        onProgress,
-        logger,
-      );
-      break;
-  }
+  const result: PhaseResult = await phaseRunners[phase](
+    node,
+    currentMeta,
+    phaseState,
+    config,
+    executor,
+    watcher,
+    structureHash,
+    onProgress,
+    logger,
+  );
 
   return {
     executed: true,

--- a/packages/service/src/orchestrator/orchestratePhase.ts
+++ b/packages/service/src/orchestrator/orchestratePhase.ts
@@ -9,9 +9,12 @@
  * @module orchestrator/orchestratePhase
  */
 
+import { copyFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
 import { buildMinimalNode } from '../discovery/buildMinimalNode.js';
 import { listMetas } from '../discovery/index.js';
-import { getScopeFiles } from '../discovery/scope.js';
+import { getScopeFiles, getScopePrefix } from '../discovery/scope.js';
 import type { MetaNode } from '../discovery/types.js';
 import type { MetaExecutor, WatcherClient } from '../interfaces/index.js';
 import { acquireLock, releaseLock } from '../lock.js';
@@ -25,6 +28,7 @@ import {
 } from '../phaseState/index.js';
 import type { ProgressEvent } from '../progress/index.js';
 import { readMetaJson } from '../readMetaJson.js';
+import { isStale } from '../scheduling/staleness.js';
 import type {
   MetaConfig,
   MetaJson,
@@ -155,6 +159,28 @@ export async function orchestratePhase(
     // Compute structure hash for the phase
     const { scopeFiles } = await getScopeFiles(winner.node, watcher);
     const structureHash = computeStructureHash(scopeFiles);
+
+    // skipUnchanged: bump _generatedAt without altering _phaseState
+    if (config.skipUnchanged && currentMeta._generatedAt) {
+      const verifiedStale = await isStale(
+        getScopePrefix(winner.node),
+        currentMeta,
+        watcher,
+      );
+      if (!verifiedStale) {
+        const freshMeta = await readMetaJson(winner.node.metaPath);
+        freshMeta._generatedAt = new Date().toISOString();
+        const lockPath = join(winner.node.metaPath, '.lock');
+        const metaJsonPath = join(winner.node.metaPath, 'meta.json');
+        await writeFile(lockPath, JSON.stringify(freshMeta, null, 2) + '\n');
+        await copyFile(lockPath, metaJsonPath);
+        logger?.debug(
+          { path: winner.node.ownerPath },
+          'Skipped unchanged meta, bumped _generatedAt',
+        );
+        return { executed: false };
+      }
+    }
 
     return await executePhase(
       winner.node,

--- a/packages/service/src/orchestrator/runPhase.ts
+++ b/packages/service/src/orchestrator/runPhase.ts
@@ -151,6 +151,16 @@ export async function runArchitect(
 
     return { executed: true, phaseState: ps, updatedMeta };
   } catch (err) {
+    // If aborted by operator, the abort route already persisted _error.
+    if (executor.aborted) {
+      ps = phaseFailed(ps, 'architect');
+      return {
+        executed: true,
+        phaseState: ps,
+        error: { step: 'architect', code: 'ABORT', message: 'Aborted by operator' },
+      };
+    }
+
     const error = toMetaError('architect', err);
     ps = phaseFailed(ps, 'architect');
 
@@ -223,6 +233,16 @@ export async function runBuilder(
 
     return { executed: true, phaseState: ps, updatedMeta };
   } catch (err) {
+    // If aborted by operator, the abort route already persisted _error.
+    if (executor.aborted) {
+      ps = phaseFailed(ps, 'builder');
+      return {
+        executed: true,
+        phaseState: ps,
+        error: { step: 'builder', code: 'ABORT', message: 'Aborted by operator' },
+      };
+    }
+
     const error = toMetaError('builder', err);
     ps = phaseFailed(ps, 'builder');
 
@@ -332,6 +352,16 @@ export async function runCritic(
       cycleComplete,
     };
   } catch (err) {
+    // If aborted by operator, the abort route already persisted _error.
+    if (executor.aborted) {
+      ps = phaseFailed(ps, 'critic');
+      return {
+        executed: true,
+        phaseState: ps,
+        error: { step: 'critic', code: 'ABORT', message: 'Aborted by operator' },
+      };
+    }
+
     const error = toMetaError('critic', err);
     ps = phaseFailed(ps, 'critic');
 

--- a/packages/service/src/orchestrator/runPhase.ts
+++ b/packages/service/src/orchestrator/runPhase.ts
@@ -61,7 +61,7 @@ export interface PhaseResult {
 }
 
 /** Shared base options for all finalize calls. */
-interface FinalizeBase {
+export interface FinalizeBase {
   metaPath: string;
   current: MetaJson;
   config: MetaConfig;
@@ -69,7 +69,7 @@ interface FinalizeBase {
 }
 
 /** Write updated meta with phase state via lock staging. */
-async function persistPhaseState(
+export async function persistPhaseState(
   base: FinalizeBase,
   phaseState: PhaseState,
   updates: Partial<MetaJson>,

--- a/packages/service/src/orchestrator/runPhase.ts
+++ b/packages/service/src/orchestrator/runPhase.ts
@@ -7,7 +7,7 @@
  * @module orchestrator/runPhase
  */
 
-import { copyFile, writeFile } from 'node:fs/promises';
+import { copyFile, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { createSnapshot, pruneArchive } from '../archive/index.js';
@@ -42,7 +42,6 @@ import {
   parseBuilderOutput,
   parseCriticOutput,
 } from './parseOutput.js';
-import { attemptTimeoutRecovery } from './timeoutRecovery.js';
 
 /** Callback for synthesis progress events. */
 export type ProgressCallback = (event: ProgressEvent) => void | Promise<void>;
@@ -201,8 +200,6 @@ export async function runBuilder(
     // Builder success: builder → fresh, critic → pending
     ps = builderSuccess(ps);
 
-    const synthesisCount = (currentMeta._synthesisCount ?? 0) + 1;
-
     const updatedMeta = await persistPhaseState(
       { metaPath: node.metaPath, current: currentMeta, config, structureHash },
       ps,
@@ -210,7 +207,6 @@ export async function runBuilder(
         _content: builderOutput.content,
         _state: builderOutput.state,
         _builderTokens: builderTokens,
-        _synthesisCount: synthesisCount,
         _generatedAt: new Date().toISOString(),
         _error: undefined,
         ...builderOutput.fields,
@@ -227,45 +223,30 @@ export async function runBuilder(
 
     return { executed: true, phaseState: ps, updatedMeta };
   } catch (err) {
-    // §4.6 partial _state recovery on timeout
-    if (err instanceof SpawnTimeoutError) {
-      const recovered = await attemptTimeoutRecovery({
-        err,
-        currentMeta,
-        metaPath: node.metaPath,
-        config,
-        builderBrief: currentMeta._builder ?? '',
-        structureHash,
-        synthesisCount: (currentMeta._synthesisCount ?? 0) + 1,
-      });
-      if (recovered) {
-        // Even with recovery, builder still failed from phase-state perspective
-        ps = phaseFailed(ps, 'builder');
-        await persistPhaseState(
-          {
-            metaPath: node.metaPath,
-            current: currentMeta,
-            config,
-            structureHash,
-          },
-          ps,
-          { _error: toMetaError('builder', err) },
-        );
-        return {
-          executed: true,
-          phaseState: ps,
-          error: toMetaError('builder', err),
-        };
-      }
-    }
-
     const error = toMetaError('builder', err);
     ps = phaseFailed(ps, 'builder');
+
+    // §4.6 partial _state recovery on timeout
+    const stateUpdates: Partial<MetaJson> = { _error: error };
+    if (err instanceof SpawnTimeoutError) {
+      try {
+        const raw = await readFile(err.outputPath, 'utf8');
+        const partial = parseBuilderOutput(raw);
+        if (
+          partial.state !== undefined &&
+          JSON.stringify(partial.state) !== JSON.stringify(currentMeta._state)
+        ) {
+          stateUpdates._state = partial.state;
+        }
+      } catch {
+        // Could not read partial output — no state recovery
+      }
+    }
 
     await persistPhaseState(
       { metaPath: node.metaPath, current: currentMeta, config, structureHash },
       ps,
-      { _error: error },
+      stateUpdates,
     );
 
     return { executed: true, phaseState: ps, error };
@@ -318,25 +299,9 @@ export async function runCritic(
       _error: undefined,
     };
 
-    // Full-cycle completion: increment _synthesisCount, archive, emit
+    // Full-cycle completion: increment _synthesisCount, archive, emit.
+    // Per spec: architect resets to 0, full-cycle increments on top.
     if (cycleComplete) {
-      // _synthesisCount was already set during builder phase; this is the
-      // closing increment per spec. But per spec, _synthesisCount tracks
-      // cycles since last architect refresh. Architect resets to 0 on success,
-      // and the full-cycle completion increments it.
-      // Actually, _synthesisCount was already incremented during builder.
-      // The full-cycle completion archives but does NOT increment again —
-      // the builder already did that. Spec says: "Increment of _synthesisCount"
-      // on full cycle. Let's re-read the spec...
-      // Spec: "_synthesisCount tracks full cycles completed since the last
-      // architect refresh. Full-cycle completion increments it; successful
-      // architect completion resets it to 0."
-      // And: "within a single cycle, a successful architect zeroes the counter
-      // first, and the cycle's closing increment lands on top of that zero."
-      // So the increment happens at full-cycle, not at builder phase.
-      // BUT the existing code increments at builder (synthesisCount++).
-      // We need to match the spec: increment at cycle completion.
-      // Since in the new model, builder doesn't increment, we do it here.
       updates._synthesisCount = (currentMeta._synthesisCount ?? 0) + 1;
     }
 

--- a/packages/service/src/orchestrator/runPhase.ts
+++ b/packages/service/src/orchestrator/runPhase.ts
@@ -92,6 +92,40 @@ async function persistPhaseState(
   return merged;
 }
 
+/**
+ * Handle phase failure (abort or error).
+ *
+ * Shared error path for all three phase executors. When the executor was
+ * aborted, returns immediately without persisting (abort route handles it).
+ * Otherwise, transitions the phase to failed and persists the error.
+ */
+async function handlePhaseFailure(
+  phase: 'architect' | 'builder' | 'critic',
+  err: unknown,
+  executor: MetaExecutor,
+  ps: PhaseState,
+  base: FinalizeBase,
+  additionalUpdates?: Partial<MetaJson>,
+): Promise<PhaseResult> {
+  if (executor.aborted) {
+    return {
+      executed: true,
+      phaseState: phaseFailed(ps, phase),
+      error: { step: phase, code: 'ABORT', message: 'Aborted by operator' },
+    };
+  }
+
+  const error = toMetaError(phase, err);
+  const failedPs = phaseFailed(ps, phase);
+
+  await persistPhaseState(base, failedPs, {
+    _error: error,
+    ...additionalUpdates,
+  });
+
+  return { executed: true, phaseState: failedPs, error };
+}
+
 // ── Architect executor ─────────────────────────────────────────────────
 
 export async function runArchitect(
@@ -151,26 +185,12 @@ export async function runArchitect(
 
     return { executed: true, phaseState: ps, updatedMeta };
   } catch (err) {
-    // If aborted by operator, the abort route already persisted _error.
-    if (executor.aborted) {
-      ps = phaseFailed(ps, 'architect');
-      return {
-        executed: true,
-        phaseState: ps,
-        error: { step: 'architect', code: 'ABORT', message: 'Aborted by operator' },
-      };
-    }
-
-    const error = toMetaError('architect', err);
-    ps = phaseFailed(ps, 'architect');
-
-    await persistPhaseState(
-      { metaPath: node.metaPath, current: currentMeta, config, structureHash },
-      ps,
-      { _error: error },
-    );
-
-    return { executed: true, phaseState: ps, error };
+    return handlePhaseFailure('architect', err, executor, ps, {
+      metaPath: node.metaPath,
+      current: currentMeta,
+      config,
+      structureHash,
+    });
   }
 }
 
@@ -233,21 +253,8 @@ export async function runBuilder(
 
     return { executed: true, phaseState: ps, updatedMeta };
   } catch (err) {
-    // If aborted by operator, the abort route already persisted _error.
-    if (executor.aborted) {
-      ps = phaseFailed(ps, 'builder');
-      return {
-        executed: true,
-        phaseState: ps,
-        error: { step: 'builder', code: 'ABORT', message: 'Aborted by operator' },
-      };
-    }
-
-    const error = toMetaError('builder', err);
-    ps = phaseFailed(ps, 'builder');
-
     // §4.6 partial _state recovery on timeout
-    const stateUpdates: Partial<MetaJson> = { _error: error };
+    let partialState: Partial<MetaJson> | undefined;
     if (err instanceof SpawnTimeoutError) {
       try {
         const raw = await readFile(err.outputPath, 'utf8');
@@ -256,20 +263,19 @@ export async function runBuilder(
           partial.state !== undefined &&
           JSON.stringify(partial.state) !== JSON.stringify(currentMeta._state)
         ) {
-          stateUpdates._state = partial.state;
+          partialState = { _state: partial.state };
         }
       } catch {
         // Could not read partial output — no state recovery
       }
     }
 
-    await persistPhaseState(
-      { metaPath: node.metaPath, current: currentMeta, config, structureHash },
-      ps,
-      stateUpdates,
-    );
-
-    return { executed: true, phaseState: ps, error };
+    return handlePhaseFailure('builder', err, executor, ps, {
+      metaPath: node.metaPath,
+      current: currentMeta,
+      config,
+      structureHash,
+    }, partialState);
   }
 }
 
@@ -352,25 +358,11 @@ export async function runCritic(
       cycleComplete,
     };
   } catch (err) {
-    // If aborted by operator, the abort route already persisted _error.
-    if (executor.aborted) {
-      ps = phaseFailed(ps, 'critic');
-      return {
-        executed: true,
-        phaseState: ps,
-        error: { step: 'critic', code: 'ABORT', message: 'Aborted by operator' },
-      };
-    }
-
-    const error = toMetaError('critic', err);
-    ps = phaseFailed(ps, 'critic');
-
-    await persistPhaseState(
-      { metaPath: node.metaPath, current: currentMeta, config, structureHash },
-      ps,
-      { _error: error },
-    );
-
-    return { executed: true, phaseState: ps, error };
+    return handlePhaseFailure('critic', err, executor, ps, {
+      metaPath: node.metaPath,
+      current: currentMeta,
+      config,
+      structureHash,
+    });
   }
 }

--- a/packages/service/src/orchestrator/runPhase.ts
+++ b/packages/service/src/orchestrator/runPhase.ts
@@ -1,0 +1,381 @@
+/**
+ * Per-phase executors for the phase-state machine.
+ *
+ * Each function runs exactly one phase on one meta, updates _phaseState
+ * via pure transitions, and persists via the lock-staged write.
+ *
+ * @module orchestrator/runPhase
+ */
+
+import { copyFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { createSnapshot, pruneArchive } from '../archive/index.js';
+import type { MetaNode } from '../discovery/index.js';
+import { toMetaError } from '../errors.js';
+import { SpawnTimeoutError } from '../executor/index.js';
+import type { MetaExecutor, WatcherClient } from '../interfaces/index.js';
+import type { MinimalLogger } from '../logger/index.js';
+import {
+  architectSuccess,
+  builderSuccess,
+  criticSuccess,
+  isFullyFresh,
+  phaseFailed,
+  phaseRunning,
+} from '../phaseState/index.js';
+import type { ProgressEvent } from '../progress/index.js';
+import type {
+  MetaConfig,
+  MetaError,
+  MetaJson,
+  PhaseState,
+} from '../schema/index.js';
+import {
+  buildArchitectTask,
+  buildBuilderTask,
+  buildCriticTask,
+} from './buildTask.js';
+import { buildContextPackage } from './contextPackage.js';
+import {
+  parseArchitectOutput,
+  parseBuilderOutput,
+  parseCriticOutput,
+} from './parseOutput.js';
+import { attemptTimeoutRecovery } from './timeoutRecovery.js';
+
+/** Callback for synthesis progress events. */
+export type ProgressCallback = (event: ProgressEvent) => void | Promise<void>;
+
+/** Result of running a single phase. */
+export interface PhaseResult {
+  /** Whether the phase executed (vs. was skipped). */
+  executed: boolean;
+  /** Updated phase state after execution. */
+  phaseState: PhaseState;
+  /** Updated meta.json content (if written). */
+  updatedMeta?: MetaJson;
+  /** Error if the phase failed. */
+  error?: MetaError;
+  /** Whether the full cycle is now complete (all phases fresh). */
+  cycleComplete?: boolean;
+}
+
+/** Shared base options for all finalize calls. */
+interface FinalizeBase {
+  metaPath: string;
+  current: MetaJson;
+  config: MetaConfig;
+  structureHash: string;
+}
+
+/** Write updated meta with phase state via lock staging. */
+async function persistPhaseState(
+  base: FinalizeBase,
+  phaseState: PhaseState,
+  updates: Partial<MetaJson>,
+): Promise<MetaJson> {
+  const lockPath = join(base.metaPath, '.lock');
+  const metaJsonPath = join(base.metaPath, 'meta.json');
+
+  const merged: MetaJson = {
+    ...base.current,
+    ...updates,
+    _phaseState: phaseState,
+    _structureHash: base.structureHash,
+  };
+
+  // Clean undefined
+  if (merged._error === undefined) delete merged._error;
+
+  await writeFile(lockPath, JSON.stringify(merged, null, 2) + '\n');
+  await copyFile(lockPath, metaJsonPath);
+  return merged;
+}
+
+// ── Architect executor ─────────────────────────────────────────────────
+
+export async function runArchitect(
+  node: MetaNode,
+  currentMeta: MetaJson,
+  phaseState: PhaseState,
+  config: MetaConfig,
+  executor: MetaExecutor,
+  watcher: WatcherClient,
+  structureHash: string,
+  onProgress?: ProgressCallback,
+  logger?: MinimalLogger,
+): Promise<PhaseResult> {
+  let ps = phaseRunning(phaseState, 'architect');
+
+  const ctx = await buildContextPackage(node, currentMeta, watcher, logger);
+
+  try {
+    await onProgress?.({
+      type: 'phase_start',
+      path: node.ownerPath,
+      phase: 'architect',
+    });
+    const phaseStart = Date.now();
+    const architectTask = buildArchitectTask(ctx, currentMeta, config);
+    const result = await executor.spawn(architectTask, {
+      thinking: config.thinking,
+      timeout: config.architectTimeout,
+      label: 'meta-architect',
+    });
+    const builderBrief = parseArchitectOutput(result.output);
+    const architectTokens = result.tokens;
+
+    // Architect success: architect → fresh, _synthesisCount → 0
+    ps = architectSuccess(ps);
+
+    const updatedMeta = await persistPhaseState(
+      { metaPath: node.metaPath, current: currentMeta, config, structureHash },
+      ps,
+      {
+        _builder: builderBrief,
+        _architect: currentMeta._architect ?? config.defaultArchitect ?? '',
+        _synthesisCount: 0,
+        _architectTokens: architectTokens,
+        _generatedAt: new Date().toISOString(),
+        _error: undefined,
+      },
+    );
+
+    await onProgress?.({
+      type: 'phase_complete',
+      path: node.ownerPath,
+      phase: 'architect',
+      tokens: architectTokens,
+      durationMs: Date.now() - phaseStart,
+    });
+
+    return { executed: true, phaseState: ps, updatedMeta };
+  } catch (err) {
+    const error = toMetaError('architect', err);
+    ps = phaseFailed(ps, 'architect');
+
+    await persistPhaseState(
+      { metaPath: node.metaPath, current: currentMeta, config, structureHash },
+      ps,
+      { _error: error },
+    );
+
+    return { executed: true, phaseState: ps, error };
+  }
+}
+
+// ── Builder executor ───────────────────────────────────────────────────
+
+export async function runBuilder(
+  node: MetaNode,
+  currentMeta: MetaJson,
+  phaseState: PhaseState,
+  config: MetaConfig,
+  executor: MetaExecutor,
+  watcher: WatcherClient,
+  structureHash: string,
+  onProgress?: ProgressCallback,
+  logger?: MinimalLogger,
+): Promise<PhaseResult> {
+  let ps = phaseRunning(phaseState, 'builder');
+
+  const ctx = await buildContextPackage(node, currentMeta, watcher, logger);
+
+  try {
+    await onProgress?.({
+      type: 'phase_start',
+      path: node.ownerPath,
+      phase: 'builder',
+    });
+    const builderStart = Date.now();
+    const builderTask = buildBuilderTask(ctx, currentMeta, config);
+    const result = await executor.spawn(builderTask, {
+      thinking: config.thinking,
+      timeout: config.builderTimeout,
+      label: 'meta-builder',
+    });
+    const builderOutput = parseBuilderOutput(result.output);
+    const builderTokens = result.tokens;
+
+    // Builder success: builder → fresh, critic → pending
+    ps = builderSuccess(ps);
+
+    const synthesisCount = (currentMeta._synthesisCount ?? 0) + 1;
+
+    const updatedMeta = await persistPhaseState(
+      { metaPath: node.metaPath, current: currentMeta, config, structureHash },
+      ps,
+      {
+        _content: builderOutput.content,
+        _state: builderOutput.state,
+        _builderTokens: builderTokens,
+        _synthesisCount: synthesisCount,
+        _generatedAt: new Date().toISOString(),
+        _error: undefined,
+        ...builderOutput.fields,
+      },
+    );
+
+    await onProgress?.({
+      type: 'phase_complete',
+      path: node.ownerPath,
+      phase: 'builder',
+      tokens: builderTokens,
+      durationMs: Date.now() - builderStart,
+    });
+
+    return { executed: true, phaseState: ps, updatedMeta };
+  } catch (err) {
+    // §4.6 partial _state recovery on timeout
+    if (err instanceof SpawnTimeoutError) {
+      const recovered = await attemptTimeoutRecovery({
+        err,
+        currentMeta,
+        metaPath: node.metaPath,
+        config,
+        builderBrief: currentMeta._builder ?? '',
+        structureHash,
+        synthesisCount: (currentMeta._synthesisCount ?? 0) + 1,
+      });
+      if (recovered) {
+        // Even with recovery, builder still failed from phase-state perspective
+        ps = phaseFailed(ps, 'builder');
+        await persistPhaseState(
+          {
+            metaPath: node.metaPath,
+            current: currentMeta,
+            config,
+            structureHash,
+          },
+          ps,
+          { _error: toMetaError('builder', err) },
+        );
+        return {
+          executed: true,
+          phaseState: ps,
+          error: toMetaError('builder', err),
+        };
+      }
+    }
+
+    const error = toMetaError('builder', err);
+    ps = phaseFailed(ps, 'builder');
+
+    await persistPhaseState(
+      { metaPath: node.metaPath, current: currentMeta, config, structureHash },
+      ps,
+      { _error: error },
+    );
+
+    return { executed: true, phaseState: ps, error };
+  }
+}
+
+// ── Critic executor ────────────────────────────────────────────────────
+
+export async function runCritic(
+  node: MetaNode,
+  currentMeta: MetaJson,
+  phaseState: PhaseState,
+  config: MetaConfig,
+  executor: MetaExecutor,
+  watcher: WatcherClient,
+  structureHash: string,
+  onProgress?: ProgressCallback,
+  logger?: MinimalLogger,
+): Promise<PhaseResult> {
+  let ps = phaseRunning(phaseState, 'critic');
+
+  const ctx = await buildContextPackage(node, currentMeta, watcher, logger);
+
+  // Build critic task using current meta's _content
+  const metaForCritic: MetaJson = { ...currentMeta };
+
+  try {
+    await onProgress?.({
+      type: 'phase_start',
+      path: node.ownerPath,
+      phase: 'critic',
+    });
+    const criticStart = Date.now();
+    const criticTask = buildCriticTask(ctx, metaForCritic, config);
+    const result = await executor.spawn(criticTask, {
+      thinking: config.thinking,
+      timeout: config.criticTimeout,
+      label: 'meta-critic',
+    });
+    const feedback = parseCriticOutput(result.output);
+    const criticTokens = result.tokens;
+
+    // Critic success: critic → fresh
+    ps = criticSuccess(ps);
+    const cycleComplete = isFullyFresh(ps);
+
+    const updates: Partial<MetaJson> = {
+      _feedback: feedback,
+      _criticTokens: criticTokens,
+      _error: undefined,
+    };
+
+    // Full-cycle completion: increment _synthesisCount, archive, emit
+    if (cycleComplete) {
+      // _synthesisCount was already set during builder phase; this is the
+      // closing increment per spec. But per spec, _synthesisCount tracks
+      // cycles since last architect refresh. Architect resets to 0 on success,
+      // and the full-cycle completion increments it.
+      // Actually, _synthesisCount was already incremented during builder.
+      // The full-cycle completion archives but does NOT increment again —
+      // the builder already did that. Spec says: "Increment of _synthesisCount"
+      // on full cycle. Let's re-read the spec...
+      // Spec: "_synthesisCount tracks full cycles completed since the last
+      // architect refresh. Full-cycle completion increments it; successful
+      // architect completion resets it to 0."
+      // And: "within a single cycle, a successful architect zeroes the counter
+      // first, and the cycle's closing increment lands on top of that zero."
+      // So the increment happens at full-cycle, not at builder phase.
+      // BUT the existing code increments at builder (synthesisCount++).
+      // We need to match the spec: increment at cycle completion.
+      // Since in the new model, builder doesn't increment, we do it here.
+      updates._synthesisCount = (currentMeta._synthesisCount ?? 0) + 1;
+    }
+
+    const updatedMeta = await persistPhaseState(
+      { metaPath: node.metaPath, current: currentMeta, config, structureHash },
+      ps,
+      updates,
+    );
+
+    // Archive on full-cycle only
+    if (cycleComplete) {
+      await createSnapshot(node.metaPath, updatedMeta);
+      await pruneArchive(node.metaPath, config.maxArchive);
+    }
+
+    await onProgress?.({
+      type: 'phase_complete',
+      path: node.ownerPath,
+      phase: 'critic',
+      tokens: criticTokens,
+      durationMs: Date.now() - criticStart,
+    });
+
+    return {
+      executed: true,
+      phaseState: ps,
+      updatedMeta,
+      cycleComplete,
+    };
+  } catch (err) {
+    const error = toMetaError('critic', err);
+    ps = phaseFailed(ps, 'critic');
+
+    await persistPhaseState(
+      { metaPath: node.metaPath, current: currentMeta, config, structureHash },
+      ps,
+      { _error: error },
+    );
+
+    return { executed: true, phaseState: ps, error };
+  }
+}

--- a/packages/service/src/orchestrator/runPhase.ts
+++ b/packages/service/src/orchestrator/runPhase.ts
@@ -270,12 +270,19 @@ export async function runBuilder(
       }
     }
 
-    return handlePhaseFailure('builder', err, executor, ps, {
-      metaPath: node.metaPath,
-      current: currentMeta,
-      config,
-      structureHash,
-    }, partialState);
+    return handlePhaseFailure(
+      'builder',
+      err,
+      executor,
+      ps,
+      {
+        metaPath: node.metaPath,
+        current: currentMeta,
+        config,
+        structureHash,
+      },
+      partialState,
+    );
   }
 }
 

--- a/packages/service/src/phaseState/derivePhaseState.test.ts
+++ b/packages/service/src/phaseState/derivePhaseState.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MetaJson } from '../schema/meta.js';
+import { derivePhaseState } from './derivePhaseState.js';
+
+describe('derivePhaseState', () => {
+  it('returns existing _phaseState when present', () => {
+    const meta: MetaJson = {
+      _phaseState: { architect: 'fresh', builder: 'pending', critic: 'stale' },
+    };
+    expect(derivePhaseState(meta)).toEqual({
+      architect: 'fresh',
+      builder: 'pending',
+      critic: 'stale',
+    });
+  });
+
+  it('never-synthesized meta (empty): architect pending', () => {
+    const meta: MetaJson = {};
+    const result = derivePhaseState(meta);
+    expect(result).toEqual({
+      architect: 'pending',
+      builder: 'stale',
+      critic: 'stale',
+    });
+  });
+
+  it('fully fresh meta: all fresh', () => {
+    const meta: MetaJson = {
+      _builder: 'brief',
+      _content: 'output',
+      _feedback: 'good',
+      _generatedAt: new Date().toISOString(),
+    };
+    const result = derivePhaseState(meta);
+    expect(result).toEqual({
+      architect: 'fresh',
+      builder: 'fresh',
+      critic: 'fresh',
+    });
+  });
+
+  it('errored at architect with no cached builder', () => {
+    const meta: MetaJson = {
+      _error: { step: 'architect', code: 'TIMEOUT', message: 'Timed out' },
+    };
+    const result = derivePhaseState(meta);
+    expect(result.architect).toBe('failed');
+    expect(result.builder).toBe('stale');
+    expect(result.critic).toBe('stale');
+  });
+
+  it('errored at builder', () => {
+    const meta: MetaJson = {
+      _builder: 'brief',
+      _content: 'old content',
+      _error: { step: 'builder', code: 'ERROR', message: 'Failed' },
+    };
+    const result = derivePhaseState(meta);
+    expect(result.builder).toBe('failed');
+    expect(result.critic).toBe('stale');
+    expect(result.architect).toBe('fresh');
+  });
+
+  it('errored at critic', () => {
+    const meta: MetaJson = {
+      _builder: 'brief',
+      _content: 'content',
+      _error: { step: 'critic', code: 'ERROR', message: 'Failed' },
+    };
+    const result = derivePhaseState(meta);
+    expect(result.critic).toBe('failed');
+    expect(result.architect).toBe('fresh');
+    expect(result.builder).toBe('fresh');
+  });
+
+  it('mid-cycle: has _builder but no _content → builder pending', () => {
+    const meta: MetaJson = {
+      _builder: 'some brief',
+      _generatedAt: new Date().toISOString(),
+    };
+    const result = derivePhaseState(meta);
+    expect(result).toEqual({
+      architect: 'fresh',
+      builder: 'pending',
+      critic: 'stale',
+    });
+  });
+
+  it('has content but no feedback → critic pending', () => {
+    const meta: MetaJson = {
+      _builder: 'brief',
+      _content: 'content',
+      _generatedAt: new Date().toISOString(),
+    };
+    const result = derivePhaseState(meta);
+    expect(result).toEqual({
+      architect: 'fresh',
+      builder: 'fresh',
+      critic: 'pending',
+    });
+  });
+
+  it('architect invalidated via inputs: structure changed', () => {
+    const meta: MetaJson = {
+      _builder: 'brief',
+      _content: 'content',
+      _feedback: 'ok',
+      _generatedAt: new Date().toISOString(),
+    };
+    const result = derivePhaseState(meta, {
+      structureChanged: true,
+      steerChanged: false,
+      architectChanged: false,
+      crossRefsChanged: false,
+      architectEvery: 10,
+    });
+    expect(result).toEqual({
+      architect: 'pending',
+      builder: 'stale',
+      critic: 'stale',
+    });
+  });
+
+  it('architect invalidated via inputs: synthesisCount >= architectEvery', () => {
+    const meta: MetaJson = {
+      _builder: 'brief',
+      _content: 'content',
+      _feedback: 'ok',
+      _generatedAt: new Date().toISOString(),
+      _synthesisCount: 10,
+    };
+    const result = derivePhaseState(meta, {
+      structureChanged: false,
+      steerChanged: false,
+      architectChanged: false,
+      crossRefsChanged: false,
+      architectEvery: 10,
+    });
+    expect(result.architect).toBe('pending');
+  });
+});

--- a/packages/service/src/phaseState/derivePhaseState.test.ts
+++ b/packages/service/src/phaseState/derivePhaseState.test.ts
@@ -40,6 +40,18 @@ describe('derivePhaseState', () => {
     });
   });
 
+  it('errored at architect with cached builder preserves fresh downstream', () => {
+    const meta: MetaJson = {
+      _builder: 'cached brief',
+      _content: 'old content',
+      _error: { step: 'architect', code: 'TIMEOUT', message: 'Timed out' },
+    };
+    const result = derivePhaseState(meta);
+    expect(result.architect).toBe('failed');
+    expect(result.builder).toBe('fresh');
+    expect(result.critic).toBe('fresh');
+  });
+
   it('errored at architect with no cached builder', () => {
     const meta: MetaJson = {
       _error: { step: 'architect', code: 'TIMEOUT', message: 'Timed out' },

--- a/packages/service/src/phaseState/derivePhaseState.ts
+++ b/packages/service/src/phaseState/derivePhaseState.ts
@@ -1,0 +1,116 @@
+/**
+ * Backward-compatible derivation of _phaseState from existing meta fields.
+ *
+ * When a meta is loaded from disk without _phaseState, this reconstructs
+ * the phase state from _content, _builder, _state, _error.step, and
+ * the architect-invalidating inputs.
+ *
+ * @module phaseState/derivePhaseState
+ */
+
+import type { MetaJson, PhaseState } from '../schema/index.js';
+import { freshPhaseState, initialPhaseState } from './phaseTransitions.js';
+
+/** Inputs needed to determine architect invalidation for derivation. */
+export interface DerivationInputs {
+  /** Whether _structureHash has changed vs. computed value. */
+  structureChanged: boolean;
+  /** Whether _steer changed vs. latest archive. */
+  steerChanged: boolean;
+  /** Whether _architect prompt changed. */
+  architectChanged: boolean;
+  /** Whether _crossRefs declaration changed. */
+  crossRefsChanged: boolean;
+  /** architectEvery config value. */
+  architectEvery: number;
+}
+
+/**
+ * Derive _phaseState from existing meta fields.
+ *
+ * If the meta already has _phaseState, returns it as-is.
+ *
+ * Otherwise, reconstructs from available fields:
+ * - Never-synthesized meta (no _content, no _builder): all phases start pending/stale.
+ * - Errored meta: the failed phase is mapped from _error.step.
+ * - Mid-cycle meta with cached _builder but no _content: builder pending.
+ * - Fully-fresh meta: all phases fresh.
+ * - Meta with stale architect inputs: architect pending, downstream stale.
+ *
+ * @param meta - The meta.json content.
+ * @param inputs - Optional derivation inputs. If not provided, a simpler
+ *   heuristic is used (no architect invalidation check).
+ * @returns The derived PhaseState.
+ */
+export function derivePhaseState(
+  meta: MetaJson,
+  inputs?: DerivationInputs,
+): PhaseState {
+  // Already has _phaseState — use it
+  if (meta._phaseState) return meta._phaseState;
+
+  // Check for errors first — _error.step maps directly to failed phase
+  if (meta._error) {
+    const failedPhase = meta._error.step;
+    const state = freshPhaseState();
+    state[failedPhase] = 'failed';
+
+    // If architect failed and no _builder, downstream is stale
+    if (failedPhase === 'architect') {
+      if (!meta._builder) {
+        state.builder = 'stale';
+        state.critic = 'stale';
+      }
+    }
+    // If builder failed, critic is stale
+    if (failedPhase === 'builder') {
+      state.critic = 'stale';
+    }
+
+    return state;
+  }
+
+  // Never synthesized: no _content AND no _builder (and no error)
+  if (!meta._content && !meta._builder) {
+    return initialPhaseState();
+  }
+
+  // Check architect invalidation (when inputs are provided)
+  if (inputs) {
+    const architectInvalidated =
+      inputs.structureChanged ||
+      inputs.steerChanged ||
+      inputs.architectChanged ||
+      inputs.crossRefsChanged ||
+      (meta._synthesisCount ?? 0) >= inputs.architectEvery;
+
+    if (architectInvalidated) {
+      return {
+        architect: 'pending',
+        builder: 'stale',
+        critic: 'stale',
+      };
+    }
+  }
+
+  // Has _builder but no _content: builder is pending
+  if (meta._builder && !meta._content) {
+    return {
+      architect: 'fresh',
+      builder: 'pending',
+      critic: 'stale',
+    };
+  }
+
+  // Has _content but no _feedback: critic is pending
+  if (meta._content && !meta._feedback) {
+    return {
+      architect: 'fresh',
+      builder: 'fresh',
+      critic: 'pending',
+    };
+  }
+
+  // Default: fully fresh
+  return freshPhaseState();
+}

--- a/packages/service/src/phaseState/index.ts
+++ b/packages/service/src/phaseState/index.ts
@@ -11,7 +11,13 @@ export {
   type InvalidationResult,
   type StalenessInputs,
 } from './invalidate.js';
-export { type PhaseCandidate, selectPhaseCandidate } from './phaseScheduler.js';
+export {
+  buildPhaseCandidates,
+  type PhaseCandidate,
+  type PhaseCandidateInput,
+  rankPhaseCandidates,
+  selectPhaseCandidate,
+} from './phaseScheduler.js';
 export {
   architectSuccess,
   builderSuccess,
@@ -26,5 +32,6 @@ export {
   isFullyFresh,
   phaseFailed,
   phaseRunning,
+  retryAllFailed,
   retryPhase,
 } from './phaseTransitions.js';

--- a/packages/service/src/phaseState/index.ts
+++ b/packages/service/src/phaseState/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Phase-state machine module.
+ *
+ * @module phaseState
+ */
+
+export { type DerivationInputs, derivePhaseState } from './derivePhaseState.js';
+export {
+  type ArchitectInvalidator,
+  computeInvalidation,
+  type InvalidationResult,
+  type StalenessInputs,
+} from './invalidate.js';
+export { type PhaseCandidate, selectPhaseCandidate } from './phaseScheduler.js';
+export {
+  architectSuccess,
+  builderSuccess,
+  criticSuccess,
+  enforceInvariant,
+  freshPhaseState,
+  getOwedPhase,
+  getPriorityBand,
+  initialPhaseState,
+  invalidateArchitect,
+  invalidateBuilder,
+  isFullyFresh,
+  phaseFailed,
+  phaseRunning,
+  retryPhase,
+} from './phaseTransitions.js';

--- a/packages/service/src/phaseState/invalidate.ts
+++ b/packages/service/src/phaseState/invalidate.ts
@@ -1,0 +1,154 @@
+/**
+ * Per-tick invalidation pass.
+ *
+ * Computes architect-invalidating and builder-invalidating inputs for a meta,
+ * then applies the cascade to update _phaseState.
+ *
+ * @module phaseState/invalidate
+ */
+
+import { readLatestArchive } from '../archive/index.js';
+import type { MetaNode } from '../discovery/types.js';
+import { hasSteerChanged } from '../scheduling/staleness.js';
+import type { MetaConfig, MetaJson, PhaseState } from '../schema/index.js';
+import { computeStructureHash } from '../structureHash.js';
+import { invalidateArchitect, invalidateBuilder } from './phaseTransitions.js';
+
+/** Architect-level invalidation reasons. */
+export type ArchitectInvalidator =
+  | 'structureHash'
+  | 'steer'
+  | '_architect'
+  | '_crossRefs'
+  | 'architectEvery';
+
+/** Staleness inputs for a meta (exposed in /preview). */
+export interface StalenessInputs {
+  structureHash: string;
+  steerChanged: boolean;
+  architectChanged: boolean;
+  crossRefsDeclChanged: boolean;
+  scopeMtimeMax: string | null;
+  crossRefContentChanged: boolean;
+}
+
+/** Result of computing invalidation for a single meta. */
+export interface InvalidationResult {
+  phaseState: PhaseState;
+  architectInvalidators: ArchitectInvalidator[];
+  stalenessInputs: StalenessInputs;
+  structureHash: string;
+  steerChanged: boolean;
+}
+
+/**
+ * Compute invalidation inputs and apply cascade for a single meta.
+ *
+ * @param meta - Current meta.json content with existing _phaseState.
+ * @param scopeFiles - Sorted file list from scope.
+ * @param config - MetaConfig for architectEvery.
+ * @param node - MetaNode for archive access.
+ * @param crossRefMetas - Map of cross-ref owner paths to their current _content.
+ * @param archiveCrossRefContent - Map of cross-ref owner paths to their archived _content.
+ * @returns Updated phase state and invalidation details.
+ */
+export async function computeInvalidation(
+  meta: MetaJson,
+  scopeFiles: string[],
+  config: MetaConfig,
+  node: MetaNode,
+  crossRefMetas?: Map<string, string | undefined>,
+  archiveCrossRefContent?: Map<string, string | undefined>,
+): Promise<InvalidationResult> {
+  let phaseState = meta._phaseState ?? {
+    architect: 'fresh',
+    builder: 'fresh',
+    critic: 'fresh',
+  };
+
+  // ── Architect-level inputs ──
+  const structureHash = computeStructureHash(scopeFiles);
+  const structureChanged = structureHash !== meta._structureHash;
+
+  const latestArchive = await readLatestArchive(node.metaPath);
+  const steerChanged = hasSteerChanged(
+    meta._steer,
+    latestArchive?._steer,
+    Boolean(latestArchive),
+  );
+
+  // _architect change: compare current vs. archive
+  const architectChanged = latestArchive
+    ? (meta._architect ?? '') !== (latestArchive._architect ?? '')
+    : Boolean(meta._architect);
+
+  // _crossRefs declaration change
+  const currentRefs = (meta._crossRefs ?? []).slice().sort().join(',');
+  const archiveRefs = (latestArchive?._crossRefs ?? [])
+    .slice()
+    .sort()
+    .join(',');
+  const crossRefsDeclChanged = latestArchive
+    ? currentRefs !== archiveRefs
+    : currentRefs.length > 0;
+
+  const architectInvalidators: ArchitectInvalidator[] = [];
+  if (structureChanged) architectInvalidators.push('structureHash');
+  if (steerChanged) architectInvalidators.push('steer');
+  if (architectChanged) architectInvalidators.push('_architect');
+  if (crossRefsDeclChanged) architectInvalidators.push('_crossRefs');
+  if ((meta._synthesisCount ?? 0) >= config.architectEvery) {
+    architectInvalidators.push('architectEvery');
+  }
+
+  // First-run check: no _builder means architect must run
+  const firstRun = !meta._builder;
+
+  if (architectInvalidators.length > 0 || firstRun) {
+    phaseState = invalidateArchitect(phaseState);
+  }
+
+  // ── Builder-level inputs ──
+  // Scope file mtime check — if any file newer than _generatedAt
+  const scopeMtimeMax: string | null = null;
+  // Note: actual mtime check is done by the caller or via isStale;
+  // here we just detect cross-ref content changes for the cascade.
+
+  // Cross-ref _content change (builder-invalidating)
+  let crossRefContentChanged = false;
+  if (crossRefMetas && archiveCrossRefContent) {
+    for (const [refPath, currentContent] of crossRefMetas) {
+      const archivedContent = archiveCrossRefContent.get(refPath);
+      if (currentContent !== archivedContent) {
+        crossRefContentChanged = true;
+        break;
+      }
+    }
+  }
+
+  // Builder invalidation: scope mtime advances OR cross-ref content changes
+  // Scope mtime is already captured by the staleness detection in the caller;
+  // here we apply cross-ref content change cascade.
+  if (
+    crossRefContentChanged &&
+    architectInvalidators.length === 0 &&
+    !firstRun
+  ) {
+    phaseState = invalidateBuilder(phaseState);
+  }
+
+  return {
+    phaseState,
+    architectInvalidators,
+    stalenessInputs: {
+      structureHash,
+      steerChanged,
+      architectChanged,
+      crossRefsDeclChanged,
+      scopeMtimeMax,
+      crossRefContentChanged,
+    },
+    structureHash,
+    steerChanged,
+  };
+}

--- a/packages/service/src/phaseState/phaseScheduler.test.ts
+++ b/packages/service/src/phaseState/phaseScheduler.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
+import type { MetaEntry } from '../discovery/listMetas.js';
 import type { MetaNode } from '../discovery/types.js';
 import type { MetaJson, PhaseState } from '../schema/meta.js';
-import { selectPhaseCandidate } from './phaseScheduler.js';
+import {
+  buildPhaseCandidates,
+  rankPhaseCandidates,
+  selectPhaseCandidate,
+} from './phaseScheduler.js';
 
 /** Helper to create a minimal MetaNode stub. */
 function makeNode(metaPath: string, treeDepth = 0): MetaNode {
@@ -228,5 +233,165 @@ describe('selectPhaseCandidate', () => {
     );
     expect(result!.owedPhase).toBe('architect');
     expect(result!.band).toBe(3);
+  });
+
+  it('treeDepth with depthWeight influences tiebreak', () => {
+    const metas = [
+      candidate(
+        'shallow/.meta',
+        { architect: 'fresh', builder: 'fresh', critic: 'pending' },
+        { actualStaleness: 1000, treeDepth: 0 },
+      ),
+      candidate(
+        'deep/.meta',
+        { architect: 'fresh', builder: 'fresh', critic: 'pending' },
+        { actualStaleness: 1000, treeDepth: 5 },
+      ),
+    ];
+
+    // With depthWeight = 0, same staleness → order depends on effective staleness calc
+    const noWeight = selectPhaseCandidate(metas, 0);
+    expect(noWeight).not.toBeNull();
+
+    // With depthWeight > 0, deeper node should get boosted staleness
+    const withWeight = selectPhaseCandidate(metas, 2);
+    expect(withWeight).not.toBeNull();
+    expect(withWeight!.node.metaPath).toBe('deep/.meta');
+  });
+});
+
+describe('buildPhaseCandidates', () => {
+  function makeEntry(
+    metaPath: string,
+    meta: MetaJson,
+    opts: {
+      locked?: boolean;
+      disabled?: boolean;
+      stalenessSeconds?: number;
+      treeDepth?: number;
+    } = {},
+  ): MetaEntry {
+    return {
+      path: metaPath,
+      depth: opts.treeDepth ?? 0,
+      emphasis: 1,
+      stalenessSeconds: opts.stalenessSeconds ?? 3600,
+      lastSynthesized: null,
+      hasError: false,
+      locked: opts.locked ?? false,
+      disabled: opts.disabled ?? false,
+      architectTokens: null,
+      builderTokens: null,
+      criticTokens: null,
+      children: 0,
+      node: makeNode(metaPath, opts.treeDepth ?? 0),
+      meta,
+    };
+  }
+
+  it('derives phase state from meta fields', () => {
+    const entries: MetaEntry[] = [
+      makeEntry('a/.meta', {}), // never-synthesized → architect pending
+    ];
+    const candidates = buildPhaseCandidates(entries);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].phaseState.architect).toBe('pending');
+    expect(candidates[0].phaseState.builder).toBe('stale');
+  });
+
+  it('auto-retries failed phases', () => {
+    const entries: MetaEntry[] = [
+      makeEntry('a/.meta', {
+        _phaseState: {
+          architect: 'fresh',
+          builder: 'failed',
+          critic: 'stale',
+        },
+      }),
+    ];
+    const candidates = buildPhaseCandidates(entries);
+    expect(candidates[0].phaseState.builder).toBe('pending');
+  });
+
+  it('maps staleness, locked, and disabled from entry', () => {
+    const entries: MetaEntry[] = [
+      makeEntry(
+        'a/.meta',
+        { _builder: 'b', _content: 'c', _feedback: 'f' },
+        { locked: true, disabled: true, stalenessSeconds: 9999 },
+      ),
+    ];
+    const candidates = buildPhaseCandidates(entries);
+    expect(candidates[0].locked).toBe(true);
+    expect(candidates[0].disabled).toBe(true);
+    expect(candidates[0].actualStaleness).toBe(9999);
+  });
+});
+
+describe('rankPhaseCandidates', () => {
+  it('returns full sorted list, not just the first', () => {
+    const metas = [
+      candidate('arch/.meta', {
+        architect: 'pending',
+        builder: 'stale',
+        critic: 'stale',
+      }),
+      candidate('build/.meta', {
+        architect: 'fresh',
+        builder: 'pending',
+        critic: 'stale',
+      }),
+      candidate('crit/.meta', {
+        architect: 'fresh',
+        builder: 'fresh',
+        critic: 'pending',
+      }),
+    ];
+
+    const ranked = rankPhaseCandidates(metas, 1);
+    expect(ranked).toHaveLength(3);
+    expect(ranked[0].owedPhase).toBe('critic');
+    expect(ranked[0].band).toBe(1);
+    expect(ranked[1].owedPhase).toBe('builder');
+    expect(ranked[1].band).toBe(2);
+    expect(ranked[2].owedPhase).toBe('architect');
+    expect(ranked[2].band).toBe(3);
+  });
+
+  it('sorts within band by effective staleness descending', () => {
+    const metas = [
+      candidate(
+        'a/.meta',
+        { architect: 'fresh', builder: 'fresh', critic: 'pending' },
+        { actualStaleness: 100 },
+      ),
+      candidate(
+        'b/.meta',
+        { architect: 'fresh', builder: 'fresh', critic: 'pending' },
+        { actualStaleness: 5000 },
+      ),
+      candidate(
+        'c/.meta',
+        { architect: 'fresh', builder: 'fresh', critic: 'pending' },
+        { actualStaleness: 2000 },
+      ),
+    ];
+
+    const ranked = rankPhaseCandidates(metas, 0);
+    expect(ranked[0].node.metaPath).toBe('b/.meta');
+    expect(ranked[1].node.metaPath).toBe('c/.meta');
+    expect(ranked[2].node.metaPath).toBe('a/.meta');
+  });
+
+  it('returns empty array when all candidates are ineligible', () => {
+    const metas = [
+      candidate('a/.meta', {
+        architect: 'fresh',
+        builder: 'fresh',
+        critic: 'fresh',
+      }),
+    ];
+    const ranked = rankPhaseCandidates(metas, 1);
+    expect(ranked).toEqual([]);
   });
 });

--- a/packages/service/src/phaseState/phaseScheduler.test.ts
+++ b/packages/service/src/phaseState/phaseScheduler.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MetaNode } from '../discovery/types.js';
+import type { MetaJson, PhaseState } from '../schema/meta.js';
+import { selectPhaseCandidate } from './phaseScheduler.js';
+
+/** Helper to create a minimal MetaNode stub. */
+function makeNode(metaPath: string, treeDepth = 0): MetaNode {
+  return {
+    metaPath,
+    ownerPath: metaPath.replace(/\/.meta$/, ''),
+    treeDepth,
+    children: [],
+    parent: null,
+  };
+}
+
+/** Helper to create a minimal MetaJson stub. */
+function makeMeta(overrides: Partial<MetaJson> = {}): MetaJson {
+  return {
+    _generatedAt: new Date(Date.now() - 3600_000).toISOString(),
+    ...overrides,
+  };
+}
+
+/** Helper to build a candidate entry. */
+function candidate(
+  path: string,
+  phaseState: PhaseState,
+  opts: {
+    actualStaleness?: number;
+    locked?: boolean;
+    disabled?: boolean;
+    isOverride?: boolean;
+    treeDepth?: number;
+    meta?: Partial<MetaJson>;
+  } = {},
+) {
+  return {
+    node: makeNode(path, opts.treeDepth ?? 0),
+    meta: makeMeta(opts.meta),
+    phaseState,
+    actualStaleness: opts.actualStaleness ?? 3600,
+    locked: opts.locked ?? false,
+    disabled: opts.disabled ?? false,
+    isOverride: opts.isOverride,
+  };
+}
+
+describe('selectPhaseCandidate', () => {
+  it('returns null for empty input', () => {
+    expect(selectPhaseCandidate([], 1)).toBeNull();
+  });
+
+  it('returns null when all metas are fully fresh', () => {
+    const result = selectPhaseCandidate(
+      [
+        candidate('a/.meta', {
+          architect: 'fresh',
+          builder: 'fresh',
+          critic: 'fresh',
+        }),
+      ],
+      1,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns null when all candidates are locked', () => {
+    const result = selectPhaseCandidate(
+      [
+        candidate(
+          'a/.meta',
+          { architect: 'pending', builder: 'stale', critic: 'stale' },
+          { locked: true },
+        ),
+      ],
+      1,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('excludes disabled metas unless override', () => {
+    const result = selectPhaseCandidate(
+      [
+        candidate(
+          'a/.meta',
+          { architect: 'pending', builder: 'stale', critic: 'stale' },
+          { disabled: true },
+        ),
+      ],
+      1,
+    );
+    expect(result).toBeNull();
+
+    const withOverride = selectPhaseCandidate(
+      [
+        candidate(
+          'a/.meta',
+          { architect: 'pending', builder: 'stale', critic: 'stale' },
+          { disabled: true, isOverride: true },
+        ),
+      ],
+      1,
+    );
+    expect(withOverride).not.toBeNull();
+    expect(withOverride!.owedPhase).toBe('architect');
+  });
+
+  it('skips phases in stale state (not yet pending)', () => {
+    // Builder is stale (not pending) — architect is fresh, so builder is first
+    // non-fresh, but stale is not scheduler-eligible
+    const result = selectPhaseCandidate(
+      [
+        candidate('a/.meta', {
+          architect: 'fresh',
+          builder: 'stale',
+          critic: 'stale',
+        }),
+      ],
+      1,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('picks pending critic over pending builder over pending architect', () => {
+    const metas = [
+      candidate('arch/.meta', {
+        architect: 'pending',
+        builder: 'stale',
+        critic: 'stale',
+      }),
+      candidate('build/.meta', {
+        architect: 'fresh',
+        builder: 'pending',
+        critic: 'stale',
+      }),
+      candidate('crit/.meta', {
+        architect: 'fresh',
+        builder: 'fresh',
+        critic: 'pending',
+      }),
+    ];
+
+    const result = selectPhaseCandidate(metas, 1);
+    expect(result).not.toBeNull();
+    expect(result!.node.metaPath).toBe('crit/.meta');
+    expect(result!.owedPhase).toBe('critic');
+    expect(result!.band).toBe(1);
+  });
+
+  it('picks builder over architect when no critic is pending', () => {
+    const metas = [
+      candidate('arch/.meta', {
+        architect: 'pending',
+        builder: 'stale',
+        critic: 'stale',
+      }),
+      candidate('build/.meta', {
+        architect: 'fresh',
+        builder: 'pending',
+        critic: 'stale',
+      }),
+    ];
+
+    const result = selectPhaseCandidate(metas, 1);
+    expect(result!.node.metaPath).toBe('build/.meta');
+    expect(result!.owedPhase).toBe('builder');
+    expect(result!.band).toBe(2);
+  });
+
+  it('breaks ties within band by effective staleness (higher wins)', () => {
+    const metas = [
+      candidate(
+        'a/.meta',
+        { architect: 'fresh', builder: 'fresh', critic: 'pending' },
+        { actualStaleness: 1000 },
+      ),
+      candidate(
+        'b/.meta',
+        { architect: 'fresh', builder: 'fresh', critic: 'pending' },
+        { actualStaleness: 5000 },
+      ),
+    ];
+
+    const result = selectPhaseCandidate(metas, 1);
+    expect(result!.node.metaPath).toBe('b/.meta');
+  });
+
+  it('failed phase is not scheduler-eligible', () => {
+    const result = selectPhaseCandidate(
+      [
+        candidate('a/.meta', {
+          architect: 'fresh',
+          builder: 'failed',
+          critic: 'stale',
+        }),
+      ],
+      1,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('running phase is not scheduler-eligible', () => {
+    const result = selectPhaseCandidate(
+      [
+        candidate('a/.meta', {
+          architect: 'fresh',
+          builder: 'running',
+          critic: 'stale',
+        }),
+      ],
+      1,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns correct band and owedPhase', () => {
+    const result = selectPhaseCandidate(
+      [
+        candidate('a/.meta', {
+          architect: 'pending',
+          builder: 'stale',
+          critic: 'stale',
+        }),
+      ],
+      1,
+    );
+    expect(result!.owedPhase).toBe('architect');
+    expect(result!.band).toBe(3);
+  });
+});

--- a/packages/service/src/phaseState/phaseScheduler.ts
+++ b/packages/service/src/phaseState/phaseScheduler.ts
@@ -1,0 +1,95 @@
+/**
+ * Corpus-wide phase scheduler.
+ *
+ * Selects the highest-priority ready phase across all metas.
+ * Priority: critic (band 1) \> builder (band 2) \> architect (band 3).
+ * Tiebreak within band: weighted staleness (§3.9).
+ *
+ * @module phaseState/phaseScheduler
+ */
+
+import type { MetaNode } from '../discovery/types.js';
+import { computeEffectiveStaleness } from '../scheduling/weightedFormula.js';
+import type { MetaJson, PhaseName, PhaseState } from '../schema/index.js';
+import { getOwedPhase, getPriorityBand } from './phaseTransitions.js';
+
+/** A candidate for phase-level scheduling. */
+export interface PhaseCandidate {
+  node: MetaNode;
+  meta: MetaJson;
+  phaseState: PhaseState;
+  owedPhase: PhaseName;
+  band: 1 | 2 | 3;
+  actualStaleness: number;
+  effectiveStaleness: number;
+}
+
+/**
+ * Select the best phase candidate across the corpus.
+ *
+ * @param metas - Array of (node, meta, phaseState, stalenessSeconds) tuples.
+ * @param depthWeight - Config depthWeight for staleness tiebreak.
+ * @returns The winning candidate, or null if no phase is ready.
+ */
+export function selectPhaseCandidate(
+  metas: Array<{
+    node: MetaNode;
+    meta: MetaJson;
+    phaseState: PhaseState;
+    actualStaleness: number;
+    locked: boolean;
+    disabled: boolean;
+    isOverride?: boolean;
+  }>,
+  depthWeight: number,
+): PhaseCandidate | null {
+  // Filter to metas with a pending (scheduler-eligible) phase
+  const eligible = metas.filter((m) => {
+    // Locked metas cannot be scheduled
+    if (m.locked) return false;
+    // Disabled metas excluded unless override
+    if (m.disabled && !m.isOverride) return false;
+
+    const owed = getOwedPhase(m.phaseState);
+    if (!owed) return false;
+
+    // Only pending phases are scheduler-eligible
+    // (stale, running, failed are not ready for picking)
+    return m.phaseState[owed] === 'pending';
+  });
+
+  if (eligible.length === 0) return null;
+
+  // Compute effective staleness for tiebreaking
+  const withStaleness = computeEffectiveStaleness(
+    eligible.map((m) => ({
+      node: m.node,
+      meta: m.meta,
+      actualStaleness: m.actualStaleness,
+    })),
+    depthWeight,
+  );
+
+  // Build candidates with band info
+  const candidates: PhaseCandidate[] = withStaleness.map((ws, i) => {
+    const m = eligible[i];
+    const owedPhase = getOwedPhase(m.phaseState)!;
+    return {
+      node: ws.node,
+      meta: ws.meta,
+      phaseState: m.phaseState,
+      owedPhase,
+      band: getPriorityBand(m.phaseState)!,
+      actualStaleness: ws.actualStaleness,
+      effectiveStaleness: ws.effectiveStaleness,
+    };
+  });
+
+  // Sort by band (ascending = critic first) then effective staleness (descending)
+  candidates.sort((a, b) => {
+    if (a.band !== b.band) return a.band - b.band;
+    return b.effectiveStaleness - a.effectiveStaleness;
+  });
+
+  return candidates[0];
+}

--- a/packages/service/src/phaseState/phaseScheduler.ts
+++ b/packages/service/src/phaseState/phaseScheduler.ts
@@ -8,10 +8,46 @@
  * @module phaseState/phaseScheduler
  */
 
+import type { MetaEntry } from '../discovery/listMetas.js';
 import type { MetaNode } from '../discovery/types.js';
 import { computeEffectiveStaleness } from '../scheduling/weightedFormula.js';
 import type { MetaJson, PhaseName, PhaseState } from '../schema/index.js';
-import { getOwedPhase, getPriorityBand } from './phaseTransitions.js';
+import { derivePhaseState } from './derivePhaseState.js';
+import {
+  getOwedPhase,
+  getPriorityBand,
+  retryAllFailed,
+} from './phaseTransitions.js';
+
+/** Input for phase candidate selection (from listMetas entries). */
+export interface PhaseCandidateInput {
+  node: MetaNode;
+  meta: MetaJson;
+  phaseState: PhaseState;
+  actualStaleness: number;
+  locked: boolean;
+  disabled: boolean;
+  isOverride?: boolean;
+}
+
+/**
+ * Build phase candidates from listMetas entries.
+ *
+ * Derives phase state and auto-retries failed phases for each entry.
+ * Used by orchestratePhase, queue route, and status route.
+ */
+export function buildPhaseCandidates(
+  entries: MetaEntry[],
+): PhaseCandidateInput[] {
+  return entries.map((entry) => ({
+    node: entry.node,
+    meta: entry.meta,
+    phaseState: retryAllFailed(derivePhaseState(entry.meta)),
+    actualStaleness: entry.stalenessSeconds,
+    locked: entry.locked,
+    disabled: entry.disabled,
+  }));
+}
 
 /** A candidate for phase-level scheduling. */
 export interface PhaseCandidate {
@@ -25,40 +61,29 @@ export interface PhaseCandidate {
 }
 
 /**
- * Select the best phase candidate across the corpus.
+ * Rank all eligible phase candidates by priority.
  *
- * @param metas - Array of (node, meta, phaseState, stalenessSeconds) tuples.
- * @param depthWeight - Config depthWeight for staleness tiebreak.
- * @returns The winning candidate, or null if no phase is ready.
+ * Filters to pending phases, computes effective staleness, and sorts by
+ * band (ascending: critic first) then effective staleness (descending).
+ *
+ * Used by selectPhaseCandidate (returns first) and the queue route (returns all).
  */
-export function selectPhaseCandidate(
-  metas: Array<{
-    node: MetaNode;
-    meta: MetaJson;
-    phaseState: PhaseState;
-    actualStaleness: number;
-    locked: boolean;
-    disabled: boolean;
-    isOverride?: boolean;
-  }>,
+export function rankPhaseCandidates(
+  metas: PhaseCandidateInput[],
   depthWeight: number,
-): PhaseCandidate | null {
+): PhaseCandidate[] {
   // Filter to metas with a pending (scheduler-eligible) phase
   const eligible = metas.filter((m) => {
-    // Locked metas cannot be scheduled
     if (m.locked) return false;
-    // Disabled metas excluded unless override
     if (m.disabled && !m.isOverride) return false;
 
     const owed = getOwedPhase(m.phaseState);
     if (!owed) return false;
 
-    // Only pending phases are scheduler-eligible
-    // (stale, running, failed are not ready for picking)
     return m.phaseState[owed] === 'pending';
   });
 
-  if (eligible.length === 0) return null;
+  if (eligible.length === 0) return [];
 
   // Compute effective staleness for tiebreaking
   const withStaleness = computeEffectiveStaleness(
@@ -91,5 +116,19 @@ export function selectPhaseCandidate(
     return b.effectiveStaleness - a.effectiveStaleness;
   });
 
-  return candidates[0];
+  return candidates;
+}
+
+/**
+ * Select the best phase candidate across the corpus.
+ *
+ * @param metas - Array of (node, meta, phaseState, stalenessSeconds) tuples.
+ * @param depthWeight - Config depthWeight for staleness tiebreak.
+ * @returns The winning candidate, or null if no phase is ready.
+ */
+export function selectPhaseCandidate(
+  metas: PhaseCandidateInput[],
+  depthWeight: number,
+): PhaseCandidate | null {
+  return rankPhaseCandidates(metas, depthWeight)[0] ?? null;
 }

--- a/packages/service/src/phaseState/phaseState.e2e.test.ts
+++ b/packages/service/src/phaseState/phaseState.e2e.test.ts
@@ -1,0 +1,378 @@
+/**
+ * End-to-end smoke test for the phase-state machine.
+ *
+ * Builds a fixture corpus (tmp dir with 2-3 meta.json files in various states),
+ * mocks the executor, drives multiple orchestratePhase() calls through the
+ * corpus, and verifies behavioral contracts.
+ *
+ * Covers Task #19: end-to-end smoke test.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { copyFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MetaNode } from '../discovery/types.js';
+import type { MetaExecutor, WatcherClient } from '../interfaces/index.js';
+import { acquireLock, releaseLock } from '../lock.js';
+import {
+  runArchitect,
+  runBuilder,
+  runCritic,
+} from '../orchestrator/runPhase.js';
+import type { MetaConfig } from '../schema/config.js';
+import type { MetaJson } from '../schema/meta.js';
+import { derivePhaseState } from './derivePhaseState.js';
+import { selectPhaseCandidate } from './phaseScheduler.js';
+import { getOwedPhase, isFullyFresh, phaseFailed } from './phaseTransitions.js';
+
+/**
+ * Helper: create a fixture meta directory with meta.json.
+ */
+function createFixtureMeta(
+  rootDir: string,
+  name: string,
+  meta: MetaJson,
+): { metaPath: string; node: MetaNode } {
+  const ownerPath = join(rootDir, name);
+  const metaPath = join(ownerPath, '.meta');
+  mkdirSync(metaPath, { recursive: true });
+  writeFileSync(join(metaPath, 'meta.json'), JSON.stringify(meta, null, 2));
+  return {
+    metaPath,
+    node: {
+      metaPath,
+      ownerPath,
+      treeDepth: 0,
+      children: [],
+      parent: null,
+    },
+  };
+}
+
+function readDiskMeta(metaPath: string): MetaJson {
+  return JSON.parse(
+    readFileSync(join(metaPath, 'meta.json'), 'utf8'),
+  ) as MetaJson;
+}
+
+const baseConfig: MetaConfig = {
+  watcherUrl: 'http://localhost:3456',
+  gatewayUrl: 'http://127.0.0.1:18789',
+  architectEvery: 10,
+  depthWeight: 0.5,
+  maxArchive: 20,
+  maxLines: 500,
+  architectTimeout: 120,
+  builderTimeout: 600,
+  criticTimeout: 300,
+  thinking: 'low',
+  defaultArchitect: '',
+  defaultCritic: '',
+  skipUnchanged: true,
+  metaProperty: { _meta: 'current' },
+  metaArchiveProperty: { _meta: 'archive' },
+};
+
+describe('phase-state e2e smoke test (Task #19)', () => {
+  let testRoot: string;
+  let mockWatcher: WatcherClient;
+
+  beforeEach(() => {
+    testRoot = join(
+      tmpdir(),
+      `jeeves-phase-e2e-${String(Date.now())}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(testRoot, { recursive: true });
+
+    mockWatcher = {
+      walk: vi.fn().mockResolvedValue([]),
+      registerRules: vi.fn().mockResolvedValue(undefined),
+      scan: vi.fn().mockResolvedValue({ points: [] }),
+    } as unknown as WatcherClient;
+  });
+
+  afterEach(() => {
+    rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  it('drives a full cycle: architect → builder → critic → archive', async () => {
+    // Create a never-synthesized meta
+    const { metaPath, node } = createFixtureMeta(testRoot, 'project-a', {
+      _id: '11111111-1111-1111-1111-111111111111',
+    });
+
+    const mockExecutor: MetaExecutor = {
+      spawn: vi
+        .fn()
+        .mockResolvedValueOnce({
+          output: 'Analyze the codebase for patterns',
+          tokens: 100,
+        })
+        .mockResolvedValueOnce({
+          output: JSON.stringify({
+            _content: '# Project A Synthesis\n\nKey findings...',
+          }),
+          tokens: 200,
+        })
+        .mockResolvedValueOnce({
+          output: 'Synthesis is comprehensive and accurate.',
+          tokens: 50,
+        }),
+    };
+
+    // Phase 1: Architect
+    let meta = readDiskMeta(metaPath);
+    let ps = derivePhaseState(meta);
+    expect(getOwedPhase(ps)).toBe('architect');
+
+    acquireLock(metaPath);
+    let result = await runArchitect(
+      node,
+      meta,
+      ps,
+      baseConfig,
+      mockExecutor,
+      mockWatcher,
+      'hash1',
+    );
+    releaseLock(metaPath);
+
+    expect(result.executed).toBe(true);
+    expect(result.phaseState.architect).toBe('fresh');
+
+    // Phase 2: Builder
+    meta = readDiskMeta(metaPath);
+    ps = derivePhaseState(meta);
+    expect(getOwedPhase(ps)).toBe('builder');
+
+    acquireLock(metaPath);
+    result = await runBuilder(
+      node,
+      meta,
+      ps,
+      baseConfig,
+      mockExecutor,
+      mockWatcher,
+      'hash1',
+    );
+    releaseLock(metaPath);
+
+    expect(result.executed).toBe(true);
+    expect(result.phaseState.builder).toBe('fresh');
+
+    // Phase 3: Critic
+    meta = readDiskMeta(metaPath);
+    ps = derivePhaseState(meta);
+    expect(getOwedPhase(ps)).toBe('critic');
+
+    acquireLock(metaPath);
+    result = await runCritic(
+      node,
+      meta,
+      ps,
+      baseConfig,
+      mockExecutor,
+      mockWatcher,
+      'hash1',
+    );
+    releaseLock(metaPath);
+
+    expect(result.cycleComplete).toBe(true);
+    expect(isFullyFresh(result.phaseState)).toBe(true);
+
+    // Verify archive was created
+    const archiveDir = join(metaPath, 'archive');
+    expect(existsSync(archiveDir)).toBe(true);
+    const archiveFiles = readdirSync(archiveDir).filter((f) =>
+      f.endsWith('.json'),
+    );
+    expect(archiveFiles.length).toBe(1);
+
+    // Verify _synthesisCount incremented
+    meta = readDiskMeta(metaPath);
+    expect(meta._synthesisCount).toBe(1);
+  });
+
+  it('surgical retry only re-runs the failed phase', async () => {
+    // Create a meta where builder has failed
+    const { metaPath, node } = createFixtureMeta(testRoot, 'project-b', {
+      _id: '22222222-2222-2222-2222-222222222222',
+      _builder: 'cached brief',
+      _generatedAt: new Date().toISOString(),
+      _phaseState: {
+        architect: 'fresh',
+        builder: 'failed',
+        critic: 'stale',
+      },
+      _error: { step: 'builder', code: 'TIMEOUT', message: 'Timed out' },
+    });
+
+    const spawnMock = vi.fn().mockResolvedValue({
+      output: JSON.stringify({
+        _content: '# Retry output\n\nRecovered content.',
+      }),
+      tokens: 150,
+    });
+    const mockExecutor: MetaExecutor = { spawn: spawnMock };
+
+    // Derive state — should show builder failed
+    let meta = readDiskMeta(metaPath);
+    let ps = derivePhaseState(meta);
+    expect(ps.builder).toBe('failed');
+
+    // Retry: builder should be re-eligible
+    const { retryPhase } = await import('./phaseTransitions.js');
+    ps = retryPhase(ps, 'builder');
+    expect(ps.builder).toBe('pending');
+    expect(getOwedPhase(ps)).toBe('builder');
+
+    // Run builder retry
+    acquireLock(metaPath);
+    const result = await runBuilder(
+      node,
+      meta,
+      ps,
+      baseConfig,
+      mockExecutor,
+      mockWatcher,
+      'hash1',
+    );
+    releaseLock(metaPath);
+
+    expect(result.executed).toBe(true);
+    expect(result.phaseState.builder).toBe('fresh');
+    expect(result.phaseState.critic).toBe('pending');
+
+    // Verify architect was NOT called (only builder)
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    // Verify _error is cleared on disk
+    meta = readDiskMeta(metaPath);
+    expect(meta._error).toBeUndefined();
+  });
+
+  it('abort sets _error.code=ABORT on disk', async () => {
+    const { metaPath } = createFixtureMeta(testRoot, 'project-c', {
+      _id: '33333333-3333-3333-3333-333333333333',
+      _builder: 'brief',
+      _content: 'existing content',
+      _generatedAt: new Date().toISOString(),
+      _phaseState: {
+        architect: 'fresh',
+        builder: 'running',
+        critic: 'stale',
+      },
+    });
+
+    acquireLock(metaPath);
+
+    // Simulate abort handler behavior
+    const meta = readDiskMeta(metaPath);
+    const ps = phaseFailed(meta._phaseState!, 'builder');
+
+    const updated = {
+      ...meta,
+      _phaseState: ps,
+      _error: {
+        step: 'builder' as const,
+        code: 'ABORT',
+        message: 'Aborted by operator',
+      },
+    };
+
+    const lockPath = join(metaPath, '.lock');
+    const metaJsonPath = join(metaPath, 'meta.json');
+    await writeFile(lockPath, JSON.stringify(updated, null, 2) + '\n');
+    await copyFile(lockPath, metaJsonPath);
+    releaseLock(metaPath);
+
+    // Verify on disk
+    const onDisk = readDiskMeta(metaPath);
+    expect(onDisk._error!.code).toBe('ABORT');
+    expect(onDisk._error!.message).toBe('Aborted by operator');
+    expect(onDisk._phaseState!.builder).toBe('failed');
+    expect(onDisk._phaseState!.architect).toBe('fresh');
+  });
+
+  it('derive + select reflect correct state after each cycle', () => {
+    // Create 3 metas in various states
+    const metaA = createFixtureMeta(testRoot, 'a', {
+      _id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    });
+    const metaB = createFixtureMeta(testRoot, 'b', {
+      _id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      _builder: 'brief',
+      _content: 'content',
+      _feedback: 'good',
+      _generatedAt: new Date(Date.now() - 3600_000).toISOString(),
+      _phaseState: {
+        architect: 'fresh',
+        builder: 'fresh',
+        critic: 'fresh',
+      },
+    });
+    const metaC = createFixtureMeta(testRoot, 'c', {
+      _id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+      _builder: 'brief',
+      _generatedAt: new Date(Date.now() - 7200_000).toISOString(),
+      _phaseState: {
+        architect: 'fresh',
+        builder: 'fresh',
+        critic: 'pending',
+      },
+    });
+
+    // Build candidates for scheduler
+    const candidates = [
+      {
+        node: metaA.node,
+        meta: readDiskMeta(metaA.metaPath),
+        phaseState: derivePhaseState(readDiskMeta(metaA.metaPath)),
+        actualStaleness: 365 * 86400, // never synthesized
+        locked: false,
+        disabled: false,
+      },
+      {
+        node: metaB.node,
+        meta: readDiskMeta(metaB.metaPath),
+        phaseState: derivePhaseState(readDiskMeta(metaB.metaPath)),
+        actualStaleness: 3600,
+        locked: false,
+        disabled: false,
+      },
+      {
+        node: metaC.node,
+        meta: readDiskMeta(metaC.metaPath),
+        phaseState: derivePhaseState(readDiskMeta(metaC.metaPath)),
+        actualStaleness: 7200,
+        locked: false,
+        disabled: false,
+      },
+    ];
+
+    // Scheduler should pick metaC (pending critic = band 1, highest priority)
+    const winner = selectPhaseCandidate(candidates, 0.5);
+    expect(winner).not.toBeNull();
+    expect(winner!.owedPhase).toBe('critic');
+    expect(winner!.band).toBe(1);
+    expect(winner!.node.metaPath).toBe(metaC.metaPath);
+
+    // metaB is fully fresh — should not be selected
+    expect(isFullyFresh(candidates[1].phaseState)).toBe(true);
+
+    // metaA is never-synthesized — should be architect band 3
+    expect(candidates[0].phaseState.architect).toBe('pending');
+    expect(getOwedPhase(candidates[0].phaseState)).toBe('architect');
+  });
+});

--- a/packages/service/src/phaseState/phaseState.integration.test.ts
+++ b/packages/service/src/phaseState/phaseState.integration.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Phase-state machine integration tests.
+ *
+ * Covers:
+ * - Task #14: Migration verification (derivePhaseState backward compat)
+ * - Task #15: Cascade + surgical-retry sequences
+ * - Task #17: Full-cycle completion logic
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { MetaJson, PhaseState } from '../schema/meta.js';
+import { derivePhaseState } from './derivePhaseState.js';
+import {
+  architectSuccess,
+  builderSuccess,
+  criticSuccess,
+  enforceInvariant,
+  freshPhaseState,
+  getOwedPhase,
+  initialPhaseState,
+  invalidateArchitect,
+  invalidateBuilder,
+  isFullyFresh,
+  phaseFailed,
+  phaseRunning,
+  retryPhase,
+} from './phaseTransitions.js';
+
+// ── Task #14: Migration verification ────────────────────────────────
+
+describe('migration verification (Task #14)', () => {
+  it('never-synthesized meta gains valid _phaseState', () => {
+    const meta: MetaJson = {};
+    const ps = derivePhaseState(meta);
+    expect(ps.architect).toBe('pending');
+    expect(ps.builder).toBe('stale');
+    expect(ps.critic).toBe('stale');
+    expect(getOwedPhase(ps)).toBe('architect');
+  });
+
+  it('fully-fresh meta (all outputs present) derives to all-fresh', () => {
+    const meta: MetaJson = {
+      _builder: 'brief',
+      _content: 'output',
+      _feedback: 'evaluation',
+      _generatedAt: new Date().toISOString(),
+    };
+    const ps = derivePhaseState(meta);
+    expect(isFullyFresh(ps)).toBe(true);
+  });
+
+  it('_error.step=architect maps to architect failed', () => {
+    const meta: MetaJson = {
+      _error: { step: 'architect', code: 'ERROR', message: 'fail' },
+    };
+    const ps = derivePhaseState(meta);
+    expect(ps.architect).toBe('failed');
+  });
+
+  it('_error.step=builder maps to builder failed', () => {
+    const meta: MetaJson = {
+      _builder: 'brief',
+      _error: { step: 'builder', code: 'TIMEOUT', message: 'timeout' },
+    };
+    const ps = derivePhaseState(meta);
+    expect(ps.builder).toBe('failed');
+    expect(ps.architect).toBe('fresh');
+  });
+
+  it('_error.step=critic maps to critic failed', () => {
+    const meta: MetaJson = {
+      _builder: 'brief',
+      _content: 'output',
+      _error: { step: 'critic', code: 'ERROR', message: 'fail' },
+    };
+    const ps = derivePhaseState(meta);
+    expect(ps.critic).toBe('failed');
+    expect(ps.architect).toBe('fresh');
+    expect(ps.builder).toBe('fresh');
+  });
+
+  it('existing _phaseState is returned unchanged (round-trip)', () => {
+    const expected: PhaseState = {
+      architect: 'fresh',
+      builder: 'failed',
+      critic: 'stale',
+    };
+    const meta: MetaJson = { _phaseState: expected };
+    expect(derivePhaseState(meta)).toEqual(expected);
+  });
+
+  it('reserved properties survive derivation (steer, crossRefs, etc.)', () => {
+    const meta: MetaJson = {
+      _steer: 'focus on X',
+      _crossRefs: ['/a', '/b'],
+      _emphasis: 2.0,
+      _depth: 3,
+      _builder: 'brief',
+      _content: 'content',
+      _feedback: 'ok',
+      _generatedAt: new Date().toISOString(),
+    };
+    const ps = derivePhaseState(meta);
+    expect(isFullyFresh(ps)).toBe(true);
+    // Properties should still be on the meta object
+    expect(meta._steer).toBe('focus on X');
+    expect(meta._crossRefs).toEqual(['/a', '/b']);
+  });
+
+  it('architect invalidation via steerChanged', () => {
+    const meta: MetaJson = {
+      _builder: 'brief',
+      _content: 'content',
+      _feedback: 'ok',
+      _generatedAt: new Date().toISOString(),
+    };
+    const ps = derivePhaseState(meta, {
+      structureChanged: false,
+      steerChanged: true,
+      architectChanged: false,
+      crossRefsChanged: false,
+      architectEvery: 10,
+    });
+    expect(ps.architect).toBe('pending');
+    expect(ps.builder).toBe('stale');
+    expect(ps.critic).toBe('stale');
+  });
+
+  it('architect invalidation via architectChanged', () => {
+    const meta: MetaJson = {
+      _builder: 'brief',
+      _content: 'content',
+      _feedback: 'ok',
+      _generatedAt: new Date().toISOString(),
+    };
+    const ps = derivePhaseState(meta, {
+      structureChanged: false,
+      steerChanged: false,
+      architectChanged: true,
+      crossRefsChanged: false,
+      architectEvery: 10,
+    });
+    expect(ps.architect).toBe('pending');
+  });
+
+  it('architect invalidation via crossRefsChanged', () => {
+    const meta: MetaJson = {
+      _builder: 'brief',
+      _content: 'content',
+      _feedback: 'ok',
+      _generatedAt: new Date().toISOString(),
+    };
+    const ps = derivePhaseState(meta, {
+      structureChanged: false,
+      steerChanged: false,
+      architectChanged: false,
+      crossRefsChanged: true,
+      architectEvery: 10,
+    });
+    expect(ps.architect).toBe('pending');
+  });
+});
+
+// ── Task #15: Cascade + surgical-retry ──────────────────────────────
+
+describe('cascade integration (Task #15)', () => {
+  it('full forward cascade: architect → builder → critic → fully fresh', () => {
+    // Start: initial state (never-synthesized)
+    let ps = initialPhaseState();
+    expect(getOwedPhase(ps)).toBe('architect');
+
+    // Architect runs and succeeds
+    ps = phaseRunning(ps, 'architect');
+    ps = architectSuccess(ps);
+    expect(ps.architect).toBe('fresh');
+    expect(ps.builder).toBe('pending');
+    expect(ps.critic).toBe('stale');
+    expect(getOwedPhase(ps)).toBe('builder');
+
+    // Builder runs and succeeds
+    ps = phaseRunning(ps, 'builder');
+    ps = builderSuccess(ps);
+    expect(ps.builder).toBe('fresh');
+    expect(ps.critic).toBe('pending');
+    expect(getOwedPhase(ps)).toBe('critic');
+
+    // Critic runs and succeeds
+    ps = phaseRunning(ps, 'critic');
+    ps = criticSuccess(ps);
+    expect(isFullyFresh(ps)).toBe(true);
+    expect(getOwedPhase(ps)).toBeNull();
+  });
+
+  it('architect invalidation mid-cycle cascades downstream', () => {
+    // Start: builder just completed, critic pending
+    let ps: PhaseState = {
+      architect: 'fresh',
+      builder: 'fresh',
+      critic: 'pending',
+    };
+
+    // External change invalidates architect
+    ps = invalidateArchitect(ps);
+    expect(ps.architect).toBe('pending');
+    expect(ps.builder).toBe('stale');
+    expect(ps.critic).toBe('stale');
+    expect(getOwedPhase(ps)).toBe('architect');
+  });
+
+  it('builder invalidation when architect is fresh', () => {
+    let ps: PhaseState = {
+      architect: 'fresh',
+      builder: 'fresh',
+      critic: 'fresh',
+    };
+
+    ps = invalidateBuilder(ps);
+    expect(ps.architect).toBe('fresh');
+    expect(ps.builder).toBe('pending');
+    expect(ps.critic).toBe('stale');
+    expect(getOwedPhase(ps)).toBe('builder');
+  });
+
+  it('builder invalidation when architect is not fresh has no effect', () => {
+    let ps: PhaseState = {
+      architect: 'pending',
+      builder: 'stale',
+      critic: 'stale',
+    };
+
+    ps = invalidateBuilder(ps);
+    // Architect is still the first non-fresh
+    expect(getOwedPhase(ps)).toBe('architect');
+  });
+
+  it('critic failure does not cascade — upstream and downstream untouched', () => {
+    let ps: PhaseState = {
+      architect: 'fresh',
+      builder: 'fresh',
+      critic: 'running',
+    };
+
+    ps = phaseFailed(ps, 'critic');
+    expect(ps.architect).toBe('fresh');
+    expect(ps.builder).toBe('fresh');
+    expect(ps.critic).toBe('failed');
+  });
+
+  it('builder failure preserves upstream architect fresh', () => {
+    let ps: PhaseState = {
+      architect: 'fresh',
+      builder: 'running',
+      critic: 'stale',
+    };
+
+    ps = phaseFailed(ps, 'builder');
+    expect(ps.architect).toBe('fresh');
+    expect(ps.builder).toBe('failed');
+    expect(ps.critic).toBe('stale');
+  });
+
+  it('surgical retry: critic failed → pending → running → success', () => {
+    let ps: PhaseState = {
+      architect: 'fresh',
+      builder: 'fresh',
+      critic: 'failed',
+    };
+
+    // Retry: failed → pending
+    ps = retryPhase(ps, 'critic');
+    expect(ps.critic).toBe('pending');
+
+    // Run
+    ps = phaseRunning(ps, 'critic');
+    expect(ps.critic).toBe('running');
+
+    // Success
+    ps = criticSuccess(ps);
+    expect(isFullyFresh(ps)).toBe(true);
+  });
+
+  it('surgical retry: builder failed → pending → running → success', () => {
+    let ps: PhaseState = {
+      architect: 'fresh',
+      builder: 'failed',
+      critic: 'stale',
+    };
+
+    ps = retryPhase(ps, 'builder');
+    expect(ps.builder).toBe('pending');
+    expect(ps.critic).toBe('stale');
+
+    ps = phaseRunning(ps, 'builder');
+    ps = builderSuccess(ps);
+    expect(ps.builder).toBe('fresh');
+    expect(ps.critic).toBe('pending');
+  });
+
+  it('abort sets phase to failed, upstream/downstream untouched', () => {
+    let ps: PhaseState = {
+      architect: 'fresh',
+      builder: 'running',
+      critic: 'stale',
+    };
+
+    // Abort = failure
+    ps = phaseFailed(ps, 'builder');
+    expect(ps.architect).toBe('fresh');
+    expect(ps.builder).toBe('failed');
+    expect(ps.critic).toBe('stale');
+
+    // Re-eligible on next tick
+    ps = retryPhase(ps, 'builder');
+    expect(ps.builder).toBe('pending');
+  });
+
+  it('retry on non-failed phase is a no-op', () => {
+    const ps: PhaseState = {
+      architect: 'fresh',
+      builder: 'pending',
+      critic: 'stale',
+    };
+    const result = retryPhase(ps, 'builder');
+    expect(result).toEqual(ps);
+  });
+});
+
+// ── Task #17: Full-cycle completion logic ───────────────────────────
+
+describe('full-cycle completion (Task #17)', () => {
+  it('cycle completes only when all three phases are fresh', () => {
+    // After architect success: not complete
+    let ps = architectSuccess(initialPhaseState());
+    expect(isFullyFresh(ps)).toBe(false);
+
+    // After builder success: not complete
+    ps = phaseRunning(ps, 'builder');
+    ps = builderSuccess(ps);
+    expect(isFullyFresh(ps)).toBe(false);
+
+    // After critic success: COMPLETE
+    ps = phaseRunning(ps, 'critic');
+    ps = criticSuccess(ps);
+    expect(isFullyFresh(ps)).toBe(true);
+  });
+
+  it('critic failure prevents cycle completion', () => {
+    let ps: PhaseState = {
+      architect: 'fresh',
+      builder: 'fresh',
+      critic: 'running',
+    };
+    ps = phaseFailed(ps, 'critic');
+    expect(isFullyFresh(ps)).toBe(false);
+  });
+
+  it('after critic retry success, cycle completes and can be archived', () => {
+    // Start with critic failed
+    let ps: PhaseState = {
+      architect: 'fresh',
+      builder: 'fresh',
+      critic: 'failed',
+    };
+
+    // Retry
+    ps = retryPhase(ps, 'critic');
+    ps = phaseRunning(ps, 'critic');
+    ps = criticSuccess(ps);
+    expect(isFullyFresh(ps)).toBe(true);
+  });
+
+  it('architect success resets _synthesisCount to 0 (via convention)', () => {
+    // This tests the convention, not the function — architect success
+    // means _synthesisCount should be set to 0 by the caller
+    const ps = architectSuccess(initialPhaseState());
+    expect(ps.architect).toBe('fresh');
+    // The actual _synthesisCount=0 happens in runArchitect, tested here
+    // as a convention verification
+  });
+
+  it('enforceInvariant promotes stale to pending when it becomes first non-fresh', () => {
+    // Simulate: architect completes, builder should become pending
+    const ps = enforceInvariant({
+      architect: 'fresh',
+      builder: 'stale',
+      critic: 'stale',
+    });
+    expect(ps.builder).toBe('pending');
+    expect(ps.critic).toBe('stale');
+  });
+
+  it('fully fresh after invalidation starts new cycle', () => {
+    let ps = freshPhaseState();
+    expect(isFullyFresh(ps)).toBe(true);
+
+    // New invalidation restarts the cycle
+    ps = invalidateArchitect(ps);
+    expect(isFullyFresh(ps)).toBe(false);
+    expect(getOwedPhase(ps)).toBe('architect');
+  });
+});

--- a/packages/service/src/phaseState/phaseState.integration.test.ts
+++ b/packages/service/src/phaseState/phaseState.integration.test.ts
@@ -386,13 +386,13 @@ describe('full-cycle completion (Task #17)', () => {
     expect(isFullyFresh(ps)).toBe(true);
   });
 
-  it('architect success resets _synthesisCount to 0 (via convention)', () => {
-    // This tests the convention, not the function — architect success
-    // means _synthesisCount should be set to 0 by the caller
+  it('architect success transitions to builder pending', () => {
     const ps = architectSuccess(initialPhaseState());
-    expect(ps.architect).toBe('fresh');
-    // The actual _synthesisCount=0 happens in runArchitect, tested here
-    // as a convention verification
+    expect(ps).toEqual({
+      architect: 'fresh',
+      builder: 'pending',
+      critic: 'stale',
+    });
   });
 
   it('enforceInvariant promotes stale to pending when it becomes first non-fresh', () => {
@@ -512,9 +512,11 @@ describe('I/O integration (Tasks #14-17)', () => {
     const onDisk = JSON.parse(
       readFileSync(join(metaPath, 'meta.json'), 'utf8'),
     ) as MetaJson;
-    expect(onDisk._phaseState).toBeDefined();
-    expect(onDisk._phaseState!.architect).toBe('fresh');
-    expect(onDisk._phaseState!.builder).toBe('pending');
+    expect(onDisk._phaseState).toEqual({
+      architect: 'fresh',
+      builder: 'pending',
+      critic: 'stale',
+    });
 
     releaseLock(metaPath);
   });
@@ -565,7 +567,7 @@ describe('I/O integration (Tasks #14-17)', () => {
     const archiveFiles = readdirSync(archiveDir).filter((f) =>
       f.endsWith('.json'),
     );
-    expect(archiveFiles.length).toBeGreaterThan(0);
+    expect(archiveFiles.length).toBe(1);
 
     // Verify archive content has _archived: true
     const archiveContent = JSON.parse(
@@ -649,10 +651,16 @@ describe('I/O integration (Tasks #14-17)', () => {
     const onDisk = JSON.parse(
       readFileSync(join(metaPath, 'meta.json'), 'utf8'),
     ) as MetaJson;
-    expect(onDisk._error).toBeDefined();
-    expect(onDisk._error!.code).toBe('ABORT');
-    expect(onDisk._error!.message).toBe('Aborted by operator');
-    expect(onDisk._phaseState!.builder).toBe('failed');
+    expect(onDisk._error).toEqual({
+      step: 'builder',
+      code: 'ABORT',
+      message: 'Aborted by operator',
+    });
+    expect(onDisk._phaseState).toEqual({
+      architect: 'fresh',
+      builder: 'failed',
+      critic: 'stale',
+    });
 
     releaseLock(metaPath);
   });

--- a/packages/service/src/phaseState/phaseState.integration.test.ts
+++ b/packages/service/src/phaseState/phaseState.integration.test.ts
@@ -5,10 +5,26 @@
  * - Task #14: Migration verification (derivePhaseState backward compat)
  * - Task #15: Cascade + surgical-retry sequences
  * - Task #17: Full-cycle completion logic
+ * - Tasks #14-17 I/O integration: lock-staged writes, archive, abort
  */
 
-import { describe, expect, it } from 'vitest';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MetaNode } from '../discovery/types.js';
+import type { MetaExecutor, WatcherClient } from '../interfaces/index.js';
+import { acquireLock, releaseLock } from '../lock.js';
+import { runArchitect, runCritic } from '../orchestrator/runPhase.js';
+import type { MetaConfig } from '../schema/config.js';
 import type { MetaJson, PhaseState } from '../schema/meta.js';
 import { derivePhaseState } from './derivePhaseState.js';
 import {
@@ -398,5 +414,246 @@ describe('full-cycle completion (Task #17)', () => {
     ps = invalidateArchitect(ps);
     expect(isFullyFresh(ps)).toBe(false);
     expect(getOwedPhase(ps)).toBe('architect');
+  });
+});
+
+// ── Tasks #14-17 I/O integration tests ──────────────────────────────
+
+describe('I/O integration (Tasks #14-17)', () => {
+  let testRoot: string;
+  let metaPath: string;
+  let node: MetaNode;
+  let mockExecutor: MetaExecutor;
+  let mockWatcher: WatcherClient;
+  const config: MetaConfig = {
+    watcherUrl: 'http://localhost:3456',
+    gatewayUrl: 'http://127.0.0.1:18789',
+    architectEvery: 10,
+    depthWeight: 0.5,
+    maxArchive: 20,
+    maxLines: 500,
+    architectTimeout: 120,
+    builderTimeout: 600,
+    criticTimeout: 300,
+    thinking: 'low',
+    defaultArchitect: '',
+    defaultCritic: '',
+    skipUnchanged: true,
+    metaProperty: { _meta: 'current' },
+    metaArchiveProperty: { _meta: 'archive' },
+  };
+
+  beforeEach(() => {
+    testRoot = join(
+      tmpdir(),
+      `jeeves-phase-io-${String(Date.now())}-${Math.random().toString(36).slice(2)}`,
+    );
+    metaPath = join(testRoot, 'owner', '.meta');
+    mkdirSync(metaPath, { recursive: true });
+
+    node = {
+      metaPath,
+      ownerPath: join(testRoot, 'owner'),
+      treeDepth: 0,
+      children: [],
+      parent: null,
+    };
+
+    mockWatcher = {
+      walk: vi.fn().mockResolvedValue([]),
+      registerRules: vi.fn().mockResolvedValue(undefined),
+      scan: vi.fn().mockResolvedValue({ points: [] }),
+    } as unknown as WatcherClient;
+  });
+
+  afterEach(() => {
+    try {
+      releaseLock(metaPath);
+    } catch {
+      // ok
+    }
+    rmSync(testRoot, { recursive: true, force: true });
+  });
+
+  it('lock-staged writes persist _phaseState to meta.json on disk', async () => {
+    const meta: MetaJson = {
+      _id: '550e8400-e29b-41d4-a716-446655440000',
+    };
+    writeFileSync(join(metaPath, 'meta.json'), JSON.stringify(meta, null, 2));
+    acquireLock(metaPath);
+
+    mockExecutor = {
+      spawn: vi.fn().mockResolvedValue({
+        output: 'Test architect brief for builder',
+        tokens: 100,
+      }),
+    };
+
+    const ps: PhaseState = {
+      architect: 'pending',
+      builder: 'stale',
+      critic: 'stale',
+    };
+
+    const result = await runArchitect(
+      node,
+      meta,
+      ps,
+      config,
+      mockExecutor,
+      mockWatcher,
+      'hash123',
+    );
+
+    expect(result.executed).toBe(true);
+    expect(result.phaseState.architect).toBe('fresh');
+
+    // Read from disk and verify _phaseState is persisted
+    const onDisk = JSON.parse(
+      readFileSync(join(metaPath, 'meta.json'), 'utf8'),
+    ) as MetaJson;
+    expect(onDisk._phaseState).toBeDefined();
+    expect(onDisk._phaseState!.architect).toBe('fresh');
+    expect(onDisk._phaseState!.builder).toBe('pending');
+
+    releaseLock(metaPath);
+  });
+
+  it('archive snapshot is created on full-cycle completion', async () => {
+    // Set up meta that's ready for critic (final phase)
+    const meta: MetaJson = {
+      _id: '550e8400-e29b-41d4-a716-446655440000',
+      _builder: 'cached brief',
+      _content: 'existing content',
+      _generatedAt: new Date().toISOString(),
+      _synthesisCount: 0,
+    };
+    writeFileSync(join(metaPath, 'meta.json'), JSON.stringify(meta, null, 2));
+    acquireLock(metaPath);
+
+    mockExecutor = {
+      spawn: vi.fn().mockResolvedValue({
+        output: 'Good synthesis, well done.',
+        tokens: 50,
+      }),
+    };
+
+    const ps: PhaseState = {
+      architect: 'fresh',
+      builder: 'fresh',
+      critic: 'pending',
+    };
+
+    const result = await runCritic(
+      node,
+      meta,
+      ps,
+      config,
+      mockExecutor,
+      mockWatcher,
+      'hash123',
+    );
+
+    expect(result.cycleComplete).toBe(true);
+
+    // Verify archive directory was created with a snapshot
+    const archiveDir = join(metaPath, 'archive');
+    expect(existsSync(archiveDir)).toBe(true);
+
+    // Check at least one archive file exists
+    const { readdirSync } = await import('node:fs');
+    const archiveFiles = readdirSync(archiveDir).filter((f) =>
+      f.endsWith('.json'),
+    );
+    expect(archiveFiles.length).toBeGreaterThan(0);
+
+    // Verify archive content has _archived: true
+    const archiveContent = JSON.parse(
+      readFileSync(join(archiveDir, archiveFiles[0]), 'utf8'),
+    ) as MetaJson;
+    expect(archiveContent._archived).toBe(true);
+
+    releaseLock(metaPath);
+  });
+
+  it('_synthesisCount is incremented in the file on full-cycle', async () => {
+    const meta: MetaJson = {
+      _id: '550e8400-e29b-41d4-a716-446655440000',
+      _builder: 'brief',
+      _content: 'content',
+      _generatedAt: new Date().toISOString(),
+      _synthesisCount: 3,
+    };
+    writeFileSync(join(metaPath, 'meta.json'), JSON.stringify(meta, null, 2));
+    acquireLock(metaPath);
+
+    mockExecutor = {
+      spawn: vi.fn().mockResolvedValue({
+        output: 'Critic feedback here.',
+        tokens: 30,
+      }),
+    };
+
+    const ps: PhaseState = {
+      architect: 'fresh',
+      builder: 'fresh',
+      critic: 'pending',
+    };
+
+    await runCritic(node, meta, ps, config, mockExecutor, mockWatcher, 'hash');
+
+    const onDisk = JSON.parse(
+      readFileSync(join(metaPath, 'meta.json'), 'utf8'),
+    ) as MetaJson;
+    expect(onDisk._synthesisCount).toBe(4);
+
+    releaseLock(metaPath);
+  });
+
+  it('abort writes _error with code ABORT to disk', async () => {
+    // Simulate an abort by writing the abort error via the same pattern
+    // as the route handler. We test the route handler's abort logic directly.
+    const meta: MetaJson = {
+      _id: '550e8400-e29b-41d4-a716-446655440000',
+      _builder: 'brief',
+      _content: 'content',
+      _generatedAt: new Date().toISOString(),
+      _phaseState: {
+        architect: 'fresh',
+        builder: 'running',
+        critic: 'stale',
+      },
+    };
+    writeFileSync(join(metaPath, 'meta.json'), JSON.stringify(meta, null, 2));
+    acquireLock(metaPath);
+
+    // Simulate what the abort handler does: phaseFailed + write _error
+    const ps = phaseFailed(meta._phaseState!, 'builder');
+    const updated = {
+      ...meta,
+      _phaseState: ps,
+      _error: {
+        step: 'builder' as const,
+        code: 'ABORT',
+        message: 'Aborted by operator',
+      },
+    };
+
+    const { writeFile, copyFile } = await import('node:fs/promises');
+    const lockPath = join(metaPath, '.lock');
+    const metaJsonPath = join(metaPath, 'meta.json');
+    await writeFile(lockPath, JSON.stringify(updated, null, 2) + '\n');
+    await copyFile(lockPath, metaJsonPath);
+
+    // Verify on disk
+    const onDisk = JSON.parse(
+      readFileSync(join(metaPath, 'meta.json'), 'utf8'),
+    ) as MetaJson;
+    expect(onDisk._error).toBeDefined();
+    expect(onDisk._error!.code).toBe('ABORT');
+    expect(onDisk._error!.message).toBe('Aborted by operator');
+    expect(onDisk._phaseState!.builder).toBe('failed');
+
+    releaseLock(metaPath);
   });
 });

--- a/packages/service/src/phaseState/phaseTransitions.test.ts
+++ b/packages/service/src/phaseState/phaseTransitions.test.ts
@@ -1,0 +1,396 @@
+import { describe, expect, it } from 'vitest';
+
+import type { PhaseState } from '../schema/meta.js';
+import {
+  architectSuccess,
+  builderSuccess,
+  criticSuccess,
+  enforceInvariant,
+  freshPhaseState,
+  getOwedPhase,
+  getPriorityBand,
+  initialPhaseState,
+  invalidateArchitect,
+  invalidateBuilder,
+  isFullyFresh,
+  phaseFailed,
+  phaseRunning,
+  retryPhase,
+} from './phaseTransitions.js';
+
+describe('phaseTransitions', () => {
+  describe('freshPhaseState', () => {
+    it('returns all fresh', () => {
+      expect(freshPhaseState()).toEqual({
+        architect: 'fresh',
+        builder: 'fresh',
+        critic: 'fresh',
+      });
+    });
+  });
+
+  describe('initialPhaseState', () => {
+    it('returns architect pending, downstream stale', () => {
+      expect(initialPhaseState()).toEqual({
+        architect: 'pending',
+        builder: 'stale',
+        critic: 'stale',
+      });
+    });
+  });
+
+  describe('enforceInvariant', () => {
+    it('promotes first stale to pending', () => {
+      const result = enforceInvariant({
+        architect: 'fresh',
+        builder: 'stale',
+        critic: 'stale',
+      });
+      expect(result).toEqual({
+        architect: 'fresh',
+        builder: 'pending',
+        critic: 'stale',
+      });
+    });
+
+    it('demotes non-first pending to stale', () => {
+      const result = enforceInvariant({
+        architect: 'pending',
+        builder: 'pending',
+        critic: 'stale',
+      });
+      expect(result).toEqual({
+        architect: 'pending',
+        builder: 'stale',
+        critic: 'stale',
+      });
+    });
+
+    it('leaves failed as first non-fresh', () => {
+      const result = enforceInvariant({
+        architect: 'fresh',
+        builder: 'failed',
+        critic: 'stale',
+      });
+      expect(result).toEqual({
+        architect: 'fresh',
+        builder: 'failed',
+        critic: 'stale',
+      });
+    });
+
+    it('preserves fully fresh', () => {
+      const result = enforceInvariant(freshPhaseState());
+      expect(result).toEqual(freshPhaseState());
+    });
+  });
+
+  // ── Invalidation cascades ──
+
+  describe('invalidateArchitect', () => {
+    it('fresh → architect pending, downstream stale', () => {
+      const result = invalidateArchitect(freshPhaseState());
+      expect(result).toEqual({
+        architect: 'pending',
+        builder: 'stale',
+        critic: 'stale',
+      });
+    });
+
+    it('preserves failed architect', () => {
+      const state: PhaseState = {
+        architect: 'failed',
+        builder: 'fresh',
+        critic: 'fresh',
+      };
+      const result = invalidateArchitect(state);
+      expect(result.architect).toBe('failed');
+    });
+
+    it('already-stale builder stays stale', () => {
+      const state: PhaseState = {
+        architect: 'fresh',
+        builder: 'stale',
+        critic: 'fresh',
+      };
+      const result = invalidateArchitect(state);
+      expect(result.builder).toBe('stale');
+    });
+  });
+
+  describe('invalidateBuilder', () => {
+    it('builder → pending when architect is fresh', () => {
+      const state: PhaseState = {
+        architect: 'fresh',
+        builder: 'fresh',
+        critic: 'fresh',
+      };
+      const result = invalidateBuilder(state);
+      expect(result).toEqual({
+        architect: 'fresh',
+        builder: 'pending',
+        critic: 'stale',
+      });
+    });
+
+    it('builder stays stale when architect is not fresh', () => {
+      const state: PhaseState = {
+        architect: 'pending',
+        builder: 'fresh',
+        critic: 'fresh',
+      };
+      const result = invalidateBuilder(state);
+      expect(result.architect).toBe('pending');
+      expect(result.builder).toBe('stale');
+    });
+
+    it('preserves failed builder', () => {
+      const state: PhaseState = {
+        architect: 'fresh',
+        builder: 'failed',
+        critic: 'fresh',
+      };
+      const result = invalidateBuilder(state);
+      expect(result.builder).toBe('failed');
+    });
+  });
+
+  // ── Phase success transitions ──
+
+  describe('architectSuccess', () => {
+    it('architect → fresh, builder → pending, critic → stale', () => {
+      const state: PhaseState = {
+        architect: 'running',
+        builder: 'stale',
+        critic: 'stale',
+      };
+      const result = architectSuccess(state);
+      expect(result).toEqual({
+        architect: 'fresh',
+        builder: 'pending',
+        critic: 'stale',
+      });
+    });
+
+    it('preserves failed builder', () => {
+      const state: PhaseState = {
+        architect: 'running',
+        builder: 'failed',
+        critic: 'stale',
+      };
+      const result = architectSuccess(state);
+      expect(result.builder).toBe('failed');
+    });
+  });
+
+  describe('builderSuccess', () => {
+    it('builder → fresh, critic → pending', () => {
+      const state: PhaseState = {
+        architect: 'fresh',
+        builder: 'running',
+        critic: 'stale',
+      };
+      const result = builderSuccess(state);
+      expect(result).toEqual({
+        architect: 'fresh',
+        builder: 'fresh',
+        critic: 'pending',
+      });
+    });
+  });
+
+  describe('criticSuccess', () => {
+    it('critic → fresh, meta fully fresh', () => {
+      const state: PhaseState = {
+        architect: 'fresh',
+        builder: 'fresh',
+        critic: 'running',
+      };
+      const result = criticSuccess(state);
+      expect(isFullyFresh(result)).toBe(true);
+    });
+  });
+
+  // ── Failure ──
+
+  describe('phaseFailed', () => {
+    it('running architect → failed, downstream unchanged', () => {
+      const state: PhaseState = {
+        architect: 'running',
+        builder: 'stale',
+        critic: 'stale',
+      };
+      const result = phaseFailed(state, 'architect');
+      expect(result.architect).toBe('failed');
+      expect(result.builder).toBe('stale');
+      expect(result.critic).toBe('stale');
+    });
+
+    it('running builder → failed, critic unchanged', () => {
+      const state: PhaseState = {
+        architect: 'fresh',
+        builder: 'running',
+        critic: 'stale',
+      };
+      const result = phaseFailed(state, 'builder');
+      expect(result.builder).toBe('failed');
+      expect(result.critic).toBe('stale');
+    });
+
+    it('running critic → failed, upstream unchanged', () => {
+      const state: PhaseState = {
+        architect: 'fresh',
+        builder: 'fresh',
+        critic: 'running',
+      };
+      const result = phaseFailed(state, 'critic');
+      expect(result.architect).toBe('fresh');
+      expect(result.builder).toBe('fresh');
+      expect(result.critic).toBe('failed');
+    });
+  });
+
+  // ── Surgical retry ──
+
+  describe('retryPhase', () => {
+    it('failed → pending', () => {
+      const state: PhaseState = {
+        architect: 'fresh',
+        builder: 'failed',
+        critic: 'stale',
+      };
+      const result = retryPhase(state, 'builder');
+      expect(result.builder).toBe('pending');
+    });
+
+    it('no-op if not failed', () => {
+      const state: PhaseState = {
+        architect: 'fresh',
+        builder: 'fresh',
+        critic: 'fresh',
+      };
+      const result = retryPhase(state, 'builder');
+      expect(result).toBe(state);
+    });
+
+    it('critic retry: pending', () => {
+      const state: PhaseState = {
+        architect: 'fresh',
+        builder: 'fresh',
+        critic: 'failed',
+      };
+      const result = retryPhase(state, 'critic');
+      expect(result.critic).toBe('pending');
+    });
+  });
+
+  // ── Running ──
+
+  describe('phaseRunning', () => {
+    it('marks phase as running', () => {
+      const state: PhaseState = {
+        architect: 'fresh',
+        builder: 'pending',
+        critic: 'stale',
+      };
+      const result = phaseRunning(state, 'builder');
+      expect(result.builder).toBe('running');
+    });
+  });
+
+  // ── Query helpers ──
+
+  describe('getOwedPhase', () => {
+    it('returns null for fully fresh', () => {
+      expect(getOwedPhase(freshPhaseState())).toBeNull();
+    });
+
+    it('returns architect when architect is not fresh', () => {
+      expect(
+        getOwedPhase({
+          architect: 'pending',
+          builder: 'stale',
+          critic: 'stale',
+        }),
+      ).toBe('architect');
+    });
+
+    it('returns builder when architect is fresh', () => {
+      expect(
+        getOwedPhase({
+          architect: 'fresh',
+          builder: 'pending',
+          critic: 'stale',
+        }),
+      ).toBe('builder');
+    });
+
+    it('returns critic when architect+builder fresh', () => {
+      expect(
+        getOwedPhase({
+          architect: 'fresh',
+          builder: 'fresh',
+          critic: 'pending',
+        }),
+      ).toBe('critic');
+    });
+
+    it('returns failed phase', () => {
+      expect(
+        getOwedPhase({
+          architect: 'fresh',
+          builder: 'fresh',
+          critic: 'failed',
+        }),
+      ).toBe('critic');
+    });
+  });
+
+  describe('getPriorityBand', () => {
+    it('critic = 1', () => {
+      expect(
+        getPriorityBand({
+          architect: 'fresh',
+          builder: 'fresh',
+          critic: 'pending',
+        }),
+      ).toBe(1);
+    });
+    it('builder = 2', () => {
+      expect(
+        getPriorityBand({
+          architect: 'fresh',
+          builder: 'pending',
+          critic: 'stale',
+        }),
+      ).toBe(2);
+    });
+    it('architect = 3', () => {
+      expect(
+        getPriorityBand({
+          architect: 'pending',
+          builder: 'stale',
+          critic: 'stale',
+        }),
+      ).toBe(3);
+    });
+    it('fully fresh = null', () => {
+      expect(getPriorityBand(freshPhaseState())).toBeNull();
+    });
+  });
+
+  describe('isFullyFresh', () => {
+    it('true for all fresh', () => {
+      expect(isFullyFresh(freshPhaseState())).toBe(true);
+    });
+    it('false if any non-fresh', () => {
+      expect(
+        isFullyFresh({
+          architect: 'fresh',
+          builder: 'fresh',
+          critic: 'pending',
+        }),
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/service/src/phaseState/phaseTransitions.test.ts
+++ b/packages/service/src/phaseState/phaseTransitions.test.ts
@@ -15,6 +15,7 @@ import {
   isFullyFresh,
   phaseFailed,
   phaseRunning,
+  retryAllFailed,
   retryPhase,
 } from './phaseTransitions.js';
 
@@ -197,6 +198,17 @@ describe('phaseTransitions', () => {
         critic: 'pending',
       });
     });
+
+    it('preserves failed critic', () => {
+      const state: PhaseState = {
+        architect: 'fresh',
+        builder: 'running',
+        critic: 'failed',
+      };
+      const result = builderSuccess(state);
+      expect(result.builder).toBe('fresh');
+      expect(result.critic).toBe('failed');
+    });
   });
 
   describe('criticSuccess', () => {
@@ -281,6 +293,53 @@ describe('phaseTransitions', () => {
       };
       const result = retryPhase(state, 'critic');
       expect(result.critic).toBe('pending');
+    });
+  });
+
+  describe('retryAllFailed', () => {
+    it('no-op when no phases are failed', () => {
+      const state: PhaseState = {
+        architect: 'fresh',
+        builder: 'pending',
+        critic: 'stale',
+      };
+      const result = retryAllFailed(state);
+      expect(result).toEqual(state);
+    });
+
+    it('retries single failed phase', () => {
+      const state: PhaseState = {
+        architect: 'fresh',
+        builder: 'failed',
+        critic: 'stale',
+      };
+      const result = retryAllFailed(state);
+      expect(result.builder).toBe('pending');
+      expect(result.critic).toBe('stale');
+    });
+
+    it('retries multiple failed phases — first becomes pending, rest stay stale', () => {
+      const state: PhaseState = {
+        architect: 'failed',
+        builder: 'failed',
+        critic: 'failed',
+      };
+      const result = retryAllFailed(state);
+      // enforceInvariant promotes only the first non-fresh to pending
+      expect(result.architect).toBe('pending');
+      expect(result.builder).toBe('stale');
+      expect(result.critic).toBe('stale');
+    });
+
+    it('retries two downstream failed phases', () => {
+      const state: PhaseState = {
+        architect: 'fresh',
+        builder: 'failed',
+        critic: 'failed',
+      };
+      const result = retryAllFailed(state);
+      expect(result.builder).toBe('pending');
+      expect(result.critic).toBe('stale');
     });
   });
 

--- a/packages/service/src/phaseState/phaseTransitions.ts
+++ b/packages/service/src/phaseState/phaseTransitions.ts
@@ -1,0 +1,219 @@
+/**
+ * Pure phase-state transition functions.
+ *
+ * Implements every row of the §8 "Transitions and invalidation cascade" table.
+ * No I/O — pure functions over PhaseState and documented inputs.
+ *
+ * @module phaseState/phaseTransitions
+ */
+
+import type { PhaseState } from '../schema/meta.js';
+
+/**
+ * Create a fresh (fully-complete) phase state.
+ */
+export function freshPhaseState(): PhaseState {
+  return { architect: 'fresh', builder: 'fresh', critic: 'fresh' };
+}
+
+/**
+ * Create a phase state for a never-synthesized meta (all pending from architect).
+ */
+export function initialPhaseState(): PhaseState {
+  return { architect: 'pending', builder: 'stale', critic: 'stale' };
+}
+
+/**
+ * Enforce the per-meta invariant: at most one phase is pending or running,
+ * and it is the first non-fresh phase in pipeline order.
+ *
+ * Stale phases that become the first non-fresh phase are promoted to pending.
+ */
+export function enforceInvariant(state: PhaseState): PhaseState {
+  const result = { ...state };
+  let foundNonFresh = false;
+
+  for (const phase of ['architect', 'builder', 'critic'] as const) {
+    const s = result[phase];
+    if (s === 'fresh') continue;
+
+    if (!foundNonFresh) {
+      foundNonFresh = true;
+      // First non-fresh: if stale, promote to pending
+      if (s === 'stale') {
+        result[phase] = 'pending';
+      }
+      // pending, running, failed stay as-is
+    } else {
+      // Subsequent non-fresh: must not be pending or running
+      if (s === 'pending') {
+        result[phase] = 'stale';
+      }
+      // running in non-first position would be a bug, but don't mask it
+    }
+  }
+
+  return result;
+}
+
+// ── Invalidation cascades ──────────────────────────────────────────────
+
+/**
+ * Architect invalidated: architect → pending; builder, critic → stale.
+ * Triggers: _structureHash change, _steer change, _architect change,
+ * _crossRefs declaration change, _synthesisCount \>= architectEvery.
+ */
+export function invalidateArchitect(state: PhaseState): PhaseState {
+  return enforceInvariant({
+    architect: state.architect === 'failed' ? 'failed' : 'pending',
+    builder: state.builder === 'fresh' ? 'stale' : state.builder,
+    critic: state.critic === 'fresh' ? 'stale' : state.critic,
+  });
+}
+
+/**
+ * Builder invalidated (scope mtime or cross-ref _content change):
+ * builder → pending; critic → stale.
+ * Only applies when architect is fresh; otherwise, builder stays stale.
+ */
+export function invalidateBuilder(state: PhaseState): PhaseState {
+  if (state.architect !== 'fresh') {
+    // Architect is not fresh — builder stays stale (or whatever it is)
+    return enforceInvariant({
+      ...state,
+      builder:
+        state.builder === 'fresh' || state.builder === 'stale'
+          ? 'stale'
+          : state.builder,
+      critic: state.critic === 'fresh' ? 'stale' : state.critic,
+    });
+  }
+
+  return enforceInvariant({
+    ...state,
+    builder: state.builder === 'failed' ? 'failed' : 'pending',
+    critic: state.critic === 'fresh' ? 'stale' : state.critic,
+  });
+}
+
+// ── Phase success transitions ──────────────────────────────────────────
+
+/**
+ * Architect completes successfully.
+ * architect → fresh; builder → pending; critic → stale.
+ */
+export function architectSuccess(state: PhaseState): PhaseState {
+  return enforceInvariant({
+    architect: 'fresh',
+    builder: state.builder === 'failed' ? 'failed' : 'pending',
+    critic: state.critic === 'fresh' ? 'stale' : state.critic,
+  });
+}
+
+/**
+ * Builder completes successfully.
+ * builder → fresh; critic → pending.
+ */
+export function builderSuccess(state: PhaseState): PhaseState {
+  return enforceInvariant({
+    ...state,
+    builder: 'fresh',
+    critic: state.critic === 'failed' ? 'failed' : 'pending',
+  });
+}
+
+/**
+ * Critic completes successfully.
+ * critic → fresh. Meta becomes fully fresh.
+ */
+export function criticSuccess(state: PhaseState): PhaseState {
+  return enforceInvariant({
+    ...state,
+    critic: 'fresh',
+  });
+}
+
+// ── Failure transition ─────────────────────────────────────────────────
+
+/**
+ * A phase fails (error, timeout, or abort).
+ * Target phase → failed; upstream and downstream unchanged.
+ */
+export function phaseFailed(
+  state: PhaseState,
+  phase: 'architect' | 'builder' | 'critic',
+): PhaseState {
+  return enforceInvariant({
+    ...state,
+    [phase]: 'failed',
+  });
+}
+
+// ── Surgical retry ─────────────────────────────────────────────────────
+
+/**
+ * Retry a failed phase: failed → pending.
+ * Only valid when the phase is currently failed.
+ */
+export function retryPhase(
+  state: PhaseState,
+  phase: 'architect' | 'builder' | 'critic',
+): PhaseState {
+  if (state[phase] !== 'failed') return state;
+  return enforceInvariant({
+    ...state,
+    [phase]: 'pending',
+  });
+}
+
+// ── Running transition ─────────────────────────────────────────────────
+
+/**
+ * Mark a phase as running (scheduler picks it).
+ */
+export function phaseRunning(
+  state: PhaseState,
+  phase: 'architect' | 'builder' | 'critic',
+): PhaseState {
+  return {
+    ...state,
+    [phase]: 'running',
+  };
+}
+
+// ── Query helpers ──────────────────────────────────────────────────────
+
+/**
+ * Get the owed phase: first non-fresh phase in pipeline order, or null.
+ */
+export function getOwedPhase(
+  state: PhaseState,
+): 'architect' | 'builder' | 'critic' | null {
+  for (const phase of ['architect', 'builder', 'critic'] as const) {
+    if (state[phase] !== 'fresh') return phase;
+  }
+  return null;
+}
+
+/**
+ * Check if a meta is fully fresh (all phases fresh).
+ */
+export function isFullyFresh(state: PhaseState): boolean {
+  return (
+    state.architect === 'fresh' &&
+    state.builder === 'fresh' &&
+    state.critic === 'fresh'
+  );
+}
+
+/**
+ * Get the scheduler priority band for a meta's owed phase.
+ * 1 = critic (highest), 2 = builder, 3 = architect, null = fully fresh.
+ */
+export function getPriorityBand(state: PhaseState): 1 | 2 | 3 | null {
+  const owed = getOwedPhase(state);
+  if (!owed) return null;
+  if (owed === 'critic') return 1;
+  if (owed === 'builder') return 2;
+  return 3;
+}

--- a/packages/service/src/phaseState/phaseTransitions.ts
+++ b/packages/service/src/phaseState/phaseTransitions.ts
@@ -166,6 +166,20 @@ export function retryPhase(
   });
 }
 
+/**
+ * Retry all failed phases: each failed phase → pending.
+ * Used by scheduler ticks and queue reads to auto-promote failed phases.
+ */
+export function retryAllFailed(state: PhaseState): PhaseState {
+  let result = state;
+  for (const phase of ['architect', 'builder', 'critic'] as const) {
+    if (result[phase] === 'failed') {
+      result = retryPhase(result, phase);
+    }
+  }
+  return result;
+}
+
 // ── Running transition ─────────────────────────────────────────────────
 
 /**

--- a/packages/service/src/queue/index.ts
+++ b/packages/service/src/queue/index.ts
@@ -269,6 +269,17 @@ export class SynthesisQueue {
     return index === -1 ? null : index;
   }
 
+  /** Dequeue the next item: overrides first, then legacy queue. */
+  private nextItem():
+    | { path: string; source: 'override' | 'legacy' }
+    | undefined {
+    const override = this.dequeueOverride();
+    if (override) return { path: override.path, source: 'override' };
+    const item = this.dequeue();
+    if (item) return { path: item.path, source: 'legacy' };
+    return undefined;
+  }
+
   /** Return a snapshot of queue state for the /status endpoint. */
   getState(): QueueState {
     return {
@@ -289,8 +300,9 @@ export class SynthesisQueue {
   }
 
   /**
-   * Process queued items one at a time until the queue is empty.
+   * Process queued items one at a time until all queues are empty.
    *
+   * Override entries are processed first (FIFO), then legacy queue items.
    * Re-entry is prevented: if already processing, the call returns
    * immediately. Errors are logged and do not block subsequent items.
    *
@@ -304,15 +316,15 @@ export class SynthesisQueue {
     this.processing = true;
 
     try {
-      let item = this.dequeue();
-      while (item) {
+      let next = this.nextItem();
+      while (next) {
         try {
-          await synthesizeFn(item.path);
+          await synthesizeFn(next.path);
         } catch (err) {
-          this.logger.error({ path: item.path, err }, 'Synthesis failed');
+          this.logger.error({ path: next.path, err }, 'Synthesis failed');
         }
-        this.complete();
-        item = this.dequeue();
+        if (next.source === 'legacy') this.complete();
+        next = this.nextItem();
       }
     } finally {
       this.processing = false;

--- a/packages/service/src/queue/index.ts
+++ b/packages/service/src/queue/index.ts
@@ -323,10 +323,12 @@ export class SynthesisQueue {
         } catch (err) {
           this.logger.error({ path: next.path, err }, 'Synthesis failed');
         }
+        this.clearCurrentPhase();
         if (next.source === 'legacy') this.complete();
         next = this.nextItem();
       }
     } finally {
+      this.clearCurrentPhase();
       this.processing = false;
     }
   }

--- a/packages/service/src/queue/index.ts
+++ b/packages/service/src/queue/index.ts
@@ -1,20 +1,39 @@
 /**
- * Single-threaded synthesis queue with priority support and deduplication.
+ * Hybrid 3-layer synthesis queue.
  *
- * The scheduler enqueues the stalest candidate each tick. HTTP-triggered
- * synthesis requests get priority (inserted at front). A path appears at
- * most once in the queue; re-triggering returns the current position.
+ * Layer 1: Current — the single item currently executing (at most one).
+ * Layer 2: Overrides — items manually enqueued via POST /synthesize with path.
+ *          FIFO among overrides, ahead of automatic candidates.
+ * Layer 3: Automatic — computed on read, not persisted. All metas with a
+ *          pending phase, ranked by scheduler priority.
+ *
+ * Legacy: `pending` array is the union of overrides + automatic.
  *
  * @module queue
  */
 
 import type { Logger } from 'pino';
 
+import type { PhaseName } from '../schema/meta.js';
+
 /** A queued synthesis work item. */
 export interface QueueItem {
   path: string;
   priority: boolean;
   enqueuedAt: string;
+}
+
+/** An override entry in the explicit queue layer. */
+export interface OverrideEntry {
+  path: string;
+  enqueuedAt: string;
+}
+
+/** The currently executing item with phase info. */
+export interface CurrentItem {
+  path: string;
+  phase: PhaseName;
+  startedAt: string;
 }
 
 /** Result returned by {@link SynthesisQueue.enqueue}. */
@@ -32,34 +51,116 @@ export interface QueueState {
 const DEPTH_WARNING_THRESHOLD = 3;
 
 /**
- * Single-threaded synthesis queue.
+ * Hybrid 3-layer synthesis queue.
  *
- * Only one synthesis runs at a time. Priority items are inserted at the
- * front of the queue. Duplicate paths are rejected with their current
- * position returned.
+ * Only one synthesis runs at a time. Override items (explicit triggers)
+ * take priority over automatic candidates.
  */
 export class SynthesisQueue {
+  /** Legacy queue (used by processQueue for backward compat). */
   private queue: QueueItem[] = [];
   private currentItem: QueueItem | null = null;
   private processing = false;
   private logger: Logger;
   private onEnqueueCallback: (() => void) | null = null;
 
-  /**
-   * Create a new SynthesisQueue.
-   *
-   * @param logger - Pino logger instance.
-   */
+  /** Explicit override entries (3-layer model). */
+  private overrideEntries: OverrideEntry[] = [];
+  /** Currently executing item with phase info (3-layer model). */
+  private currentPhaseItem: CurrentItem | null = null;
+
   constructor(logger: Logger) {
     this.logger = logger;
   }
 
-  /**
-   * Set a callback to invoke when a new (non-duplicate) item is enqueued.
-   */
+  /** Set a callback to invoke when a new (non-duplicate) item is enqueued. */
   onEnqueue(callback: () => void): void {
     this.onEnqueueCallback = callback;
   }
+
+  // ── Override layer (3-layer model) ─────────────────────────────────
+
+  /**
+   * Add an explicit override entry (from POST /synthesize with path).
+   * Deduped by path. Returns position and whether already queued.
+   */
+  enqueueOverride(path: string): EnqueueResult {
+    // Check if currently executing
+    if (
+      this.currentPhaseItem?.path === path ||
+      this.currentItem?.path === path
+    ) {
+      return { position: 0, alreadyQueued: true };
+    }
+
+    // Check if already in overrides
+    const existing = this.overrideEntries.findIndex((e) => e.path === path);
+    if (existing !== -1) {
+      return { position: existing, alreadyQueued: true };
+    }
+
+    this.overrideEntries.push({
+      path,
+      enqueuedAt: new Date().toISOString(),
+    });
+
+    const position = this.overrideEntries.length - 1;
+
+    if (this.overrideEntries.length > DEPTH_WARNING_THRESHOLD) {
+      this.logger.warn(
+        { depth: this.overrideEntries.length },
+        'Override queue depth exceeds threshold',
+      );
+    }
+
+    this.onEnqueueCallback?.();
+    return { position, alreadyQueued: false };
+  }
+
+  /** Dequeue the next override entry, or undefined if empty. */
+  dequeueOverride(): OverrideEntry | undefined {
+    return this.overrideEntries.shift();
+  }
+
+  /** Get all override entries (shallow copy). */
+  get overrides(): OverrideEntry[] {
+    return [...this.overrideEntries];
+  }
+
+  /** Clear all override entries. Returns count removed. */
+  clearOverrides(): number {
+    const count = this.overrideEntries.length;
+    this.overrideEntries = [];
+    return count;
+  }
+
+  /** Check if a path is in the override layer. */
+  hasOverride(path: string): boolean {
+    return this.overrideEntries.some((e) => e.path === path);
+  }
+
+  // ── Current-item tracking (3-layer model) ──────────────────────────
+
+  /** Set the currently executing phase item. */
+  setCurrentPhase(path: string, phase: PhaseName): void {
+    this.currentPhaseItem = {
+      path,
+      phase,
+      startedAt: new Date().toISOString(),
+    };
+  }
+
+  /** Clear the current phase item. */
+  clearCurrentPhase(): void {
+    this.currentPhaseItem = null;
+  }
+
+  /** The currently executing phase item, or null. */
+  get currentPhase(): CurrentItem | null {
+    return this.currentPhaseItem;
+  }
+
+  // ── Legacy queue interface (preserved for backward compat) ─────────
 
   /**
    * Add a path to the synthesis queue.
@@ -69,12 +170,10 @@ export class SynthesisQueue {
    * @returns Position and whether the path was already queued.
    */
   enqueue(path: string, priority = false): EnqueueResult {
-    // Check if currently being synthesized.
     if (this.currentItem?.path === path) {
       return { position: 0, alreadyQueued: true };
     }
 
-    // Check if already in queue.
     const existingIndex = this.queue.findIndex((item) => item.path === path);
     if (existingIndex !== -1) {
       return { position: existingIndex, alreadyQueued: true };
@@ -104,11 +203,7 @@ export class SynthesisQueue {
     return { position, alreadyQueued: false };
   }
 
-  /**
-   * Remove and return the next item from the queue.
-   *
-   * @returns The next QueueItem, or undefined if the queue is empty.
-   */
+  /** Remove and return the next item from the queue. */
   dequeue(): QueueItem | undefined {
     const item = this.queue.shift();
     if (item) {
@@ -144,7 +239,6 @@ export class SynthesisQueue {
 
   /**
    * Remove all pending items from the queue.
-   *
    * Does not affect the currently-running item.
    *
    * @returns The number of items removed.
@@ -155,41 +249,42 @@ export class SynthesisQueue {
     return count;
   }
 
-  /**
-   * Check whether a path is in the queue or currently being synthesized.
-   *
-   * @param path - Meta path to look up.
-   * @returns True if the path is queued or currently running.
-   */
+  /** Check whether a path is in the queue or currently being synthesized. */
   has(path: string): boolean {
     if (this.currentItem?.path === path) return true;
-    return this.queue.some((item) => item.path === path);
+    if (this.currentPhaseItem?.path === path) return true;
+    return (
+      this.queue.some((item) => item.path === path) ||
+      this.overrideEntries.some((e) => e.path === path)
+    );
   }
 
-  /**
-   * Get the 0-indexed position of a path in the queue.
-   *
-   * @param path - Meta path to look up.
-   * @returns Position index, or null if not found in the queue.
-   */
+  /** Get the 0-indexed position of a path in the queue. */
   getPosition(path: string): number | null {
+    // Check overrides first
+    const overrideIdx = this.overrideEntries.findIndex((e) => e.path === path);
+    if (overrideIdx !== -1) return overrideIdx;
+
     const index = this.queue.findIndex((item) => item.path === path);
     return index === -1 ? null : index;
   }
 
-  /**
-   * Return a snapshot of queue state for the /status endpoint.
-   *
-   * @returns Queue depth and item list.
-   */
+  /** Return a snapshot of queue state for the /status endpoint. */
   getState(): QueueState {
     return {
-      depth: this.queue.length,
-      items: this.queue.map((item) => ({
-        path: item.path,
-        priority: item.priority,
-        enqueuedAt: item.enqueuedAt,
-      })),
+      depth: this.queue.length + this.overrideEntries.length,
+      items: [
+        ...this.overrideEntries.map((e) => ({
+          path: e.path,
+          priority: true,
+          enqueuedAt: e.enqueuedAt,
+        })),
+        ...this.queue.map((item) => ({
+          path: item.path,
+          priority: item.priority,
+          enqueuedAt: item.enqueuedAt,
+        })),
+      ],
     };
   }
 

--- a/packages/service/src/queue/queue.test.ts
+++ b/packages/service/src/queue/queue.test.ts
@@ -205,4 +205,119 @@ describe('SynthesisQueue', () => {
     expect(queue.getPosition('/meta/b')).toBe(1);
     expect(queue.getPosition('/meta/c')).toBeNull();
   });
+
+  // ── 3-Layer Model (Override + CurrentPhase) ─────────────────────────
+
+  describe('override layer', () => {
+    it('enqueueOverride adds an entry', () => {
+      const result = queue.enqueueOverride('/meta/x');
+      expect(result.alreadyQueued).toBe(false);
+      expect(result.position).toBe(0);
+      expect(queue.overrides).toHaveLength(1);
+      expect(queue.overrides[0]?.path).toBe('/meta/x');
+    });
+
+    it('enqueueOverride deduplicates by path', () => {
+      queue.enqueueOverride('/meta/x');
+      const result = queue.enqueueOverride('/meta/x');
+      expect(result.alreadyQueued).toBe(true);
+      expect(result.position).toBe(0);
+      expect(queue.overrides).toHaveLength(1);
+    });
+
+    it('enqueueOverride detects current phase item', () => {
+      queue.setCurrentPhase('/meta/x', 'builder');
+      const result = queue.enqueueOverride('/meta/x');
+      expect(result.alreadyQueued).toBe(true);
+      expect(result.position).toBe(0);
+    });
+
+    it('enqueueOverride detects legacy current item', () => {
+      queue.enqueue('/meta/x');
+      queue.dequeue();
+      const result = queue.enqueueOverride('/meta/x');
+      expect(result.alreadyQueued).toBe(true);
+    });
+
+    it('dequeueOverride returns entries in FIFO order', () => {
+      queue.enqueueOverride('/meta/a');
+      queue.enqueueOverride('/meta/b');
+      queue.enqueueOverride('/meta/c');
+
+      expect(queue.dequeueOverride()?.path).toBe('/meta/a');
+      expect(queue.dequeueOverride()?.path).toBe('/meta/b');
+      expect(queue.dequeueOverride()?.path).toBe('/meta/c');
+      expect(queue.dequeueOverride()).toBeUndefined();
+    });
+
+    it('clearOverrides removes all override entries', () => {
+      queue.enqueueOverride('/meta/a');
+      queue.enqueueOverride('/meta/b');
+      const count = queue.clearOverrides();
+      expect(count).toBe(2);
+      expect(queue.overrides).toHaveLength(0);
+    });
+
+    it('hasOverride checks override layer', () => {
+      queue.enqueueOverride('/meta/a');
+      expect(queue.hasOverride('/meta/a')).toBe(true);
+      expect(queue.hasOverride('/meta/b')).toBe(false);
+    });
+
+    it('has checks override layer', () => {
+      queue.enqueueOverride('/meta/a');
+      expect(queue.has('/meta/a')).toBe(true);
+    });
+
+    it('getPosition checks overrides first', () => {
+      queue.enqueueOverride('/meta/a');
+      queue.enqueue('/meta/b');
+      expect(queue.getPosition('/meta/a')).toBe(0);
+      expect(queue.getPosition('/meta/b')).toBe(0);
+    });
+
+    it('getState includes overrides in depth and items', () => {
+      queue.enqueueOverride('/meta/a');
+      queue.enqueue('/meta/b');
+      const state = queue.getState();
+      expect(state.depth).toBe(2);
+      expect(state.items).toHaveLength(2);
+      expect(state.items[0]?.path).toBe('/meta/a');
+      expect(state.items[0]?.priority).toBe(true);
+    });
+
+    it('warns when override depth exceeds threshold', () => {
+      queue.enqueueOverride('/meta/a');
+      queue.enqueueOverride('/meta/b');
+      queue.enqueueOverride('/meta/c');
+      expect(logger.warn).not.toHaveBeenCalled();
+
+      queue.enqueueOverride('/meta/d');
+      expect(logger.warn).toHaveBeenCalledWith(
+        { depth: 4 },
+        'Override queue depth exceeds threshold',
+      );
+    });
+  });
+
+  describe('currentPhase tracking', () => {
+    it('setCurrentPhase / clearCurrentPhase', () => {
+      expect(queue.currentPhase).toBeNull();
+
+      queue.setCurrentPhase('/meta/x', 'architect');
+      expect(queue.currentPhase).not.toBeNull();
+      expect(queue.currentPhase?.path).toBe('/meta/x');
+      expect(queue.currentPhase?.phase).toBe('architect');
+      expect(queue.currentPhase?.startedAt).toBeDefined();
+
+      queue.clearCurrentPhase();
+      expect(queue.currentPhase).toBeNull();
+    });
+
+    it('has detects currentPhase item', () => {
+      queue.setCurrentPhase('/meta/x', 'critic');
+      expect(queue.has('/meta/x')).toBe(true);
+      expect(queue.has('/meta/y')).toBe(false);
+    });
+  });
 });

--- a/packages/service/src/queue/queue.test.ts
+++ b/packages/service/src/queue/queue.test.ts
@@ -308,7 +308,8 @@ describe('SynthesisQueue', () => {
       expect(queue.currentPhase).not.toBeNull();
       expect(queue.currentPhase?.path).toBe('/meta/x');
       expect(queue.currentPhase?.phase).toBe('architect');
-      expect(queue.currentPhase?.startedAt).toBeDefined();
+      expect(typeof queue.currentPhase?.startedAt).toBe('string');
+      expect(new Date(queue.currentPhase!.startedAt).getTime()).not.toBeNaN();
 
       queue.clearCurrentPhase();
       expect(queue.currentPhase).toBeNull();
@@ -318,6 +319,63 @@ describe('SynthesisQueue', () => {
       queue.setCurrentPhase('/meta/x', 'critic');
       expect(queue.has('/meta/x')).toBe(true);
       expect(queue.has('/meta/y')).toBe(false);
+    });
+  });
+
+  describe('clear', () => {
+    it('removes all legacy queue items and returns count', () => {
+      queue.enqueue('/meta/a');
+      queue.enqueue('/meta/b');
+      queue.enqueue('/meta/c');
+      const count = queue.clear();
+      expect(count).toBe(3);
+      expect(queue.depth).toBe(0);
+      expect(queue.items).toEqual([]);
+    });
+
+    it('does not affect currently-running item', () => {
+      queue.enqueue('/meta/a');
+      queue.enqueue('/meta/b');
+      queue.dequeue(); // /meta/a becomes current
+      queue.clear();
+      expect(queue.current?.path).toBe('/meta/a');
+      expect(queue.depth).toBe(0);
+    });
+
+    it('returns 0 when queue is already empty', () => {
+      expect(queue.clear()).toBe(0);
+    });
+  });
+
+  describe('onEnqueue callback', () => {
+    it('fires on new legacy enqueue', () => {
+      const cb = vi.fn();
+      queue.onEnqueue(cb);
+      queue.enqueue('/meta/a');
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires on new override enqueue', () => {
+      const cb = vi.fn();
+      queue.onEnqueue(cb);
+      queue.enqueueOverride('/meta/a');
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires on duplicate legacy enqueue (callback still called)', () => {
+      const cb = vi.fn();
+      queue.onEnqueue(cb);
+      queue.enqueue('/meta/a');
+      queue.enqueue('/meta/a'); // duplicate — callback not called
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires on duplicate override enqueue (callback not called)', () => {
+      const cb = vi.fn();
+      queue.onEnqueue(cb);
+      queue.enqueueOverride('/meta/a');
+      queue.enqueueOverride('/meta/a'); // duplicate — callback not called
+      expect(cb).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/service/src/routes/__testUtils.ts
+++ b/packages/service/src/routes/__testUtils.ts
@@ -1,0 +1,135 @@
+/**
+ * Shared test utilities for route test files.
+ *
+ * Provides factories for RouteDeps, logger mocks, watcher mocks, and
+ * filesystem-based meta fixtures. Eliminates duplication across 9+ test files.
+ *
+ * @module routes/__testUtils
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { Logger } from 'pino';
+import { vi } from 'vitest';
+
+import type { WatcherClient } from '../interfaces/index.js';
+import { SynthesisQueue } from '../queue/index.js';
+import type { RouteDeps, ServiceStats } from './index.js';
+
+/** Default service config for tests. */
+const DEFAULT_TEST_CONFIG: RouteDeps['config'] = {
+  watcherUrl: 'http://localhost:3456',
+  gatewayUrl: 'http://127.0.0.1:18789',
+  depthWeight: 0.5,
+  architectEvery: 10,
+  maxArchive: 20,
+  maxLines: 500,
+  architectTimeout: 120,
+  builderTimeout: 600,
+  criticTimeout: 300,
+  thinking: 'low',
+  defaultArchitect: 'arch',
+  defaultCritic: 'crit',
+  skipUnchanged: true,
+  metaProperty: {},
+  metaArchiveProperty: {},
+  port: 1938,
+  schedule: '*/30 * * * *',
+  watcherHealthIntervalMs: 60000,
+  logging: { level: 'info' },
+  autoSeed: [],
+};
+
+/** Default service stats for tests. */
+const DEFAULT_TEST_STATS: ServiceStats = {
+  totalSyntheses: 0,
+  totalTokens: 0,
+  totalErrors: 0,
+  lastCycleDurationMs: null,
+  lastCycleAt: null,
+};
+
+/** Create a mock pino logger with all standard methods. */
+export function makeTestLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+    child: vi.fn(),
+    level: 'info',
+  } as unknown as Logger;
+}
+
+/** Overrides for makeTestDeps — config can be partially specified. */
+type TestDepsOverrides = Omit<Partial<RouteDeps>, 'config'> & {
+  config?: Partial<RouteDeps['config']>;
+};
+
+/** Create a RouteDeps object with sensible test defaults. */
+export function makeTestDeps(overrides: TestDepsOverrides = {}): RouteDeps {
+  const { config: configOverrides, ...rest } = overrides;
+  return {
+    config: {
+      ...DEFAULT_TEST_CONFIG,
+      ...configOverrides,
+    } as RouteDeps['config'],
+    logger: rest.logger ?? makeTestLogger(),
+    queue: rest.queue ?? new SynthesisQueue(makeTestLogger()),
+    watcher: rest.watcher ?? ({} as RouteDeps['watcher']),
+    scheduler: rest.scheduler ?? null,
+    stats: rest.stats ?? { ...DEFAULT_TEST_STATS },
+    ...rest,
+  };
+}
+
+/**
+ * Create a mock WatcherClient that resolves walk() with given paths.
+ *
+ * @param metaJsonPaths - Paths to return from walk().
+ * @param scan - Optional custom scan mock (defaults to empty results).
+ */
+export function makeTestWatcher(
+  metaJsonPaths: string[] = [],
+  scan = vi.fn().mockResolvedValue({ points: [], cursor: null }),
+): WatcherClient {
+  return {
+    walk: vi.fn().mockResolvedValue(metaJsonPaths),
+    registerRules: vi.fn().mockResolvedValue(undefined),
+    scan,
+  };
+}
+
+/** Create a mock WatcherClient that rejects walk() calls. */
+export function makeFailingTestWatcher(): WatcherClient {
+  return {
+    walk: vi.fn().mockRejectedValue(new Error('connection refused')),
+    registerRules: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/**
+ * Create a .meta/meta.json on disk and return the meta.json path.
+ *
+ * @param ownerDir - The owner directory to create .meta/ in.
+ * @param meta - Additional meta fields (merged with default _id).
+ * @returns The path to the created meta.json file.
+ */
+export function createTestMeta(
+  ownerDir: string,
+  meta: Record<string, unknown> = {},
+): string {
+  const metaDir = join(ownerDir, '.meta');
+  mkdirSync(metaDir, { recursive: true });
+  writeFileSync(
+    join(metaDir, 'meta.json'),
+    JSON.stringify({
+      _id: '550e8400-e29b-41d4-a716-446655440099',
+      ...meta,
+    }),
+  );
+  return join(metaDir, 'meta.json');
+}

--- a/packages/service/src/routes/config.test.ts
+++ b/packages/service/src/routes/config.test.ts
@@ -3,58 +3,20 @@
  */
 
 import Fastify, { type FastifyInstance } from 'fastify';
-import type { Logger } from 'pino';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { makeTestDeps } from './__testUtils.js';
 import { registerConfigRoute } from './config.js';
-import type { RouteDeps } from './index.js';
-
-function makeDeps(overrides: Partial<RouteDeps> = {}): RouteDeps {
-  return {
-    config: {
-      watcherUrl: 'http://localhost:3456',
-      gatewayUrl: 'http://127.0.0.1:18789',
-      gatewayApiKey: 'secret-key',
-      depthWeight: 0.5,
-      architectEvery: 10,
-      maxArchive: 20,
-      maxLines: 500,
-      architectTimeout: 120,
-      builderTimeout: 600,
-      criticTimeout: 300,
-      thinking: 'low',
-      defaultArchitect: 'arch',
-      defaultCritic: 'crit',
-      skipUnchanged: true,
-      metaProperty: {},
-      metaArchiveProperty: {},
-      port: 1938,
-      schedule: '*/30 * * * *',
-      watcherHealthIntervalMs: 60000,
-      logging: { level: 'info' },
-      autoSeed: [],
-    },
-    logger: { warn: vi.fn(), error: vi.fn() } as unknown as Logger,
-    queue: {} as RouteDeps['queue'],
-    watcher: {} as RouteDeps['watcher'],
-    scheduler: null,
-    stats: {
-      totalSyntheses: 0,
-      totalTokens: 0,
-      totalErrors: 0,
-      lastCycleDurationMs: null,
-      lastCycleAt: null,
-    },
-    ...overrides,
-  };
-}
 
 describe('GET /config', () => {
   let app: FastifyInstance;
 
   beforeEach(async () => {
     app = Fastify();
-    registerConfigRoute(app, makeDeps());
+    registerConfigRoute(
+      app,
+      makeTestDeps({ config: { gatewayApiKey: 'secret-key' } }),
+    );
     await app.ready();
   });
 

--- a/packages/service/src/routes/index.ts
+++ b/packages/service/src/routes/index.ts
@@ -33,6 +33,18 @@ export interface ServiceStats {
   lastCycleAt: string | null;
 }
 
+/**
+ * Large generated fields excluded from detail/update response projections.
+ * Shared between metas detail and metasUpdate routes.
+ */
+export const DEFAULT_EXCLUDE_FIELDS = new Set([
+  '_architect',
+  '_builder',
+  '_critic',
+  '_content',
+  '_feedback',
+]);
+
 /** Dependencies injected into route handlers. */
 export interface RouteDeps {
   config: ServiceConfig;

--- a/packages/service/src/routes/metas.test.ts
+++ b/packages/service/src/routes/metas.test.ts
@@ -331,6 +331,8 @@ describe('GET /metas — list with filters', () => {
       'architectTokens',
       'builderTokens',
       'criticTokens',
+      'phaseState',
+      'owedPhase',
     ];
     expect(Object.keys(body.metas[0]).sort()).toEqual(expectedKeys.sort());
   });

--- a/packages/service/src/routes/metas.test.ts
+++ b/packages/service/src/routes/metas.test.ts
@@ -12,68 +12,25 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import Fastify, { type FastifyInstance } from 'fastify';
-import type { Logger } from 'pino';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { WatcherClient } from '../interfaces/index.js';
 import { normalizePath } from '../normalizePath.js';
+import {
+  createTestMeta,
+  makeTestDeps,
+  makeTestWatcher,
+} from './__testUtils.js';
 import type { RouteDeps } from './index.js';
 import { registerMetasRoutes } from './metas.js';
 
 const testRoot = join(tmpdir(), `jeeves-meta-metas-${Date.now().toString()}`);
 
 function makeDeps(overrides: Partial<RouteDeps> = {}): RouteDeps {
-  return {
-    config: {
-      watcherUrl: 'http://localhost:3456',
-      gatewayUrl: 'http://127.0.0.1:18789',
-      depthWeight: 1,
-      architectEvery: 10,
-      maxArchive: 20,
-      maxLines: 500,
-      architectTimeout: 120,
-      builderTimeout: 600,
-      criticTimeout: 300,
-      thinking: 'low',
-      defaultArchitect: 'arch',
-      defaultCritic: 'crit',
-      skipUnchanged: true,
-      metaProperty: {},
-      metaArchiveProperty: {},
-      port: 1938,
-      schedule: '*/30 * * * *',
-      watcherHealthIntervalMs: 60000,
-      logging: { level: 'info' },
-      autoSeed: [],
-    },
-    logger: {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    } as unknown as Logger,
-    queue: {} as RouteDeps['queue'],
-    watcher: {} as RouteDeps['watcher'],
-    scheduler: null,
-    stats: {
-      totalSyntheses: 0,
-      totalTokens: 0,
-      totalErrors: 0,
-      lastCycleDurationMs: null,
-      lastCycleAt: null,
-    },
-    ...overrides,
-  };
-}
-
-function makeWatcher(
-  metaJsonPaths: string[],
-  scan = vi.fn().mockResolvedValue({ points: [], cursor: null }),
-): WatcherClient {
-  return {
-    walk: vi.fn().mockResolvedValue(metaJsonPaths),
-    registerRules: vi.fn().mockResolvedValue(undefined),
-    scan,
-  };
+  const { config: configOverrides, ...rest } = overrides;
+  return makeTestDeps({
+    ...rest,
+    config: { depthWeight: 1, ...configOverrides },
+  });
 }
 
 describe('GET /metas — list with filters', () => {
@@ -83,22 +40,6 @@ describe('GET /metas — list with filters', () => {
     `jeeves-meta-metas-list-${Date.now().toString()}`,
   );
 
-  function createMeta(
-    ownerDir: string,
-    meta: Record<string, unknown> = {},
-  ): string {
-    const metaDir = join(ownerDir, '.meta');
-    mkdirSync(metaDir, { recursive: true });
-    writeFileSync(
-      join(metaDir, 'meta.json'),
-      JSON.stringify({
-        _id: '550e8400-e29b-41d4-a716-446655440099',
-        ...meta,
-      }),
-    );
-    return join(metaDir, 'meta.json');
-  }
-
   afterEach(async () => {
     await app.close();
     rmSync(listRoot, { recursive: true, force: true });
@@ -106,11 +47,11 @@ describe('GET /metas — list with filters', () => {
 
   it('returns summary + metas array', async () => {
     const ownerA = join(listRoot, 'projA');
-    const pathA = createMeta(ownerA, {
+    const pathA = createTestMeta(ownerA, {
       _id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
       _generatedAt: '2026-03-01T00:00:00Z',
     });
-    const watcher = makeWatcher([pathA]);
+    const watcher = makeTestWatcher([pathA]);
     const deps = makeDeps({
       watcher: watcher as unknown as RouteDeps['watcher'],
     });
@@ -134,15 +75,15 @@ describe('GET /metas — list with filters', () => {
   it('pathPrefix filter works', async () => {
     const ownerA = join(listRoot, 'alpha', 'projA');
     const ownerB = join(listRoot, 'beta', 'projB');
-    const pathA = createMeta(ownerA, {
+    const pathA = createTestMeta(ownerA, {
       _id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
       _generatedAt: '2026-03-01T00:00:00Z',
     });
-    const pathB = createMeta(ownerB, {
+    const pathB = createTestMeta(ownerB, {
       _id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
       _generatedAt: '2026-03-01T00:00:00Z',
     });
-    const watcher = makeWatcher([pathA, pathB]);
+    const watcher = makeTestWatcher([pathA, pathB]);
     const deps = makeDeps({
       watcher: watcher as unknown as RouteDeps['watcher'],
     });
@@ -167,11 +108,11 @@ describe('GET /metas — list with filters', () => {
   it('hasError filter works', async () => {
     const ownerOk = join(listRoot, 'ok');
     const ownerErr = join(listRoot, 'err');
-    const pathOk = createMeta(ownerOk, {
+    const pathOk = createTestMeta(ownerOk, {
       _id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
       _generatedAt: '2026-03-01T00:00:00Z',
     });
-    const pathErr = createMeta(ownerErr, {
+    const pathErr = createTestMeta(ownerErr, {
       _id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
       _generatedAt: '2026-03-01T00:00:00Z',
       _error: {
@@ -180,7 +121,7 @@ describe('GET /metas — list with filters', () => {
         timestamp: '2026-03-01T00:00:00Z',
       },
     });
-    const watcher = makeWatcher([pathOk, pathErr]);
+    const watcher = makeTestWatcher([pathOk, pathErr]);
     const deps = makeDeps({
       watcher: watcher as unknown as RouteDeps['watcher'],
     });
@@ -204,15 +145,15 @@ describe('GET /metas — list with filters', () => {
   it('staleHours filter works', async () => {
     const ownerRecent = join(listRoot, 'recent');
     const ownerOld = join(listRoot, 'old');
-    const pathRecent = createMeta(ownerRecent, {
+    const pathRecent = createTestMeta(ownerRecent, {
       _id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
       _generatedAt: new Date(Date.now() - 1800_000).toISOString(), // 30 min ago
     });
-    const pathOld = createMeta(ownerOld, {
+    const pathOld = createTestMeta(ownerOld, {
       _id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
       _generatedAt: new Date(Date.now() - 86400_000 * 3).toISOString(), // 3 days ago
     });
-    const watcher = makeWatcher([pathRecent, pathOld]);
+    const watcher = makeTestWatcher([pathRecent, pathOld]);
     const deps = makeDeps({
       watcher: watcher as unknown as RouteDeps['watcher'],
     });
@@ -236,14 +177,14 @@ describe('GET /metas — list with filters', () => {
   it('neverSynthesized=true returns only never-synthesized entries', async () => {
     const ownerSynth = join(listRoot, 'synth');
     const ownerFresh = join(listRoot, 'fresh');
-    const pathSynth = createMeta(ownerSynth, {
+    const pathSynth = createTestMeta(ownerSynth, {
       _id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
       _generatedAt: '2026-03-01T00:00:00Z',
     });
-    const pathFresh = createMeta(ownerFresh, {
+    const pathFresh = createTestMeta(ownerFresh, {
       _id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
     });
-    const watcher = makeWatcher([pathSynth, pathFresh]);
+    const watcher = makeTestWatcher([pathSynth, pathFresh]);
     const deps = makeDeps({
       watcher: watcher as unknown as RouteDeps['watcher'],
     });
@@ -278,12 +219,12 @@ describe('GET /metas — list with filters', () => {
 
   it('field projection with custom fields query param', async () => {
     const owner = join(listRoot, 'proj');
-    const path = createMeta(owner, {
+    const path = createTestMeta(owner, {
       _id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
       _generatedAt: '2026-03-01T00:00:00Z',
       _architectTokens: 100,
     });
-    const watcher = makeWatcher([path]);
+    const watcher = makeTestWatcher([path]);
     const deps = makeDeps({
       watcher: watcher as unknown as RouteDeps['watcher'],
     });
@@ -304,11 +245,11 @@ describe('GET /metas — list with filters', () => {
 
   it('default field projection matches expected keys', async () => {
     const owner = join(listRoot, 'defaults');
-    const path = createMeta(owner, {
+    const path = createTestMeta(owner, {
       _id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
       _generatedAt: '2026-03-01T00:00:00Z',
     });
-    const watcher = makeWatcher([path]);
+    const watcher = makeTestWatcher([path]);
     const deps = makeDeps({
       watcher: watcher as unknown as RouteDeps['watcher'],
     });
@@ -340,16 +281,16 @@ describe('GET /metas — list with filters', () => {
   it('disabled filter works (true and false)', async () => {
     const ownerActive = join(listRoot, 'active');
     const ownerDisabled = join(listRoot, 'disabled-owner');
-    const pathActive = createMeta(ownerActive, {
+    const pathActive = createTestMeta(ownerActive, {
       _id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
       _generatedAt: '2026-03-01T00:00:00Z',
     });
-    const pathDisabled = createMeta(ownerDisabled, {
+    const pathDisabled = createTestMeta(ownerDisabled, {
       _id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
       _generatedAt: '2026-03-01T00:00:00Z',
       _disabled: true,
     });
-    const watcher = makeWatcher([pathActive, pathDisabled]);
+    const watcher = makeTestWatcher([pathActive, pathDisabled]);
     const deps = makeDeps({
       watcher: watcher as unknown as RouteDeps['watcher'],
     });
@@ -416,7 +357,7 @@ describe('GET /metas/:path — crossRefs status', () => {
     );
 
     // refDirB has no .meta directory (missing)
-    const watcher = makeWatcher([join(metaDir, 'meta.json')]);
+    const watcher = makeTestWatcher([join(metaDir, 'meta.json')]);
     const deps = makeDeps({
       watcher: watcher as unknown as RouteDeps['watcher'],
     });
@@ -538,7 +479,7 @@ describe('GET /metas/:path — archive reads', () => {
       cursor: null,
     });
 
-    const watcher = makeWatcher([join(metaDir, 'meta.json')], scan);
+    const watcher = makeTestWatcher([join(metaDir, 'meta.json')], scan);
     app = Fastify();
     registerMetasRoutes(
       app,
@@ -562,7 +503,7 @@ describe('GET /metas/:path — archive reads', () => {
   });
 
   it('falls back to disk reads when watcher scan fails', async () => {
-    const watcher = makeWatcher(
+    const watcher = makeTestWatcher(
       [join(metaDir, 'meta.json')],
       vi.fn().mockRejectedValue(new Error('watcher down')),
     );

--- a/packages/service/src/routes/metas.ts
+++ b/packages/service/src/routes/metas.ts
@@ -21,7 +21,7 @@ import { findNode, listMetas } from '../discovery/index.js';
 import { normalizePath } from '../normalizePath.js';
 import { derivePhaseState, getOwedPhase } from '../phaseState/index.js';
 import { computeStalenessScore } from '../scheduling/index.js';
-import type { RouteDeps } from './index.js';
+import { DEFAULT_EXCLUDE_FIELDS, type RouteDeps } from './index.js';
 
 const metasQuerySchema = z.object({
   pathPrefix: z.string().optional(),
@@ -168,13 +168,6 @@ export function registerMetasRoutes(
       ) as Record<string, unknown>;
 
       // Field projection
-      const defaultExclude = new Set([
-        '_architect',
-        '_builder',
-        '_critic',
-        '_content',
-        '_feedback',
-      ]);
       const fieldList = query.fields?.split(',');
 
       const projectMeta = (
@@ -187,7 +180,7 @@ export function registerMetasRoutes(
         }
         const r: Record<string, unknown> = {};
         for (const [k, v] of Object.entries(m)) {
-          if (!defaultExclude.has(k)) r[k] = v;
+          if (!DEFAULT_EXCLUDE_FIELDS.has(k)) r[k] = v;
         }
         return r;
       };

--- a/packages/service/src/routes/metas.ts
+++ b/packages/service/src/routes/metas.ts
@@ -19,6 +19,7 @@ import { computeSummary } from '../discovery/computeSummary.js';
 import { getScopeFiles } from '../discovery/index.js';
 import { findNode, listMetas } from '../discovery/index.js';
 import { normalizePath } from '../normalizePath.js';
+import { derivePhaseState, getOwedPhase } from '../phaseState/index.js';
 import { computeStalenessScore } from '../scheduling/index.js';
 import type { RouteDeps } from './index.js';
 
@@ -110,10 +111,13 @@ export function registerMetasRoutes(
       'architectTokens',
       'builderTokens',
       'criticTokens',
+      'phaseState',
+      'owedPhase',
     ];
     const projectedFields = fieldList ?? defaultFields;
 
     const metas = entries.map((e) => {
+      const ps = derivePhaseState(e.meta);
       const full: Record<string, unknown> = {
         path: e.path,
         depth: e.depth,
@@ -129,6 +133,8 @@ export function registerMetasRoutes(
         architectTokens: e.architectTokens,
         builderTokens: e.builderTokens,
         criticTokens: e.criticTokens,
+        phaseState: ps,
+        owedPhase: getOwedPhase(ps),
       };
       const projected: Record<string, unknown> = {};
       for (const f of projectedFields) {
@@ -207,6 +213,13 @@ export function registerMetasRoutes(
         config.depthWeight,
       );
 
+      // Phase state
+      const entry = result.entries.find(
+        (e) => e.node.metaPath === targetNode.metaPath,
+      );
+      const phaseState = entry ? derivePhaseState(entry.meta) : null;
+      const owedPhase = phaseState ? getOwedPhase(phaseState) : null;
+
       const response: Record<string, unknown> = {
         path: targetNode.metaPath,
         meta: projectMeta(meta),
@@ -219,6 +232,8 @@ export function registerMetasRoutes(
           seconds: staleSeconds,
           score: Math.round(score * 100) / 100,
         },
+        phaseState,
+        owedPhase,
       };
 
       // Cross-refs status

--- a/packages/service/src/routes/metasUpdate.test.ts
+++ b/packages/service/src/routes/metasUpdate.test.ts
@@ -4,16 +4,15 @@
  * @module routes/metasUpdate.test
  */
 
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import Fastify, { type FastifyInstance } from 'fastify';
-import type { Logger } from 'pino';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
-import type { WatcherClient } from '../interfaces/index.js';
 import { normalizePath } from '../normalizePath.js';
+import { createTestMeta, makeTestDeps, makeTestWatcher } from './__testUtils.js';
 import type { RouteDeps } from './index.js';
 import { registerMetasUpdateRoute } from './metasUpdate.js';
 
@@ -22,70 +21,12 @@ const root = join(
   `jeeves-meta-metas-update-${Date.now().toString()}`,
 );
 
-function makeDeps(overrides: Partial<RouteDeps> = {}): RouteDeps {
-  return {
-    config: {
-      watcherUrl: 'http://localhost:3456',
-      gatewayUrl: 'http://127.0.0.1:18789',
-      depthWeight: 1,
-      architectEvery: 10,
-      maxArchive: 20,
-      maxLines: 500,
-      architectTimeout: 120,
-      builderTimeout: 600,
-      criticTimeout: 300,
-      thinking: 'low',
-      defaultArchitect: 'arch',
-      defaultCritic: 'crit',
-      skipUnchanged: true,
-      metaProperty: {},
-      metaArchiveProperty: {},
-      port: 1938,
-      schedule: '*/30 * * * *',
-      watcherHealthIntervalMs: 60000,
-      logging: { level: 'info' },
-      autoSeed: [],
-    },
-    logger: {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    } as unknown as Logger,
-    queue: {} as RouteDeps['queue'],
-    watcher: {} as RouteDeps['watcher'],
-    scheduler: null,
-    stats: {
-      totalSyntheses: 0,
-      totalTokens: 0,
-      totalErrors: 0,
-      lastCycleDurationMs: null,
-      lastCycleAt: null,
-    },
-    ...overrides,
-  };
-}
-
-function makeWatcher(metaJsonPaths: string[]): WatcherClient {
-  return {
-    walk: vi.fn().mockResolvedValue(metaJsonPaths),
-    registerRules: vi.fn().mockResolvedValue(undefined),
-  };
-}
-
 function createMeta(
   ownerDir: string,
   meta: Record<string, unknown> = {},
 ): { metaJsonPath: string; metaDir: string } {
+  const metaJsonPath = createTestMeta(ownerDir, meta);
   const metaDir = join(ownerDir, '.meta');
-  mkdirSync(metaDir, { recursive: true });
-  const metaJsonPath = join(metaDir, 'meta.json');
-  writeFileSync(
-    metaJsonPath,
-    JSON.stringify({
-      _id: '550e8400-e29b-41d4-a716-446655440099',
-      ...meta,
-    }),
-  );
   return { metaJsonPath, metaDir };
 }
 
@@ -108,8 +49,8 @@ describe('PATCH /metas/:path', () => {
     const owner = join(root, 'disableMe');
     const { metaJsonPath, metaDir } = createMeta(owner);
 
-    const watcher = makeWatcher([metaJsonPath]);
-    const deps = makeDeps({
+    const watcher = makeTestWatcher([metaJsonPath]);
+    const deps = makeTestDeps({
       watcher: watcher as unknown as RouteDeps['watcher'],
     });
     app = Fastify();
@@ -135,8 +76,8 @@ describe('PATCH /metas/:path', () => {
   it('updates _steer', async () => {
     const owner = join(root, 'steerMe');
     const { metaJsonPath, metaDir } = createMeta(owner);
-    const watcher = makeWatcher([metaJsonPath]);
-    const deps = makeDeps({
+    const watcher = makeTestWatcher([metaJsonPath]);
+    const deps = makeTestDeps({
       watcher: watcher as unknown as RouteDeps['watcher'],
     });
     app = Fastify();
@@ -161,8 +102,8 @@ describe('PATCH /metas/:path', () => {
     const { metaJsonPath, metaDir } = createMeta(owner, {
       _steer: 'old steer',
     });
-    const watcher = makeWatcher([metaJsonPath]);
-    const deps = makeDeps({
+    const watcher = makeTestWatcher([metaJsonPath]);
+    const deps = makeTestDeps({
       watcher: watcher as unknown as RouteDeps['watcher'],
     });
     app = Fastify();
@@ -185,8 +126,8 @@ describe('PATCH /metas/:path', () => {
   it('rejects engine-managed properties (strict validation)', async () => {
     const owner = join(root, 'strict');
     const { metaJsonPath } = createMeta(owner);
-    const watcher = makeWatcher([metaJsonPath]);
-    const deps = makeDeps({
+    const watcher = makeTestWatcher([metaJsonPath]);
+    const deps = makeTestDeps({
       watcher: watcher as unknown as RouteDeps['watcher'],
     });
     app = Fastify();
@@ -206,8 +147,8 @@ describe('PATCH /metas/:path', () => {
   });
 
   it('returns 404 for unknown path', async () => {
-    const watcher = makeWatcher([]);
-    const deps = makeDeps({
+    const watcher = makeTestWatcher([]);
+    const deps = makeTestDeps({
       watcher: watcher as unknown as RouteDeps['watcher'],
     });
     app = Fastify();
@@ -236,8 +177,8 @@ describe('PATCH /metas/:path', () => {
       _feedback: 'FEEDBACK',
       _steer: 'old',
     });
-    const watcher = makeWatcher([metaJsonPath]);
-    const deps = makeDeps({
+    const watcher = makeTestWatcher([metaJsonPath]);
+    const deps = makeTestDeps({
       watcher: watcher as unknown as RouteDeps['watcher'],
     });
     app = Fastify();

--- a/packages/service/src/routes/metasUpdate.test.ts
+++ b/packages/service/src/routes/metasUpdate.test.ts
@@ -12,7 +12,11 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { normalizePath } from '../normalizePath.js';
-import { createTestMeta, makeTestDeps, makeTestWatcher } from './__testUtils.js';
+import {
+  createTestMeta,
+  makeTestDeps,
+  makeTestWatcher,
+} from './__testUtils.js';
 import type { RouteDeps } from './index.js';
 import { registerMetasUpdateRoute } from './metasUpdate.js';
 

--- a/packages/service/src/routes/metasUpdate.ts
+++ b/packages/service/src/routes/metasUpdate.ts
@@ -16,7 +16,7 @@ import { z } from 'zod';
 import { resolveMetaDir } from '../lock.js';
 import { normalizePath } from '../normalizePath.js';
 import { readMetaJson } from '../readMetaJson.js';
-import type { RouteDeps } from './index.js';
+import { DEFAULT_EXCLUDE_FIELDS, type RouteDeps } from './index.js';
 
 const updateBodySchema = z
   .object({
@@ -87,16 +87,9 @@ export function registerMetasUpdateRoute(
       await writeFile(metaJsonPath, JSON.stringify(updated, null, 2) + '\n');
 
       // Project the response — exclude the same large fields as the detail route.
-      const defaultExclude = new Set([
-        '_architect',
-        '_builder',
-        '_critic',
-        '_content',
-        '_feedback',
-      ]);
       const projected: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(updated)) {
-        if (!defaultExclude.has(k)) projected[k] = v;
+        if (!DEFAULT_EXCLUDE_FIELDS.has(k)) projected[k] = v;
       }
 
       return reply.send({

--- a/packages/service/src/routes/phaseState.routes.test.ts
+++ b/packages/service/src/routes/phaseState.routes.test.ts
@@ -8,65 +8,12 @@
  */
 
 import Fastify, { type FastifyInstance } from 'fastify';
-import type { Logger } from 'pino';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { SynthesisQueue } from '../queue/index.js';
-import type { RouteDeps } from './index.js';
+import { makeTestDeps, makeTestLogger } from './__testUtils.js';
 import { registerQueueRoutes } from './queue.js';
 import { registerStatusRoute } from './status.js';
-
-function makeLogger(): Logger {
-  return {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
-    fatal: vi.fn(),
-    trace: vi.fn(),
-    child: vi.fn(),
-    level: 'info',
-  } as unknown as Logger;
-}
-
-function makeDeps(overrides: Partial<RouteDeps> = {}): RouteDeps {
-  return {
-    config: {
-      watcherUrl: 'http://localhost:3456',
-      gatewayUrl: 'http://127.0.0.1:18789',
-      depthWeight: 0.5,
-      architectEvery: 10,
-      maxArchive: 20,
-      maxLines: 500,
-      architectTimeout: 120,
-      builderTimeout: 600,
-      criticTimeout: 300,
-      thinking: 'low',
-      defaultArchitect: 'arch',
-      defaultCritic: 'crit',
-      skipUnchanged: true,
-      metaProperty: {},
-      metaArchiveProperty: {},
-      port: 1938,
-      schedule: '*/30 * * * *',
-      watcherHealthIntervalMs: 60000,
-      logging: { level: 'info' },
-      autoSeed: [],
-    },
-    logger: makeLogger(),
-    queue: new SynthesisQueue(makeLogger()),
-    watcher: {} as RouteDeps['watcher'],
-    scheduler: null,
-    stats: {
-      totalSyntheses: 0,
-      totalTokens: 0,
-      totalErrors: 0,
-      lastCycleDurationMs: null,
-      lastCycleAt: null,
-    },
-    ...overrides,
-  };
-}
 
 describe('phase-state operator surfaces (Task #18)', () => {
   let app: FastifyInstance | undefined;
@@ -77,7 +24,7 @@ describe('phase-state operator surfaces (Task #18)', () => {
 
   describe('GET /status — phaseStateSummary and nextPhase', () => {
     it('includes phaseStateSummary in health', async () => {
-      const deps = makeDeps();
+      const deps = makeTestDeps();
       app = Fastify();
       registerStatusRoute(app, deps);
       await app.ready();
@@ -113,7 +60,7 @@ describe('phase-state operator surfaces (Task #18)', () => {
     });
 
     it('includes nextPhase in health (null when no candidates)', async () => {
-      const deps = makeDeps();
+      const deps = makeTestDeps();
       app = Fastify();
       registerStatusRoute(app, deps);
       await app.ready();
@@ -129,9 +76,9 @@ describe('phase-state operator surfaces (Task #18)', () => {
 
   describe('GET /queue — 3-layer model', () => {
     it('returns current, overrides, automatic, pending, state', async () => {
-      const logger = makeLogger();
+      const logger = makeTestLogger();
       const queue = new SynthesisQueue(logger);
-      const deps = makeDeps({ queue });
+      const deps = makeTestDeps({ queue });
       app = Fastify();
       registerQueueRoutes(app, deps);
       await app.ready();
@@ -153,11 +100,11 @@ describe('phase-state operator surfaces (Task #18)', () => {
     });
 
     it('current includes phase when phase-aware item is set', async () => {
-      const logger = makeLogger();
+      const logger = makeTestLogger();
       const queue = new SynthesisQueue(logger);
       queue.setCurrentPhase('/meta/test', 'builder');
 
-      const deps = makeDeps({ queue });
+      const deps = makeTestDeps({ queue });
       app = Fastify();
       registerQueueRoutes(app, deps);
       await app.ready();
@@ -174,12 +121,12 @@ describe('phase-state operator surfaces (Task #18)', () => {
     });
 
     it('overrides reflect enqueued override entries', async () => {
-      const logger = makeLogger();
+      const logger = makeTestLogger();
       const queue = new SynthesisQueue(logger);
       queue.enqueueOverride('/meta/override-a');
       queue.enqueueOverride('/meta/override-b');
 
-      const deps = makeDeps({ queue });
+      const deps = makeTestDeps({ queue });
       app = Fastify();
       registerQueueRoutes(app, deps);
       await app.ready();
@@ -199,12 +146,12 @@ describe('phase-state operator surfaces (Task #18)', () => {
     });
 
     it('POST /queue/clear removes only overrides', async () => {
-      const logger = makeLogger();
+      const logger = makeTestLogger();
       const queue = new SynthesisQueue(logger);
       queue.enqueueOverride('/meta/override-a');
       queue.enqueue('/meta/legacy-item');
 
-      const deps = makeDeps({ queue });
+      const deps = makeTestDeps({ queue });
       app = Fastify();
       registerQueueRoutes(app, deps);
       await app.ready();
@@ -221,7 +168,7 @@ describe('phase-state operator surfaces (Task #18)', () => {
 
   describe('POST /synthesize/abort — phase-state integration', () => {
     it('returns {status: idle} when nothing is running', async () => {
-      const deps = makeDeps();
+      const deps = makeTestDeps();
       app = Fastify();
       registerQueueRoutes(app, deps);
       await app.ready();
@@ -235,11 +182,11 @@ describe('phase-state operator surfaces (Task #18)', () => {
     });
 
     it('returns {status: aborted, path, phase} when phase item is running', async () => {
-      const logger = makeLogger();
+      const logger = makeTestLogger();
       const queue = new SynthesisQueue(logger);
       queue.setCurrentPhase('/meta/active', 'critic');
 
-      const deps = makeDeps({ queue, executor: { abort: vi.fn() } });
+      const deps = makeTestDeps({ queue, executor: { abort: vi.fn() } });
       app = Fastify();
       registerQueueRoutes(app, deps);
       await app.ready();

--- a/packages/service/src/routes/phaseState.routes.test.ts
+++ b/packages/service/src/routes/phaseState.routes.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Operator-surface integration tests for phase-state additive contracts.
+ *
+ * Verifies that GET /status, GET /queue, and GET /metas include the
+ * phase-state fields specified in spec §8 "Operator surfaces."
+ *
+ * Task #18: Operator-surface integration tests.
+ */
+
+import Fastify, { type FastifyInstance } from 'fastify';
+import type { Logger } from 'pino';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { SynthesisQueue } from '../queue/index.js';
+import type { RouteDeps } from './index.js';
+import { registerQueueRoutes } from './queue.js';
+import { registerStatusRoute } from './status.js';
+
+function makeLogger(): Logger {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    fatal: vi.fn(),
+    trace: vi.fn(),
+    child: vi.fn(),
+    level: 'info',
+  } as unknown as Logger;
+}
+
+function makeDeps(overrides: Partial<RouteDeps> = {}): RouteDeps {
+  return {
+    config: {
+      watcherUrl: 'http://localhost:3456',
+      gatewayUrl: 'http://127.0.0.1:18789',
+      depthWeight: 0.5,
+      architectEvery: 10,
+      maxArchive: 20,
+      maxLines: 500,
+      architectTimeout: 120,
+      builderTimeout: 600,
+      criticTimeout: 300,
+      thinking: 'low',
+      defaultArchitect: 'arch',
+      defaultCritic: 'crit',
+      skipUnchanged: true,
+      metaProperty: {},
+      metaArchiveProperty: {},
+      port: 1938,
+      schedule: '*/30 * * * *',
+      watcherHealthIntervalMs: 60000,
+      logging: { level: 'info' },
+      autoSeed: [],
+    },
+    logger: makeLogger(),
+    queue: new SynthesisQueue(makeLogger()),
+    watcher: {} as RouteDeps['watcher'],
+    scheduler: null,
+    stats: {
+      totalSyntheses: 0,
+      totalTokens: 0,
+      totalErrors: 0,
+      lastCycleDurationMs: null,
+      lastCycleAt: null,
+    },
+    ...overrides,
+  };
+}
+
+describe('phase-state operator surfaces (Task #18)', () => {
+  let app: FastifyInstance | undefined;
+
+  afterEach(async () => {
+    await app?.close();
+  });
+
+  describe('GET /status — phaseStateSummary and nextPhase', () => {
+    it('includes phaseStateSummary in health', async () => {
+      const deps = makeDeps();
+      app = Fastify();
+      registerStatusRoute(app, deps);
+      await app.ready();
+
+      const res = await app.inject({ method: 'GET', url: '/status' });
+      const body = res.json<{
+        health: {
+          phaseStateSummary: Record<string, Record<string, number>>;
+          nextPhase: unknown;
+        };
+      }>();
+
+      // phaseStateSummary should exist (may be empty if watcher unreachable)
+      expect(body.health).toHaveProperty('phaseStateSummary');
+      const pss = body.health.phaseStateSummary;
+      expect(pss).toHaveProperty('architect');
+      expect(pss).toHaveProperty('builder');
+      expect(pss).toHaveProperty('critic');
+
+      // Each phase should have counts for all states
+      for (const phase of ['architect', 'builder', 'critic']) {
+        for (const state of [
+          'fresh',
+          'stale',
+          'pending',
+          'running',
+          'failed',
+        ]) {
+          expect(pss[phase]).toHaveProperty(state);
+          expect(typeof pss[phase][state]).toBe('number');
+        }
+      }
+    });
+
+    it('includes nextPhase in health (null when no candidates)', async () => {
+      const deps = makeDeps();
+      app = Fastify();
+      registerStatusRoute(app, deps);
+      await app.ready();
+
+      const res = await app.inject({ method: 'GET', url: '/status' });
+      const body = res.json<{ health: { nextPhase: unknown } }>();
+
+      expect(body.health).toHaveProperty('nextPhase');
+      // No watcher = no candidates = null
+      expect(body.health.nextPhase).toBeNull();
+    });
+  });
+
+  describe('GET /queue — 3-layer model', () => {
+    it('returns current, overrides, automatic, pending, state', async () => {
+      const logger = makeLogger();
+      const queue = new SynthesisQueue(logger);
+      const deps = makeDeps({ queue });
+      app = Fastify();
+      registerQueueRoutes(app, deps);
+      await app.ready();
+
+      const res = await app.inject({ method: 'GET', url: '/queue' });
+      const body = res.json<{
+        current: unknown;
+        overrides: unknown[];
+        automatic: unknown[];
+        pending: unknown[];
+        state: { depth: number; items: unknown[] };
+      }>();
+
+      expect(body).toHaveProperty('current');
+      expect(body).toHaveProperty('overrides');
+      expect(body).toHaveProperty('automatic');
+      expect(body).toHaveProperty('pending');
+      expect(body).toHaveProperty('state');
+    });
+
+    it('current includes phase when phase-aware item is set', async () => {
+      const logger = makeLogger();
+      const queue = new SynthesisQueue(logger);
+      queue.setCurrentPhase('/meta/test', 'builder');
+
+      const deps = makeDeps({ queue });
+      app = Fastify();
+      registerQueueRoutes(app, deps);
+      await app.ready();
+
+      const res = await app.inject({ method: 'GET', url: '/queue' });
+      const body = res.json<{
+        current: { path: string; phase: string; startedAt: string };
+      }>();
+
+      expect(body.current).not.toBeNull();
+      expect(body.current.path).toBe('/meta/test');
+      expect(body.current.phase).toBe('builder');
+      expect(body.current.startedAt).toBeDefined();
+    });
+
+    it('overrides reflect enqueued override entries', async () => {
+      const logger = makeLogger();
+      const queue = new SynthesisQueue(logger);
+      queue.enqueueOverride('/meta/override-a');
+      queue.enqueueOverride('/meta/override-b');
+
+      const deps = makeDeps({ queue });
+      app = Fastify();
+      registerQueueRoutes(app, deps);
+      await app.ready();
+
+      const res = await app.inject({ method: 'GET', url: '/queue' });
+      const body = res.json<{
+        overrides: Array<{
+          path: string;
+          owedPhase: string | null;
+          enqueuedAt: string;
+        }>;
+      }>();
+
+      expect(body.overrides).toHaveLength(2);
+      expect(body.overrides[0].path).toBe('/meta/override-a');
+      expect(body.overrides[1].path).toBe('/meta/override-b');
+    });
+
+    it('POST /queue/clear removes only overrides', async () => {
+      const logger = makeLogger();
+      const queue = new SynthesisQueue(logger);
+      queue.enqueueOverride('/meta/override-a');
+      queue.enqueue('/meta/legacy-item');
+
+      const deps = makeDeps({ queue });
+      app = Fastify();
+      registerQueueRoutes(app, deps);
+      await app.ready();
+
+      const res = await app.inject({ method: 'POST', url: '/queue/clear' });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ cleared: 1 });
+
+      // Legacy queue should be unaffected
+      expect(queue.depth).toBe(1);
+      expect(queue.overrides).toHaveLength(0);
+    });
+  });
+
+  describe('POST /synthesize/abort — phase-state integration', () => {
+    it('returns {status: idle} when nothing is running', async () => {
+      const deps = makeDeps();
+      app = Fastify();
+      registerQueueRoutes(app, deps);
+      await app.ready();
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/synthesize/abort',
+      });
+      expect(res.statusCode).toBe(200);
+      expect(res.json()).toEqual({ status: 'idle' });
+    });
+
+    it('returns {status: aborted, path, phase} when phase item is running', async () => {
+      const logger = makeLogger();
+      const queue = new SynthesisQueue(logger);
+      queue.setCurrentPhase('/meta/active', 'critic');
+
+      const deps = makeDeps({ queue, executor: { abort: vi.fn() } });
+      app = Fastify();
+      registerQueueRoutes(app, deps);
+      await app.ready();
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/synthesize/abort',
+      });
+      const body = res.json<{
+        status: string;
+        path: string;
+        phase: string;
+      }>();
+
+      expect(body.status).toBe('aborted');
+      expect(body.path).toBe('/meta/active');
+      expect(body.phase).toBe('critic');
+    });
+  });
+});

--- a/packages/service/src/routes/preview.test.ts
+++ b/packages/service/src/routes/preview.test.ts
@@ -4,95 +4,26 @@
  * @module routes/preview.test
  */
 
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import Fastify, { type FastifyInstance } from 'fastify';
-import type { Logger } from 'pino';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
-import type { WatcherClient } from '../interfaces/index.js';
+import {
+  createTestMeta,
+  makeFailingTestWatcher,
+  makeTestDeps,
+  makeTestWatcher,
+} from './__testUtils.js';
 import type { RouteDeps } from './index.js';
 import { registerPreviewRoute } from './preview.js';
-
-function makeDeps(overrides: Partial<RouteDeps> = {}): RouteDeps {
-  return {
-    config: {
-      watcherUrl: 'http://localhost:3456',
-      gatewayUrl: 'http://127.0.0.1:18789',
-      depthWeight: 0.5,
-      architectEvery: 10,
-      maxArchive: 20,
-      maxLines: 500,
-      architectTimeout: 120,
-      builderTimeout: 600,
-      criticTimeout: 300,
-      thinking: 'low',
-      defaultArchitect: 'arch',
-      defaultCritic: 'crit',
-      skipUnchanged: true,
-      metaProperty: {},
-      metaArchiveProperty: {},
-      port: 1938,
-      schedule: '*/30 * * * *',
-      watcherHealthIntervalMs: 60000,
-      logging: { level: 'info' },
-      autoSeed: [],
-    },
-    logger: {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    } as unknown as Logger,
-    queue: {} as RouteDeps['queue'],
-    watcher: {} as RouteDeps['watcher'],
-    scheduler: null,
-    stats: {
-      totalSyntheses: 0,
-      totalTokens: 0,
-      totalErrors: 0,
-      lastCycleDurationMs: null,
-      lastCycleAt: null,
-    },
-    ...overrides,
-  };
-}
-
-function makeWatcher(metaJsonPaths: string[]): WatcherClient {
-  return {
-    walk: vi.fn().mockResolvedValue(metaJsonPaths),
-    registerRules: vi.fn().mockResolvedValue(undefined),
-  };
-}
-
-function makeFailingWatcher(): WatcherClient {
-  return {
-    walk: vi.fn().mockRejectedValue(new Error('connection refused')),
-    registerRules: vi.fn().mockResolvedValue(undefined),
-  };
-}
 
 const previewRoot = join(
   tmpdir(),
   `jeeves-meta-preview-${Date.now().toString()}`,
 );
-
-function createMeta(
-  ownerDir: string,
-  meta: Record<string, unknown> = {},
-): string {
-  const metaDir = join(ownerDir, '.meta');
-  mkdirSync(metaDir, { recursive: true });
-  writeFileSync(
-    join(metaDir, 'meta.json'),
-    JSON.stringify({
-      _id: '550e8400-e29b-41d4-a716-446655440099',
-      ...meta,
-    }),
-  );
-  return join(metaDir, 'meta.json');
-}
 
 describe('GET /preview', () => {
   let app: FastifyInstance;
@@ -105,16 +36,16 @@ describe('GET /preview', () => {
   it('returns preview for stalest candidate when no path query', async () => {
     const ownerA = join(previewRoot, 'old');
     const ownerB = join(previewRoot, 'recent');
-    const pathA = createMeta(ownerA, {
+    const pathA = createTestMeta(ownerA, {
       _id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
       _generatedAt: new Date(Date.now() - 86400_000 * 7).toISOString(),
     });
-    const pathB = createMeta(ownerB, {
+    const pathB = createTestMeta(ownerB, {
       _id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
       _generatedAt: new Date(Date.now() - 3600_000).toISOString(),
     });
-    const watcher = makeWatcher([pathA, pathB]);
-    const deps = makeDeps({
+    const watcher = makeTestWatcher([pathA, pathB]);
+    const deps = makeTestDeps({
       watcher: watcher as unknown as RouteDeps['watcher'],
     });
     app = Fastify();
@@ -132,12 +63,12 @@ describe('GET /preview', () => {
 
   it('returns preview for specific path when path query provided', async () => {
     const owner = join(previewRoot, 'specific');
-    const metaJsonPath = createMeta(owner, {
+    const metaJsonPath = createTestMeta(owner, {
       _id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
       _generatedAt: new Date(Date.now() - 3600_000).toISOString(),
     });
-    const watcher = makeWatcher([metaJsonPath]);
-    const deps = makeDeps({
+    const watcher = makeTestWatcher([metaJsonPath]);
+    const deps = makeTestDeps({
       watcher: watcher as unknown as RouteDeps['watcher'],
     });
     app = Fastify();
@@ -156,8 +87,8 @@ describe('GET /preview', () => {
   });
 
   it('returns 503 when watcher is unreachable', async () => {
-    const watcher = makeFailingWatcher();
-    const deps = makeDeps({
+    const watcher = makeFailingTestWatcher();
+    const deps = makeTestDeps({
       watcher: watcher as unknown as RouteDeps['watcher'],
     });
     app = Fastify();
@@ -173,7 +104,7 @@ describe('GET /preview', () => {
 
   it('response includes architectWillRun, scope, staleness, estimatedTokens', async () => {
     const owner = join(previewRoot, 'full');
-    const metaJsonPath = createMeta(owner, {
+    const metaJsonPath = createTestMeta(owner, {
       _id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
       _generatedAt: new Date(Date.now() - 86400_000).toISOString(),
       _builder: 'cached builder prompt',
@@ -181,8 +112,8 @@ describe('GET /preview', () => {
       _builderTokens: 200,
       _criticTokens: 50,
     });
-    const watcher = makeWatcher([metaJsonPath]);
-    const deps = makeDeps({
+    const watcher = makeTestWatcher([metaJsonPath]);
+    const deps = makeTestDeps({
       watcher: watcher as unknown as RouteDeps['watcher'],
     });
     app = Fastify();
@@ -210,13 +141,13 @@ describe('GET /preview', () => {
 
   it('architect is triggered for fresh meta (no _builder)', async () => {
     const owner = join(previewRoot, 'fresh');
-    const metaJsonPath = createMeta(owner, {
+    const metaJsonPath = createTestMeta(owner, {
       _id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
       _generatedAt: new Date(Date.now() - 3600_000).toISOString(),
       // No _builder field — first run
     });
-    const watcher = makeWatcher([metaJsonPath]);
-    const deps = makeDeps({
+    const watcher = makeTestWatcher([metaJsonPath]);
+    const deps = makeTestDeps({
       watcher: watcher as unknown as RouteDeps['watcher'],
     });
     app = Fastify();

--- a/packages/service/src/routes/preview.ts
+++ b/packages/service/src/routes/preview.ts
@@ -14,6 +14,12 @@ import {
   listMetas,
 } from '../discovery/index.js';
 import { normalizePath } from '../normalizePath.js';
+import {
+  type ArchitectInvalidator,
+  derivePhaseState,
+  getOwedPhase,
+  getPriorityBand,
+} from '../phaseState/index.js';
 import { readMetaJson } from '../readMetaJson.js';
 import {
   computeStalenessScore,
@@ -83,6 +89,21 @@ export function registerPreviewRoute(
       Boolean(latestArchive),
     );
 
+    // _architect change detection
+    const architectChanged = latestArchive
+      ? (meta._architect ?? '') !== (latestArchive._architect ?? '')
+      : Boolean(meta._architect);
+
+    // _crossRefs declaration change detection
+    const currentRefs = (meta._crossRefs ?? []).slice().sort().join(',');
+    const archiveRefs = (latestArchive?._crossRefs ?? [])
+      .slice()
+      .sort()
+      .join(',');
+    const crossRefsDeclChanged = latestArchive
+      ? currentRefs !== archiveRefs
+      : currentRefs.length > 0;
+
     const architectTriggered = isArchitectTriggered(
       meta,
       structureChanged,
@@ -111,6 +132,39 @@ export function registerPreviewRoute(
       config.depthWeight,
     );
 
+    // Phase state
+    const phaseState = derivePhaseState(meta, {
+      structureChanged,
+      steerChanged,
+      architectChanged,
+      crossRefsChanged: crossRefsDeclChanged,
+      architectEvery: config.architectEvery,
+    });
+    const owedPhase = getOwedPhase(phaseState);
+    const priorityBand = getPriorityBand(phaseState);
+
+    // Architect invalidators
+    const architectInvalidators: ArchitectInvalidator[] = [];
+    if (owedPhase === 'architect') {
+      if (structureChanged) architectInvalidators.push('structureHash');
+      if (steerChanged) architectInvalidators.push('steer');
+      if (architectChanged) architectInvalidators.push('_architect');
+      if (crossRefsDeclChanged) architectInvalidators.push('_crossRefs');
+      if ((meta._synthesisCount ?? 0) >= config.architectEvery) {
+        architectInvalidators.push('architectEvery');
+      }
+    }
+
+    // Staleness inputs
+    const stalenessInputs = {
+      structureHash,
+      steerChanged,
+      architectChanged,
+      crossRefsDeclChanged,
+      scopeMtimeMax: null as string | null,
+      crossRefContentChanged: false,
+    };
+
     return {
       path: targetNode.metaPath,
       staleness: {
@@ -136,6 +190,12 @@ export function registerPreviewRoute(
         deltaCount: deltaFiles.length,
       },
       estimatedTokens,
+      // New phase-state fields (additive)
+      owedPhase,
+      priorityBand,
+      phaseState,
+      stalenessInputs,
+      architectInvalidators,
     };
   });
 }

--- a/packages/service/src/routes/queue.test.ts
+++ b/packages/service/src/routes/queue.test.ts
@@ -97,12 +97,12 @@ describe('queue routes', () => {
     expect(body.state.items).toHaveLength(2);
   });
 
-  it('POST /queue/clear removes pending items only', async () => {
+  it('POST /queue/clear removes override entries only', async () => {
     const queue = new SynthesisQueue(makeLogger());
     queue.enqueue('/meta/current');
     queue.dequeue();
-    queue.enqueue('/meta/pending-a');
-    queue.enqueue('/meta/pending-b');
+    queue.enqueueOverride('/meta/override-a');
+    queue.enqueueOverride('/meta/override-b');
 
     app = Fastify();
     registerQueueRoutes(app, makeDeps({ queue }));
@@ -112,20 +112,17 @@ describe('queue routes', () => {
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ cleared: 2 });
     expect(queue.current?.path).toBe('/meta/current');
-    expect(queue.pending).toHaveLength(0);
+    expect(queue.overrides).toHaveLength(0);
   });
 
-  it('POST /synthesize/abort returns 404 when idle', async () => {
+  it('POST /synthesize/abort returns idle when nothing running', async () => {
     app = Fastify();
     registerQueueRoutes(app, makeDeps());
     await app.ready();
 
     const res = await app.inject({ method: 'POST', url: '/synthesize/abort' });
-    expect(res.statusCode).toBe(404);
-    expect(res.json()).toEqual({
-      error: 'NOT_FOUND',
-      message: 'No synthesis in progress',
-    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ status: 'idle' });
   });
 
   it('POST /synthesize/abort aborts the executor and releases the lock', async () => {

--- a/packages/service/src/routes/queue.test.ts
+++ b/packages/service/src/routes/queue.test.ts
@@ -10,8 +10,8 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { SynthesisQueue } from '../queue/index.js';
-import type { RouteDeps } from './index.js';
 import { makeTestDeps, makeTestLogger } from './__testUtils.js';
+import type { RouteDeps } from './index.js';
 import { registerQueueRoutes } from './queue.js';
 
 describe('queue routes', () => {

--- a/packages/service/src/routes/queue.test.ts
+++ b/packages/service/src/routes/queue.test.ts
@@ -7,65 +7,12 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import Fastify, { type FastifyInstance } from 'fastify';
-import type { Logger } from 'pino';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { SynthesisQueue } from '../queue/index.js';
 import type { RouteDeps } from './index.js';
+import { makeTestDeps, makeTestLogger } from './__testUtils.js';
 import { registerQueueRoutes } from './queue.js';
-
-function makeLogger(): Logger {
-  return {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
-    fatal: vi.fn(),
-    trace: vi.fn(),
-    child: vi.fn(),
-    level: 'info',
-  } as unknown as Logger;
-}
-
-function makeDeps(overrides: Partial<RouteDeps> = {}): RouteDeps {
-  return {
-    config: {
-      watcherUrl: 'http://localhost:3456',
-      gatewayUrl: 'http://127.0.0.1:18789',
-      depthWeight: 0.5,
-      architectEvery: 10,
-      maxArchive: 20,
-      maxLines: 500,
-      architectTimeout: 120,
-      builderTimeout: 600,
-      criticTimeout: 300,
-      thinking: 'low',
-      defaultArchitect: 'arch',
-      defaultCritic: 'crit',
-      skipUnchanged: true,
-      metaProperty: {},
-      metaArchiveProperty: {},
-      port: 1938,
-      schedule: '*/30 * * * *',
-      watcherHealthIntervalMs: 60000,
-      logging: { level: 'info' },
-      autoSeed: [],
-    },
-    logger: makeLogger(),
-    queue: new SynthesisQueue(makeLogger()),
-    watcher: {} as RouteDeps['watcher'],
-    scheduler: null,
-    stats: {
-      totalSyntheses: 0,
-      totalTokens: 0,
-      totalErrors: 0,
-      lastCycleDurationMs: null,
-      lastCycleAt: null,
-    },
-    executor: { abort: vi.fn() } as RouteDeps['executor'],
-    ...overrides,
-  };
-}
 
 describe('queue routes', () => {
   let app: FastifyInstance;
@@ -75,12 +22,12 @@ describe('queue routes', () => {
   });
 
   it('GET /queue returns current, pending, and state', async () => {
-    const queue = new SynthesisQueue(makeLogger());
+    const queue = new SynthesisQueue(makeTestLogger());
     queue.enqueue('/meta/a');
     queue.enqueue('/meta/b');
 
     app = Fastify();
-    registerQueueRoutes(app, makeDeps({ queue }));
+    registerQueueRoutes(app, makeTestDeps({ queue }));
     await app.ready();
 
     const res = await app.inject({ method: 'GET', url: '/queue' });
@@ -98,14 +45,14 @@ describe('queue routes', () => {
   });
 
   it('POST /queue/clear removes override entries only', async () => {
-    const queue = new SynthesisQueue(makeLogger());
+    const queue = new SynthesisQueue(makeTestLogger());
     queue.enqueue('/meta/current');
     queue.dequeue();
     queue.enqueueOverride('/meta/override-a');
     queue.enqueueOverride('/meta/override-b');
 
     app = Fastify();
-    registerQueueRoutes(app, makeDeps({ queue }));
+    registerQueueRoutes(app, makeTestDeps({ queue }));
     await app.ready();
 
     const res = await app.inject({ method: 'POST', url: '/queue/clear' });
@@ -117,7 +64,7 @@ describe('queue routes', () => {
 
   it('POST /synthesize/abort returns idle when nothing running', async () => {
     app = Fastify();
-    registerQueueRoutes(app, makeDeps());
+    registerQueueRoutes(app, makeTestDeps());
     await app.ready();
 
     const res = await app.inject({ method: 'POST', url: '/synthesize/abort' });
@@ -135,7 +82,7 @@ describe('queue routes', () => {
       JSON.stringify({ _lockPid: process.pid, _lockStartedAt: new Date() }),
     );
 
-    const queue = new SynthesisQueue(makeLogger());
+    const queue = new SynthesisQueue(makeTestLogger());
     queue.enqueue(ownerDir);
     queue.dequeue();
     const abort = vi.fn();
@@ -143,7 +90,7 @@ describe('queue routes', () => {
     app = Fastify();
     registerQueueRoutes(
       app,
-      makeDeps({ queue, executor: { abort } as RouteDeps['executor'] }),
+      makeTestDeps({ queue, executor: { abort } as RouteDeps['executor'] }),
     );
     await app.ready();
 

--- a/packages/service/src/routes/queue.ts
+++ b/packages/service/src/routes/queue.ts
@@ -8,9 +8,21 @@
  * @module routes/queue
  */
 
+import { copyFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
 import type { FastifyInstance } from 'fastify';
 
+import { listMetas } from '../discovery/index.js';
 import { releaseLock, resolveMetaDir } from '../lock.js';
+import {
+  derivePhaseState,
+  getOwedPhase,
+  getPriorityBand,
+  phaseFailed,
+  retryPhase,
+} from '../phaseState/index.js';
+import { readMetaJson } from '../readMetaJson.js';
 import type { RouteDeps } from './index.js';
 
 /** Register queue management routes. */
@@ -20,15 +32,117 @@ export function registerQueueRoutes(
 ): void {
   const { queue } = deps;
 
-  app.get('/queue', () => {
+  app.get('/queue', async () => {
     const currentPhase = queue.currentPhase;
     const overrides = queue.overrides;
 
-    // Legacy: pending is the union of overrides + legacy queue items
+    // Compute owedPhase for each override entry by reading meta state
+    const enrichedOverrides = await Promise.all(
+      overrides.map(async (o) => {
+        try {
+          const metaDir = resolveMetaDir(o.path);
+          const meta = await readMetaJson(metaDir);
+          const ps = derivePhaseState(meta);
+          return {
+            path: o.path,
+            owedPhase: getOwedPhase(ps),
+            enqueuedAt: o.enqueuedAt,
+          };
+        } catch {
+          return {
+            path: o.path,
+            owedPhase: null as string | null,
+            enqueuedAt: o.enqueuedAt,
+          };
+        }
+      }),
+    );
+
+    // Compute automatic layer: all metas with a pending owed phase,
+    // ranked by scheduler priority (computed on read, not persisted)
+    let automatic: Array<{
+      path: string;
+      owedPhase: string;
+      priorityBand: number;
+      effectiveStaleness: number;
+    }> = [];
+    try {
+      const metaResult = await listMetas(deps.config, deps.watcher);
+      const candidates = [];
+      for (const entry of metaResult.entries) {
+        let ps = derivePhaseState(entry.meta);
+
+        // Auto-retry failed phases (same as orchestratePhase)
+        for (const phase of ['architect', 'builder', 'critic'] as const) {
+          if (ps[phase] === 'failed') {
+            ps = retryPhase(ps, phase);
+          }
+        }
+
+        candidates.push({
+          node: entry.node,
+          meta: entry.meta,
+          phaseState: ps,
+          actualStaleness: entry.stalenessSeconds,
+          locked: entry.locked,
+          disabled: entry.disabled,
+        });
+      }
+
+      // Filter to those with a pending owed phase, then rank
+      const eligible = candidates.filter((c) => {
+        const owed = getOwedPhase(c.phaseState);
+        return owed !== null && c.phaseState[owed] === 'pending';
+      });
+
+      // Use selectPhaseCandidate logic for ranking: sort all eligible
+      // by band asc, then effective staleness desc
+      if (eligible.length > 0) {
+        // We need the full sorted list, not just the winner.
+        // Re-use the scheduler's ranking approach directly.
+        const { computeEffectiveStaleness } =
+          await import('../scheduling/weightedFormula.js');
+        const withStaleness = computeEffectiveStaleness(
+          eligible.map((m) => ({
+            node: m.node,
+            meta: m.meta,
+            actualStaleness: m.actualStaleness,
+          })),
+          deps.config.depthWeight,
+        );
+
+        const ranked = withStaleness.map((ws, i) => {
+          const m = eligible[i];
+          const owedPhase = getOwedPhase(m.phaseState)!;
+          return {
+            path: m.node.metaPath,
+            owedPhase,
+            priorityBand: getPriorityBand(m.phaseState)!,
+            effectiveStaleness: ws.effectiveStaleness,
+          };
+        });
+
+        ranked.sort((a, b) => {
+          if (a.priorityBand !== b.priorityBand)
+            return a.priorityBand - b.priorityBand;
+          return b.effectiveStaleness - a.effectiveStaleness;
+        });
+
+        automatic = ranked;
+      }
+    } catch {
+      // If listing fails, automatic stays empty
+    }
+
+    // Legacy: pending is the union of overrides + automatic + legacy queue items
     const pendingItems = [
-      ...overrides.map((o) => ({
+      ...enrichedOverrides.map((o) => ({
         path: o.path,
-        owedPhase: null as string | null,
+        owedPhase: o.owedPhase,
+      })),
+      ...automatic.map((a) => ({
+        path: a.path,
+        owedPhase: a.owedPhase as string | null,
       })),
       ...queue.pending.map((item) => ({
         path: item.path,
@@ -50,12 +164,8 @@ export function registerQueueRoutes(
               startedAt: queue.current.enqueuedAt,
             }
           : null,
-      overrides: overrides.map((o) => ({
-        path: o.path,
-        owedPhase: null,
-        enqueuedAt: o.enqueuedAt,
-      })),
-      automatic: [],
+      overrides: enrichedOverrides,
+      automatic,
       pending: pendingItems,
       // Legacy state
       state: queue.getState(),
@@ -79,16 +189,44 @@ export function registerQueueRoutes(
     // Abort the executor
     deps.executor?.abort();
 
+    const metaDir = resolveMetaDir(current.path);
+    const phase = currentPhase?.phase ?? null;
+
+    // Transition running phase to failed and write _error to meta.json
+    if (phase) {
+      try {
+        const meta = await readMetaJson(metaDir);
+        let ps = derivePhaseState(meta);
+        ps = phaseFailed(ps, phase);
+
+        const updated = {
+          ...meta,
+          _phaseState: ps,
+          _error: {
+            step: phase,
+            code: 'ABORT',
+            message: 'Aborted by operator',
+          },
+        };
+
+        const lockPath = join(metaDir, '.lock');
+        const metaJsonPath = join(metaDir, 'meta.json');
+        await writeFile(lockPath, JSON.stringify(updated, null, 2) + '\n');
+        await copyFile(lockPath, metaJsonPath);
+      } catch {
+        // Best-effort — meta may be unreadable
+      }
+    }
+
     // Release the lock for the current meta path
     try {
-      releaseLock(resolveMetaDir(current.path));
+      releaseLock(metaDir);
     } catch {
       // Lock may already be released
     }
 
     deps.logger.info({ path: current.path }, 'Synthesis aborted');
 
-    const phase = currentPhase?.phase ?? null;
     return {
       status: 'aborted',
       path: current.path,

--- a/packages/service/src/routes/queue.ts
+++ b/packages/service/src/routes/queue.ts
@@ -16,11 +16,11 @@ import type { FastifyInstance } from 'fastify';
 import { listMetas } from '../discovery/index.js';
 import { releaseLock, resolveMetaDir } from '../lock.js';
 import {
+  buildPhaseCandidates,
   derivePhaseState,
   getOwedPhase,
-  getPriorityBand,
   phaseFailed,
-  retryPhase,
+  rankPhaseCandidates,
 } from '../phaseState/index.js';
 import { readMetaJson } from '../readMetaJson.js';
 import type { RouteDeps } from './index.js';
@@ -68,68 +68,14 @@ export function registerQueueRoutes(
     }> = [];
     try {
       const metaResult = await listMetas(deps.config, deps.watcher);
-      const candidates = [];
-      for (const entry of metaResult.entries) {
-        let ps = derivePhaseState(entry.meta);
-
-        // Auto-retry failed phases (same as orchestratePhase)
-        for (const phase of ['architect', 'builder', 'critic'] as const) {
-          if (ps[phase] === 'failed') {
-            ps = retryPhase(ps, phase);
-          }
-        }
-
-        candidates.push({
-          node: entry.node,
-          meta: entry.meta,
-          phaseState: ps,
-          actualStaleness: entry.stalenessSeconds,
-          locked: entry.locked,
-          disabled: entry.disabled,
-        });
-      }
-
-      // Filter to those with a pending owed phase, then rank
-      const eligible = candidates.filter((c) => {
-        const owed = getOwedPhase(c.phaseState);
-        return owed !== null && c.phaseState[owed] === 'pending';
-      });
-
-      // Use selectPhaseCandidate logic for ranking: sort all eligible
-      // by band asc, then effective staleness desc
-      if (eligible.length > 0) {
-        // We need the full sorted list, not just the winner.
-        // Re-use the scheduler's ranking approach directly.
-        const { computeEffectiveStaleness } =
-          await import('../scheduling/weightedFormula.js');
-        const withStaleness = computeEffectiveStaleness(
-          eligible.map((m) => ({
-            node: m.node,
-            meta: m.meta,
-            actualStaleness: m.actualStaleness,
-          })),
-          deps.config.depthWeight,
-        );
-
-        const ranked = withStaleness.map((ws, i) => {
-          const m = eligible[i];
-          const owedPhase = getOwedPhase(m.phaseState)!;
-          return {
-            path: m.node.metaPath,
-            owedPhase,
-            priorityBand: getPriorityBand(m.phaseState)!,
-            effectiveStaleness: ws.effectiveStaleness,
-          };
-        });
-
-        ranked.sort((a, b) => {
-          if (a.priorityBand !== b.priorityBand)
-            return a.priorityBand - b.priorityBand;
-          return b.effectiveStaleness - a.effectiveStaleness;
-        });
-
-        automatic = ranked;
-      }
+      const candidates = buildPhaseCandidates(metaResult.entries);
+      const ranked = rankPhaseCandidates(candidates, deps.config.depthWeight);
+      automatic = ranked.map((c) => ({
+        path: c.node.metaPath,
+        owedPhase: c.owedPhase,
+        priorityBand: c.band,
+        effectiveStaleness: c.effectiveStaleness,
+      }));
     } catch {
       // If listing fails, automatic stays empty
     }

--- a/packages/service/src/routes/queue.ts
+++ b/packages/service/src/routes/queue.ts
@@ -1,8 +1,8 @@
 /**
  * Queue management and abort routes.
  *
- * - GET /queue — current queue state
- * - POST /queue/clear — remove all pending items
+ * - GET /queue — 3-layer queue model (current, overrides, automatic, pending)
+ * - POST /queue/clear — remove override entries only
  * - POST /synthesize/abort — abort the current synthesis
  *
  * @module routes/queue
@@ -20,23 +20,60 @@ export function registerQueueRoutes(
 ): void {
   const { queue } = deps;
 
-  app.get('/queue', () => ({
-    current: queue.current,
-    pending: queue.pending,
-    state: queue.getState(),
-  }));
+  app.get('/queue', () => {
+    const currentPhase = queue.currentPhase;
+    const overrides = queue.overrides;
+
+    // Legacy: pending is the union of overrides + legacy queue items
+    const pendingItems = [
+      ...overrides.map((o) => ({
+        path: o.path,
+        owedPhase: null as string | null,
+      })),
+      ...queue.pending.map((item) => ({
+        path: item.path,
+        owedPhase: null as string | null,
+      })),
+    ];
+
+    return {
+      current: currentPhase
+        ? {
+            path: currentPhase.path,
+            phase: currentPhase.phase,
+            startedAt: currentPhase.startedAt,
+          }
+        : queue.current
+          ? {
+              path: queue.current.path,
+              phase: null,
+              startedAt: queue.current.enqueuedAt,
+            }
+          : null,
+      overrides: overrides.map((o) => ({
+        path: o.path,
+        owedPhase: null,
+        enqueuedAt: o.enqueuedAt,
+      })),
+      automatic: [],
+      pending: pendingItems,
+      // Legacy state
+      state: queue.getState(),
+    };
+  });
 
   app.post('/queue/clear', () => {
-    const removed = queue.clear();
+    const removed = queue.clearOverrides();
     return { cleared: removed };
   });
 
   app.post('/synthesize/abort', async (_request, reply) => {
-    const current = queue.current;
+    // Check 3-layer current first
+    const currentPhase = queue.currentPhase;
+    const current = currentPhase ?? queue.current;
+
     if (!current) {
-      return reply
-        .status(404)
-        .send({ error: 'NOT_FOUND', message: 'No synthesis in progress' });
+      return reply.status(200).send({ status: 'idle' });
     }
 
     // Abort the executor
@@ -51,6 +88,11 @@ export function registerQueueRoutes(
 
     deps.logger.info({ path: current.path }, 'Synthesis aborted');
 
-    return { status: 'aborted', path: current.path };
+    const phase = currentPhase?.phase ?? null;
+    return {
+      status: 'aborted',
+      path: current.path,
+      ...(phase ? { phase } : {}),
+    };
   });
 }

--- a/packages/service/src/routes/seed.test.ts
+++ b/packages/service/src/routes/seed.test.ts
@@ -9,56 +9,12 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import Fastify, { type FastifyInstance } from 'fastify';
-import type { Logger } from 'pino';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import type { RouteDeps } from './index.js';
+import { makeTestDeps } from './__testUtils.js';
 import { registerSeedRoute } from './seed.js';
 
 const testRoot = join(tmpdir(), `jeeves-meta-seed-${Date.now().toString()}`);
-
-function makeDeps(overrides: Partial<RouteDeps> = {}): RouteDeps {
-  return {
-    config: {
-      watcherUrl: 'http://localhost:3456',
-      gatewayUrl: 'http://127.0.0.1:18789',
-      depthWeight: 1,
-      architectEvery: 10,
-      maxArchive: 20,
-      maxLines: 500,
-      architectTimeout: 120,
-      builderTimeout: 600,
-      criticTimeout: 300,
-      thinking: 'low',
-      defaultArchitect: 'arch',
-      defaultCritic: 'crit',
-      skipUnchanged: true,
-      metaProperty: {},
-      metaArchiveProperty: {},
-      port: 1938,
-      schedule: '*/30 * * * *',
-      watcherHealthIntervalMs: 60000,
-      logging: { level: 'info' },
-      autoSeed: [],
-    },
-    logger: {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    } as unknown as Logger,
-    queue: {} as RouteDeps['queue'],
-    watcher: {} as RouteDeps['watcher'],
-    scheduler: null,
-    stats: {
-      totalSyntheses: 0,
-      totalTokens: 0,
-      totalErrors: 0,
-      lastCycleDurationMs: null,
-      lastCycleAt: null,
-    },
-    ...overrides,
-  };
-}
 
 describe('POST /seed', () => {
   let app: FastifyInstance;
@@ -66,7 +22,7 @@ describe('POST /seed', () => {
 
   beforeEach(async () => {
     app = Fastify();
-    registerSeedRoute(app, makeDeps());
+    registerSeedRoute(app, makeTestDeps({ config: { depthWeight: 1 } }));
     await app.ready();
     ownerDir = join(testRoot, `owner-${Date.now().toString()}`);
   });

--- a/packages/service/src/routes/status.test.ts
+++ b/packages/service/src/routes/status.test.ts
@@ -5,64 +5,21 @@
  */
 
 import Fastify, { type FastifyInstance } from 'fastify';
-import type { Logger } from 'pino';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { SynthesisQueue } from '../queue/index.js';
 import type { RouteDeps } from './index.js';
+import { makeTestDeps, makeTestLogger } from './__testUtils.js';
 import { registerStatusRoute } from './status.js';
 
-function makeLogger(): Logger {
-  return {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
-    fatal: vi.fn(),
-    trace: vi.fn(),
-    child: vi.fn(),
-    level: 'info',
-  } as unknown as Logger;
-}
-
-function makeDeps(overrides: Partial<RouteDeps> = {}): RouteDeps {
-  return {
-    config: {
-      watcherUrl: 'http://localhost:3456',
-      gatewayUrl: 'http://127.0.0.1:18789',
-      depthWeight: 0.5,
-      architectEvery: 10,
-      maxArchive: 20,
-      maxLines: 500,
-      architectTimeout: 120,
-      builderTimeout: 600,
-      criticTimeout: 300,
-      thinking: 'low',
-      defaultArchitect: 'arch',
-      defaultCritic: 'crit',
-      skipUnchanged: true,
-      metaProperty: {},
-      metaArchiveProperty: {},
-      port: 1938,
-      schedule: '*/30 * * * *',
-      watcherHealthIntervalMs: 60000,
-      logging: { level: 'info' },
-      autoSeed: [],
-    },
-    logger: makeLogger(),
-    queue: new SynthesisQueue(makeLogger()),
-    watcher: {} as RouteDeps['watcher'],
-    scheduler: null,
-    stats: {
-      totalSyntheses: 5,
-      totalTokens: 12000,
-      totalErrors: 1,
-      lastCycleDurationMs: 45000,
-      lastCycleAt: '2026-03-24T08:00:00Z',
-    },
-    ...overrides,
-  };
-}
+/** Custom stats used by status tests. */
+const TEST_STATS: RouteDeps['stats'] = {
+  totalSyntheses: 5,
+  totalTokens: 12000,
+  totalErrors: 1,
+  lastCycleDurationMs: 45000,
+  lastCycleAt: '2026-03-24T08:00:00Z',
+};
 
 interface StatusResponse {
   name: string;
@@ -96,7 +53,10 @@ describe('GET /status', () => {
   });
 
   it('returns service name, version, uptime', async () => {
-    const deps = makeDeps();
+    const deps = makeTestDeps({
+      queue: new SynthesisQueue(makeTestLogger()),
+      stats: TEST_STATS,
+    });
     app = Fastify();
     registerStatusRoute(app, deps);
     await app.ready();
@@ -112,7 +72,10 @@ describe('GET /status', () => {
   });
 
   it('returns SDK status and nested dependency health', async () => {
-    const deps = makeDeps();
+    const deps = makeTestDeps({
+      queue: new SynthesisQueue(makeTestLogger()),
+      stats: TEST_STATS,
+    });
     app = Fastify();
     registerStatusRoute(app, deps);
     await app.ready();
@@ -126,12 +89,12 @@ describe('GET /status', () => {
   });
 
   it('includes queue state', async () => {
-    const logger = makeLogger();
+    const logger = makeTestLogger();
     const queue = new SynthesisQueue(logger);
     queue.enqueue('/meta/a');
     queue.enqueue('/meta/b', true);
 
-    const deps = makeDeps({ queue });
+    const deps = makeTestDeps({ queue, stats: TEST_STATS });
     app = Fastify();
     registerStatusRoute(app, deps);
     await app.ready();
@@ -145,7 +108,10 @@ describe('GET /status', () => {
   });
 
   it('includes stats (totalSyntheses, totalTokens, etc.)', async () => {
-    const deps = makeDeps();
+    const deps = makeTestDeps({
+      queue: new SynthesisQueue(makeTestLogger()),
+      stats: TEST_STATS,
+    });
     app = Fastify();
     registerStatusRoute(app, deps);
     await app.ready();
@@ -161,7 +127,10 @@ describe('GET /status', () => {
   });
 
   it('includes schedule info (expression, nextAt)', async () => {
-    const deps = makeDeps();
+    const deps = makeTestDeps({
+      queue: new SynthesisQueue(makeTestLogger()),
+      stats: TEST_STATS,
+    });
     app = Fastify();
     registerStatusRoute(app, deps);
     await app.ready();
@@ -174,12 +143,12 @@ describe('GET /status', () => {
   });
 
   it('shows currentTarget in nested health when synthesis is active', async () => {
-    const logger = makeLogger();
+    const logger = makeTestLogger();
     const queue = new SynthesisQueue(logger);
     queue.enqueue('/meta/active');
     queue.dequeue();
 
-    const deps = makeDeps({ queue });
+    const deps = makeTestDeps({ queue, stats: TEST_STATS });
     app = Fastify();
     registerStatusRoute(app, deps);
     await app.ready();
@@ -192,7 +161,10 @@ describe('GET /status', () => {
   });
 
   it('returns serviceState "idle" when nothing is happening', async () => {
-    const deps = makeDeps();
+    const deps = makeTestDeps({
+      queue: new SynthesisQueue(makeTestLogger()),
+      stats: TEST_STATS,
+    });
     app = Fastify();
     registerStatusRoute(app, deps);
     await app.ready();
@@ -203,12 +175,12 @@ describe('GET /status', () => {
   });
 
   it('returns serviceState "synthesizing" when a synthesis is in progress', async () => {
-    const logger = makeLogger();
+    const logger = makeTestLogger();
     const queue = new SynthesisQueue(logger);
     queue.enqueue('/meta/active');
     queue.dequeue();
 
-    const deps = makeDeps({ queue });
+    const deps = makeTestDeps({ queue, stats: TEST_STATS });
     app = Fastify();
     registerStatusRoute(app, deps);
     await app.ready();
@@ -219,11 +191,11 @@ describe('GET /status', () => {
   });
 
   it('returns serviceState "waiting" when queue has items but none processing', async () => {
-    const logger = makeLogger();
+    const logger = makeTestLogger();
     const queue = new SynthesisQueue(logger);
     queue.enqueue('/meta/pending');
 
-    const deps = makeDeps({ queue });
+    const deps = makeTestDeps({ queue, stats: TEST_STATS });
     app = Fastify();
     registerStatusRoute(app, deps);
     await app.ready();
@@ -234,7 +206,11 @@ describe('GET /status', () => {
   });
 
   it('returns serviceState "stopping" during shutdown', async () => {
-    const deps = makeDeps({ shuttingDown: true });
+    const deps = makeTestDeps({
+      queue: new SynthesisQueue(makeTestLogger()),
+      shuttingDown: true,
+      stats: TEST_STATS,
+    });
     app = Fastify();
     registerStatusRoute(app, deps);
     await app.ready();

--- a/packages/service/src/routes/status.test.ts
+++ b/packages/service/src/routes/status.test.ts
@@ -8,8 +8,8 @@ import Fastify, { type FastifyInstance } from 'fastify';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { SynthesisQueue } from '../queue/index.js';
-import type { RouteDeps } from './index.js';
 import { makeTestDeps, makeTestLogger } from './__testUtils.js';
+import type { RouteDeps } from './index.js';
 import { registerStatusRoute } from './status.js';
 
 /** Custom stats used by status tests. */

--- a/packages/service/src/routes/status.ts
+++ b/packages/service/src/routes/status.ts
@@ -12,7 +12,11 @@ import type { FastifyInstance } from 'fastify';
 
 import { SERVICE_NAME, SERVICE_VERSION } from '../constants.js';
 import { listMetas } from '../discovery/index.js';
-import { derivePhaseState, selectPhaseCandidate } from '../phaseState/index.js';
+import {
+  buildPhaseCandidates,
+  derivePhaseState,
+  selectPhaseCandidate,
+} from '../phaseState/index.js';
 import type { PhaseName, PhaseStatus } from '../schema/meta.js';
 import type { RouteDeps } from './index.js';
 
@@ -112,24 +116,16 @@ export function registerStatusRoute(
       try {
         const metaResult = await listMetas(config, watcher);
 
-        const candidates = [];
-
+        // Count raw phase states (before retry) for display
         for (const entry of metaResult.entries) {
           const ps = derivePhaseState(entry.meta);
-          // Count phase states
           for (const phase of ['architect', 'builder', 'critic'] as const) {
             phaseStateSummary[phase][ps[phase]]++;
           }
-
-          candidates.push({
-            node: entry.node,
-            meta: entry.meta,
-            phaseState: ps,
-            actualStaleness: entry.stalenessSeconds,
-            locked: entry.locked,
-            disabled: entry.disabled,
-          });
         }
+
+        // Build candidates (with auto-retry) for scheduling
+        const candidates = buildPhaseCandidates(metaResult.entries);
 
         // Find next phase candidate
         const winner = selectPhaseCandidate(candidates, config.depthWeight);

--- a/packages/service/src/routes/status.ts
+++ b/packages/service/src/routes/status.ts
@@ -11,6 +11,9 @@ import { createStatusHandler } from '@karmaniverous/jeeves';
 import type { FastifyInstance } from 'fastify';
 
 import { SERVICE_NAME, SERVICE_VERSION } from '../constants.js';
+import { listMetas } from '../discovery/index.js';
+import { derivePhaseState, selectPhaseCandidate } from '../phaseState/index.js';
+import type { PhaseName, PhaseStatus } from '../schema/meta.js';
 import type { RouteDeps } from './index.js';
 
 interface DepHealth {
@@ -35,7 +38,6 @@ async function checkDependency(url: string, path: string): Promise<DepHealth> {
   }
 }
 
-/** Check watcher, surfacing initialScan.active as indexing state. */
 async function checkWatcher(url: string): Promise<WatcherHealth> {
   const checkedAt = new Date().toISOString();
   try {
@@ -65,9 +67,16 @@ export type ServiceState = 'idle' | 'synthesizing' | 'waiting' | 'stopping';
 /** Derive service-specific state from current activity and lifecycle. */
 function deriveServiceState(deps: RouteDeps): ServiceState {
   if (deps.shuttingDown) return 'stopping';
-  if (deps.queue.current) return 'synthesizing';
-  if (deps.queue.depth > 0) return 'waiting';
+  if (deps.queue.current || deps.queue.currentPhase) return 'synthesizing';
+  if (deps.queue.depth > 0 || deps.queue.overrides.length > 0) return 'waiting';
   return 'idle';
+}
+
+/** Phase state count record. */
+type PhaseStateCounts = Record<PhaseStatus, number>;
+
+function emptyPhaseCounts(): PhaseStateCounts {
+  return { fresh: 0, stale: 0, pending: 0, running: 0, failed: 0 };
 }
 
 export function registerStatusRoute(
@@ -78,7 +87,7 @@ export function registerStatusRoute(
     name: SERVICE_NAME,
     version: SERVICE_VERSION,
     getHealth: async () => {
-      const { config, queue, scheduler, stats } = deps;
+      const { config, queue, scheduler, stats, watcher } = deps;
 
       // On-demand dependency checks
       const [watcherHealth, gatewayHealth] = await Promise.all([
@@ -86,9 +95,59 @@ export function registerStatusRoute(
         checkDependency(config.gatewayUrl, '/status'),
       ]);
 
+      // Phase state summary
+      const phaseStateSummary: Record<PhaseName, PhaseStateCounts> = {
+        architect: emptyPhaseCounts(),
+        builder: emptyPhaseCounts(),
+        critic: emptyPhaseCounts(),
+      };
+
+      let nextPhase: {
+        path: string;
+        phase: PhaseName;
+        band: number;
+        staleness: number;
+      } | null = null;
+
+      try {
+        const metaResult = await listMetas(config, watcher);
+
+        const candidates = [];
+
+        for (const entry of metaResult.entries) {
+          const ps = derivePhaseState(entry.meta);
+          // Count phase states
+          for (const phase of ['architect', 'builder', 'critic'] as const) {
+            phaseStateSummary[phase][ps[phase]]++;
+          }
+
+          candidates.push({
+            node: entry.node,
+            meta: entry.meta,
+            phaseState: ps,
+            actualStaleness: entry.stalenessSeconds,
+            locked: entry.locked,
+            disabled: entry.disabled,
+          });
+        }
+
+        // Find next phase candidate
+        const winner = selectPhaseCandidate(candidates, config.depthWeight);
+        if (winner) {
+          nextPhase = {
+            path: winner.node.metaPath,
+            phase: winner.owedPhase,
+            band: winner.band,
+            staleness: winner.effectiveStaleness,
+          };
+        }
+      } catch {
+        // Watcher unreachable — phase summary unavailable
+      }
+
       return {
         serviceState: deriveServiceState(deps),
-        currentTarget: queue.current?.path ?? null,
+        currentTarget: queue.current?.path ?? queue.currentPhase?.path ?? null,
         queue: queue.getState(),
         stats: {
           totalSyntheses: stats.totalSyntheses,
@@ -108,6 +167,8 @@ export function registerStatusRoute(
           },
           gateway: gatewayHealth,
         },
+        phaseStateSummary,
+        nextPhase,
       };
     },
   });

--- a/packages/service/src/routes/synthesize.test.ts
+++ b/packages/service/src/routes/synthesize.test.ts
@@ -4,16 +4,21 @@
  * @module routes/synthesize.test
  */
 
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import Fastify, { type FastifyInstance } from 'fastify';
-import type { Logger } from 'pino';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
-import type { WatcherClient } from '../interfaces/index.js';
 import { SynthesisQueue } from '../queue/index.js';
+import {
+  createTestMeta,
+  makeFailingTestWatcher,
+  makeTestDeps,
+  makeTestLogger,
+  makeTestWatcher,
+} from './__testUtils.js';
 import type { RouteDeps } from './index.js';
 import { registerSynthesizeRoute } from './synthesize.js';
 
@@ -21,81 +26,6 @@ const synthRoot = join(
   tmpdir(),
   `jeeves-meta-synthesize-${Date.now().toString()}`,
 );
-
-function makeLogger(): Logger {
-  return {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    debug: vi.fn(),
-    fatal: vi.fn(),
-    trace: vi.fn(),
-    child: vi.fn(),
-    level: 'info',
-  } as unknown as Logger;
-}
-
-function makeDeps(overrides: Partial<RouteDeps> = {}): RouteDeps {
-  return {
-    config: {
-      watcherUrl: 'http://localhost:3456',
-      gatewayUrl: 'http://127.0.0.1:18789',
-      depthWeight: 0.5,
-      architectEvery: 10,
-      maxArchive: 20,
-      maxLines: 500,
-      architectTimeout: 120,
-      builderTimeout: 600,
-      criticTimeout: 300,
-      thinking: 'low',
-      defaultArchitect: 'arch',
-      defaultCritic: 'crit',
-      skipUnchanged: true,
-      metaProperty: {},
-      metaArchiveProperty: {},
-      port: 1938,
-      schedule: '*/30 * * * *',
-      watcherHealthIntervalMs: 60000,
-      logging: { level: 'info' },
-      autoSeed: [],
-    },
-    logger: makeLogger(),
-    queue: new SynthesisQueue(makeLogger()),
-    watcher: {} as RouteDeps['watcher'],
-    scheduler: null,
-    stats: {
-      totalSyntheses: 0,
-      totalTokens: 0,
-      totalErrors: 0,
-      lastCycleDurationMs: null,
-      lastCycleAt: null,
-    },
-    ...overrides,
-  };
-}
-
-function makeWatcher(metaJsonPaths: string[]): WatcherClient {
-  return {
-    walk: vi.fn().mockResolvedValue(metaJsonPaths),
-    registerRules: vi.fn().mockResolvedValue(undefined),
-  };
-}
-
-function createMeta(
-  ownerDir: string,
-  meta: Record<string, unknown> = {},
-): string {
-  const metaDir = join(ownerDir, '.meta');
-  mkdirSync(metaDir, { recursive: true });
-  writeFileSync(
-    join(metaDir, 'meta.json'),
-    JSON.stringify({
-      _id: '550e8400-e29b-41d4-a716-446655440099',
-      ...meta,
-    }),
-  );
-  return join(metaDir, 'meta.json');
-}
 
 describe('POST /synthesize', () => {
   let app: FastifyInstance;
@@ -106,9 +36,9 @@ describe('POST /synthesize', () => {
   });
 
   it('enqueues synthesis for a valid path', async () => {
-    const logger = makeLogger();
+    const logger = makeTestLogger();
     const queue = new SynthesisQueue(logger);
-    const deps = makeDeps({ queue });
+    const deps = makeTestDeps({ queue });
     app = Fastify();
     registerSynthesizeRoute(app, deps);
     await app.ready();
@@ -135,9 +65,9 @@ describe('POST /synthesize', () => {
   });
 
   it('normalizes owner path to .meta path', async () => {
-    const logger = makeLogger();
+    const logger = makeTestLogger();
     const queue = new SynthesisQueue(logger);
-    const deps = makeDeps({ queue });
+    const deps = makeTestDeps({ queue });
     app = Fastify();
     registerSynthesizeRoute(app, deps);
     await app.ready();
@@ -156,9 +86,9 @@ describe('POST /synthesize', () => {
   });
 
   it('preserves path already ending in .meta', async () => {
-    const logger = makeLogger();
+    const logger = makeTestLogger();
     const queue = new SynthesisQueue(logger);
-    const deps = makeDeps({ queue });
+    const deps = makeTestDeps({ queue });
     app = Fastify();
     registerSynthesizeRoute(app, deps);
     await app.ready();
@@ -177,12 +107,12 @@ describe('POST /synthesize', () => {
   });
 
   it('returns queue position', async () => {
-    const logger = makeLogger();
+    const logger = makeTestLogger();
     const queue = new SynthesisQueue(logger);
     queue.enqueue('/meta/first');
     queue.enqueue('/meta/second');
 
-    const deps = makeDeps({ queue });
+    const deps = makeTestDeps({ queue });
     app = Fastify();
     registerSynthesizeRoute(app, deps);
     await app.ready();
@@ -200,10 +130,10 @@ describe('POST /synthesize', () => {
   });
 
   it('returns already-queued status for duplicate path', async () => {
-    const logger = makeLogger();
+    const logger = makeTestLogger();
     const queue = new SynthesisQueue(logger);
 
-    const deps = makeDeps({ queue });
+    const deps = makeTestDeps({ queue });
     app = Fastify();
     registerSynthesizeRoute(app, deps);
     await app.ready();
@@ -233,15 +163,15 @@ describe('POST /synthesize', () => {
 
   it('discovers stalest candidate when no path provided', async () => {
     const owner = join(synthRoot, 'stale');
-    const metaJsonPath = createMeta(owner, {
+    const metaJsonPath = createTestMeta(owner, {
       _id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
       _generatedAt: new Date(Date.now() - 86400_000).toISOString(),
     });
-    const watcher = makeWatcher([metaJsonPath]);
-    const logger = makeLogger();
+    const watcher = makeTestWatcher([metaJsonPath]);
+    const logger = makeTestLogger();
     const queue = new SynthesisQueue(logger);
 
-    const deps = makeDeps({
+    const deps = makeTestDeps({
       queue,
       watcher: watcher as unknown as RouteDeps['watcher'],
     });
@@ -263,16 +193,16 @@ describe('POST /synthesize', () => {
 
   it('skips disabled metas during auto-select but honors explicit path', async () => {
     const ownerStale = join(synthRoot, 'disabled-stale');
-    const metaJsonPath = createMeta(ownerStale, {
+    const metaJsonPath = createTestMeta(ownerStale, {
       _id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
       _generatedAt: new Date(Date.now() - 86400_000).toISOString(),
       _disabled: true,
     });
-    const watcher = makeWatcher([metaJsonPath]);
-    const logger = makeLogger();
+    const watcher = makeTestWatcher([metaJsonPath]);
+    const logger = makeTestLogger();
     const queue = new SynthesisQueue(logger);
 
-    const deps = makeDeps({
+    const deps = makeTestDeps({
       queue,
       watcher: watcher as unknown as RouteDeps['watcher'],
     });
@@ -305,16 +235,12 @@ describe('POST /synthesize', () => {
   });
 
   it('returns 503 when watcher unreachable and no path provided', async () => {
-    const watcher: WatcherClient = {
-      walk: vi.fn().mockRejectedValue(new Error('connection refused')),
-      registerRules: vi.fn().mockResolvedValue(undefined),
-    };
-    const logger = makeLogger();
+    const logger = makeTestLogger();
     const queue = new SynthesisQueue(logger);
 
-    const deps = makeDeps({
+    const deps = makeTestDeps({
       queue,
-      watcher: watcher as unknown as RouteDeps['watcher'],
+      watcher: makeFailingTestWatcher() as unknown as RouteDeps['watcher'],
     });
     app = Fastify();
     registerSynthesizeRoute(app, deps);

--- a/packages/service/src/routes/synthesize.test.ts
+++ b/packages/service/src/routes/synthesize.test.ts
@@ -127,11 +127,11 @@ describe('POST /synthesize', () => {
       alreadyQueued: boolean;
     }>();
 
-    expect(body.status).toBe('accepted');
+    expect(body.status).toBe('queued');
     expect(body.path).toBe('/meta/target/.meta');
     expect(body.queuePosition).toBe(0);
     expect(body.alreadyQueued).toBe(false);
-    expect(queue.depth).toBe(1);
+    expect(queue.overrides).toHaveLength(1);
   });
 
   it('normalizes owner path to .meta path', async () => {
@@ -150,9 +150,9 @@ describe('POST /synthesize', () => {
 
     expect(res.statusCode).toBe(202);
     const body = res.json<{ status: string; path: string }>();
-    expect(body.status).toBe('accepted');
+    expect(body.status).toBe('queued');
     expect(body.path).toMatch(/[/\\]some[/\\]owner[/\\]dir[/\\]\.meta$/);
-    expect(queue.depth).toBe(1);
+    expect(queue.overrides).toHaveLength(1);
   });
 
   it('preserves path already ending in .meta', async () => {
@@ -171,9 +171,9 @@ describe('POST /synthesize', () => {
 
     expect(res.statusCode).toBe(202);
     const body = res.json<{ status: string; path: string }>();
-    expect(body.status).toBe('accepted');
+    expect(body.status).toBe('queued');
     expect(body.path).toBe('/some/owner/dir/.meta');
-    expect(queue.depth).toBe(1);
+    expect(queue.overrides).toHaveLength(1);
   });
 
   it('returns queue position', async () => {
@@ -227,7 +227,7 @@ describe('POST /synthesize', () => {
       alreadyQueued: boolean;
     }>();
 
-    expect(body.status).toBe('accepted');
+    expect(body.status).toBe('queued');
     expect(body.alreadyQueued).toBe(true);
   });
 
@@ -299,9 +299,9 @@ describe('POST /synthesize', () => {
     });
     expect(resExplicit.statusCode).toBe(202);
     const bodyExplicit = resExplicit.json<{ status: string; path: string }>();
-    expect(bodyExplicit.status).toBe('accepted');
+    expect(bodyExplicit.status).toBe('queued');
     expect(bodyExplicit.path).toContain('disabled-stale');
-    expect(queue.depth).toBe(1);
+    expect(queue.overrides).toHaveLength(1);
   });
 
   it('returns 503 when watcher unreachable and no path provided', async () => {

--- a/packages/service/src/routes/synthesize.ts
+++ b/packages/service/src/routes/synthesize.ts
@@ -36,30 +36,24 @@ export function registerSynthesizeRoute(
 
       // Read meta to determine owed phase
       let owedPhase: string | null = null;
+      let meta;
       try {
-        const meta = await readMetaJson(targetPath);
+        meta = await readMetaJson(targetPath);
         const phaseState = derivePhaseState(meta);
         owedPhase = getOwedPhase(phaseState);
       } catch {
         // Meta unreadable — proceed, phase will be evaluated at dequeue time
       }
 
-      // Fully fresh meta → skip
-      if (owedPhase === null) {
-        try {
-          const meta = await readMetaJson(targetPath);
-          if (meta._phaseState || meta._content) {
-            return await reply.code(200).send({
-              status: 'skipped',
-              path: targetPath,
-              owedPhase: null,
-              queuePosition: -1,
-              alreadyQueued: false,
-            });
-          }
-        } catch {
-          // If we can't read it, still enqueue as override
-        }
+      // Fully fresh meta → skip (reuse meta already read above)
+      if (owedPhase === null && meta && (meta._phaseState || meta._content)) {
+        return await reply.code(200).send({
+          status: 'skipped',
+          path: targetPath,
+          owedPhase: null,
+          queuePosition: -1,
+          alreadyQueued: false,
+        });
       }
 
       const result = queue.enqueueOverride(targetPath);

--- a/packages/service/src/routes/synthesize.ts
+++ b/packages/service/src/routes/synthesize.ts
@@ -1,6 +1,9 @@
 /**
  * POST /synthesize route handler.
  *
+ * Path-targeted triggers create explicit override entries in the queue.
+ * Corpus-wide triggers discover the stalest candidate.
+ *
  * @module routes/synthesize
  */
 
@@ -9,6 +12,8 @@ import { z } from 'zod';
 
 import { listMetas } from '../discovery/index.js';
 import { resolveMetaDir } from '../lock.js';
+import { derivePhaseState, getOwedPhase } from '../phaseState/index.js';
+import { readMetaJson } from '../readMetaJson.js';
 import { discoverStalestPath } from '../scheduling/index.js';
 import type { RouteDeps } from './index.js';
 
@@ -25,44 +30,80 @@ export function registerSynthesizeRoute(
     const body = synthesizeBodySchema.parse(request.body);
     const { config, watcher, queue } = deps;
 
-    let targetPath: string;
     if (body.path) {
-      targetPath = resolveMetaDir(body.path);
-    } else {
-      // Discover stalest candidate
-      let result;
+      // Path-targeted trigger: create override entry
+      const targetPath = resolveMetaDir(body.path);
+
+      // Read meta to determine owed phase
+      let owedPhase: string | null = null;
       try {
-        result = await listMetas(config, watcher);
+        const meta = await readMetaJson(targetPath);
+        const phaseState = derivePhaseState(meta);
+        owedPhase = getOwedPhase(phaseState);
       } catch {
-        return reply.status(503).send({
-          error: 'SERVICE_UNAVAILABLE',
-          message: 'Watcher unreachable — cannot discover candidates',
-        });
+        // Meta unreadable — proceed, phase will be evaluated at dequeue time
       }
-      const stale = result.entries
-        .filter((e) => e.stalenessSeconds > 0 && !e.disabled)
-        .map((e) => ({
-          node: e.node,
-          meta: e.meta,
-          actualStaleness: e.stalenessSeconds,
-        }));
-      const stalest = discoverStalestPath(stale, config.depthWeight);
-      if (!stalest) {
-        return reply.code(200).send({
-          status: 'skipped',
-          message: 'No stale metas found. Nothing to synthesize.',
-        });
+
+      // Fully fresh meta → skip
+      if (owedPhase === null) {
+        try {
+          const meta = await readMetaJson(targetPath);
+          if (meta._phaseState || meta._content) {
+            return await reply.code(200).send({
+              status: 'skipped',
+              path: targetPath,
+              owedPhase: null,
+              queuePosition: -1,
+              alreadyQueued: false,
+            });
+          }
+        } catch {
+          // If we can't read it, still enqueue as override
+        }
       }
-      targetPath = stalest;
+
+      const result = queue.enqueueOverride(targetPath);
+      return reply.code(202).send({
+        status: 'queued',
+        path: targetPath,
+        owedPhase,
+        queuePosition: result.position,
+        alreadyQueued: result.alreadyQueued,
+      });
     }
 
-    const result = queue.enqueue(targetPath, body.path !== undefined);
+    // Corpus-wide trigger: discover stalest candidate
+    let result;
+    try {
+      result = await listMetas(config, watcher);
+    } catch {
+      return reply.status(503).send({
+        error: 'SERVICE_UNAVAILABLE',
+        message: 'Watcher unreachable — cannot discover candidates',
+      });
+    }
+    const stale = result.entries
+      .filter((e) => e.stalenessSeconds > 0 && !e.disabled)
+      .map((e) => ({
+        node: e.node,
+        meta: e.meta,
+        actualStaleness: e.stalenessSeconds,
+      }));
+    const stalest = discoverStalestPath(stale, config.depthWeight);
+    if (!stalest) {
+      return reply.code(200).send({
+        status: 'skipped',
+        message: 'No stale metas found. Nothing to synthesize.',
+      });
+    }
+
+    const enqueueResult = queue.enqueue(stalest);
 
     return reply.code(202).send({
       status: 'accepted',
-      path: targetPath,
-      queuePosition: result.position,
-      alreadyQueued: result.alreadyQueued,
+      path: stalest,
+      queuePosition: enqueueResult.position,
+      alreadyQueued: enqueueResult.alreadyQueued,
     });
   });
 }

--- a/packages/service/src/routes/unlock.test.ts
+++ b/packages/service/src/routes/unlock.test.ts
@@ -9,59 +9,15 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import Fastify, { type FastifyInstance } from 'fastify';
-import type { Logger } from 'pino';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
-import type { RouteDeps } from './index.js';
+import { makeTestDeps } from './__testUtils.js';
 import { registerUnlockRoute } from './unlock.js';
 
 const unlockRoot = join(
   tmpdir(),
   `jeeves-meta-unlock-${Date.now().toString()}`,
 );
-
-function makeDeps(overrides: Partial<RouteDeps> = {}): RouteDeps {
-  return {
-    config: {
-      watcherUrl: 'http://localhost:3456',
-      gatewayUrl: 'http://127.0.0.1:18789',
-      depthWeight: 0.5,
-      architectEvery: 10,
-      maxArchive: 20,
-      maxLines: 500,
-      architectTimeout: 120,
-      builderTimeout: 600,
-      criticTimeout: 300,
-      thinking: 'low',
-      defaultArchitect: 'arch',
-      defaultCritic: 'crit',
-      skipUnchanged: true,
-      metaProperty: {},
-      metaArchiveProperty: {},
-      port: 1938,
-      schedule: '*/30 * * * *',
-      watcherHealthIntervalMs: 60000,
-      logging: { level: 'info' },
-      autoSeed: [],
-    },
-    logger: {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    } as unknown as Logger,
-    queue: {} as RouteDeps['queue'],
-    watcher: {} as RouteDeps['watcher'],
-    scheduler: null,
-    stats: {
-      totalSyntheses: 0,
-      totalTokens: 0,
-      totalErrors: 0,
-      lastCycleDurationMs: null,
-      lastCycleAt: null,
-    },
-    ...overrides,
-  };
-}
 
 describe('POST /unlock', () => {
   let app: FastifyInstance;
@@ -82,7 +38,7 @@ describe('POST /unlock', () => {
       }),
     );
 
-    const deps = makeDeps();
+    const deps = makeTestDeps();
     app = Fastify();
     registerUnlockRoute(app, deps);
     await app.ready();
@@ -105,7 +61,7 @@ describe('POST /unlock', () => {
     mkdirSync(metaDir, { recursive: true });
     // No .lock file created
 
-    const deps = makeDeps();
+    const deps = makeTestDeps();
     app = Fastify();
     registerUnlockRoute(app, deps);
     await app.ready();
@@ -124,7 +80,7 @@ describe('POST /unlock', () => {
   it('returns 409 when meta path does not exist', async () => {
     const nonExistent = join(unlockRoot, 'nonexistent', '.meta');
 
-    const deps = makeDeps();
+    const deps = makeTestDeps();
     app = Fastify();
     registerUnlockRoute(app, deps);
     await app.ready();

--- a/packages/service/src/scheduler/index.ts
+++ b/packages/service/src/scheduler/index.ts
@@ -10,9 +10,7 @@ import type { Logger } from 'pino';
 
 import { listMetas } from '../discovery/index.js';
 import {
-  derivePhaseState,
-  getOwedPhase,
-  retryPhase,
+  buildPhaseCandidates,
   selectPhaseCandidate,
 } from '../phaseState/index.js';
 import type { SynthesisQueue } from '../queue/index.js';
@@ -216,29 +214,7 @@ export class Scheduler {
     try {
       const result = await listMetas(this.config, this.watcher);
 
-      const candidates = result.entries
-        .map((e) => {
-          let phaseState = derivePhaseState(e.meta);
-
-          // Surgical retry: promote failed phases to pending
-          const owed = getOwedPhase(phaseState);
-          if (owed && phaseState[owed] === 'failed') {
-            phaseState = retryPhase(phaseState, owed);
-          }
-
-          return {
-            node: e.node,
-            meta: e.meta,
-            phaseState,
-            actualStaleness: e.stalenessSeconds,
-            locked: e.locked,
-            disabled: e.disabled,
-          };
-        })
-        .filter((c) => {
-          const owed = getOwedPhase(c.phaseState);
-          return owed !== null;
-        });
+      const candidates = buildPhaseCandidates(result.entries);
 
       const winner = selectPhaseCandidate(candidates, this.config.depthWeight);
 

--- a/packages/service/src/scheduler/index.ts
+++ b/packages/service/src/scheduler/index.ts
@@ -1,6 +1,6 @@
 /**
- * Croner-based scheduler that discovers the stalest meta candidate each tick
- * and enqueues it for synthesis.
+ * Croner-based scheduler that discovers the highest-priority ready phase
+ * across the corpus each tick and enqueues it for execution.
  *
  * @module scheduler
  */
@@ -9,17 +9,30 @@ import { Cron } from 'croner';
 import type { Logger } from 'pino';
 
 import { listMetas } from '../discovery/index.js';
+import {
+  derivePhaseState,
+  getOwedPhase,
+  retryPhase,
+  selectPhaseCandidate,
+} from '../phaseState/index.js';
 import type { SynthesisQueue } from '../queue/index.js';
 import type { RuleRegistrar } from '../rules/index.js';
-import { discoverStalestPath } from '../scheduling/index.js';
 import type { ServiceConfig } from '../schema/config.js';
 import { autoSeedPass } from '../seed/index.js';
 import type { HttpWatcherClient } from '../watcher-client/index.js';
 
 const MAX_BACKOFF_MULTIPLIER = 4;
 
+/** Result of a scheduler tick's candidate discovery. */
+export interface TickCandidate {
+  path: string;
+  phase: 'architect' | 'builder' | 'critic';
+  band: number;
+}
+
 /**
- * Periodic scheduler that discovers stale meta candidates and enqueues them.
+ * Periodic scheduler that discovers the highest-priority ready phase
+ * across all metas and enqueues it for execution.
  *
  * Supports adaptive backoff when no candidates are found and hot-reloadable
  * cron expressions via {@link Scheduler.updateSchedule}.
@@ -89,10 +102,10 @@ export class Scheduler {
     }
   }
 
-  /** Reset backoff multiplier (call after successful synthesis). */
+  /** Reset backoff multiplier (call after successful phase execution). */
   resetBackoff(): void {
     if (this.backoffMultiplier > 1) {
-      this.logger.debug('Backoff reset after successful synthesis');
+      this.logger.debug('Backoff reset after successful phase execution');
     }
     this.backoffMultiplier = 1;
   }
@@ -109,10 +122,9 @@ export class Scheduler {
   }
 
   /**
-   * Single tick: discover stalest candidate and enqueue it.
+   * Single tick: discover the highest-priority ready phase and enqueue it.
    *
-   * Skips if the queue is currently processing. Applies adaptive backoff
-   * when no candidates are found.
+   * Applies adaptive backoff when no candidates are found.
    */
   private async tick(): Promise<void> {
     this.tickCount++;
@@ -151,7 +163,7 @@ export class Scheduler {
       }
     }
 
-    const candidate = await this.discoverStalest();
+    const candidate = await this.discoverNextPhase();
 
     if (!candidate) {
       this.backoffMultiplier = Math.min(
@@ -160,13 +172,17 @@ export class Scheduler {
       );
       this.logger.debug(
         { backoffMultiplier: this.backoffMultiplier },
-        'No stale candidates found, increasing backoff',
+        'No ready phases found, increasing backoff',
       );
       return;
     }
 
-    this.queue.enqueue(candidate);
-    this.logger.info({ path: candidate }, 'Enqueued stale candidate');
+    // Enqueue using the legacy queue path (backward compat with processQueue)
+    this.queue.enqueue(candidate.path);
+    this.logger.info(
+      { path: candidate.path, phase: candidate.phase, band: candidate.band },
+      'Enqueued phase candidate',
+    );
 
     // Opportunistic watcher restart detection
     if (this.registrar) {
@@ -190,21 +206,51 @@ export class Scheduler {
   }
 
   /**
-   * Discover the stalest meta candidate via watcher.
+   * Discover the highest-priority ready phase across the corpus.
+   *
+   * Uses phase-state-aware scheduling: priority order is
+   * critic (band 1) \> builder (band 2) \> architect (band 3),
+   * with weighted staleness as tiebreaker within a band.
    */
-  private async discoverStalest(): Promise<string | null> {
+  private async discoverNextPhase(): Promise<TickCandidate | null> {
     try {
       const result = await listMetas(this.config, this.watcher);
-      const stale = result.entries
-        .filter((e) => e.stalenessSeconds > 0 && !e.disabled)
-        .map((e) => ({
-          node: e.node,
-          meta: e.meta,
-          actualStaleness: e.stalenessSeconds,
-        }));
-      return discoverStalestPath(stale, this.config.depthWeight);
+
+      const candidates = result.entries
+        .map((e) => {
+          let phaseState = derivePhaseState(e.meta);
+
+          // Surgical retry: promote failed phases to pending
+          const owed = getOwedPhase(phaseState);
+          if (owed && phaseState[owed] === 'failed') {
+            phaseState = retryPhase(phaseState, owed);
+          }
+
+          return {
+            node: e.node,
+            meta: e.meta,
+            phaseState,
+            actualStaleness: e.stalenessSeconds,
+            locked: e.locked,
+            disabled: e.disabled,
+          };
+        })
+        .filter((c) => {
+          const owed = getOwedPhase(c.phaseState);
+          return owed !== null;
+        });
+
+      const winner = selectPhaseCandidate(candidates, this.config.depthWeight);
+
+      if (!winner) return null;
+
+      return {
+        path: winner.node.metaPath,
+        phase: winner.owedPhase,
+        band: winner.band,
+      };
     } catch (err) {
-      this.logger.warn({ err }, 'Failed to discover stalest candidate');
+      this.logger.warn({ err }, 'Failed to discover next phase candidate');
       return null;
     }
   }

--- a/packages/service/src/scheduler/scheduler.test.ts
+++ b/packages/service/src/scheduler/scheduler.test.ts
@@ -106,4 +106,23 @@ describe('Scheduler', () => {
     expect(scheduler.isRunning).toBe(true);
     expect(secondNext).not.toEqual(firstNext);
   });
+
+  it('resetBackoff sets backoffMultiplier to 1', () => {
+    scheduler.start();
+
+    // Access private backoffMultiplier to verify initial state
+    const getBackoff = () =>
+      (scheduler as unknown as { backoffMultiplier: number }).backoffMultiplier;
+
+    expect(getBackoff()).toBe(1);
+
+    // Simulate backoff increase by calling tick with no candidates multiple times
+    // Instead, directly set the private field to simulate backoff state
+    (scheduler as unknown as { backoffMultiplier: number }).backoffMultiplier =
+      4;
+    expect(getBackoff()).toBe(4);
+
+    scheduler.resetBackoff();
+    expect(getBackoff()).toBe(1);
+  });
 });

--- a/packages/service/src/schema/index.ts
+++ b/packages/service/src/schema/index.ts
@@ -12,4 +12,13 @@ export {
   serviceConfigSchema,
 } from './config.js';
 export { type MetaError, metaErrorSchema } from './error.js';
-export { type MetaJson, metaJsonSchema } from './meta.js';
+export {
+  type MetaJson,
+  metaJsonSchema,
+  type PhaseName,
+  phaseNames,
+  type PhaseState,
+  phaseStateSchema,
+  type PhaseStatus,
+  phaseStatuses,
+} from './meta.js';

--- a/packages/service/src/schema/meta.test.ts
+++ b/packages/service/src/schema/meta.test.ts
@@ -175,6 +175,35 @@ describe('metaJsonSchema', () => {
     expect(result.data?._disabled).toBeUndefined();
   });
 
+  it('rejects negative _emphasis', () => {
+    const result = metaJsonSchema.safeParse({
+      _emphasis: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts _emphasis of 0', () => {
+    const result = metaJsonSchema.safeParse({
+      _emphasis: 0,
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?._emphasis).toBe(0);
+  });
+
+  it('rejects non-integer _synthesisCount', () => {
+    const result = metaJsonSchema.safeParse({
+      _synthesisCount: 1.5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid _generatedAt datetime', () => {
+    const result = metaJsonSchema.safeParse({
+      _generatedAt: 'not-a-date',
+    });
+    expect(result.success).toBe(false);
+  });
+
   // ── _phaseState schema tests (Task #1 gap) ────────────────────────
 
   it('accepts valid _phaseState with all fresh', () => {

--- a/packages/service/src/schema/meta.test.ts
+++ b/packages/service/src/schema/meta.test.ts
@@ -174,4 +174,71 @@ describe('metaJsonSchema', () => {
     expect(result.success).toBe(true);
     expect(result.data?._disabled).toBeUndefined();
   });
+
+  // ── _phaseState schema tests (Task #1 gap) ────────────────────────
+
+  it('accepts valid _phaseState with all fresh', () => {
+    const result = metaJsonSchema.safeParse({
+      _phaseState: {
+        architect: 'fresh',
+        builder: 'fresh',
+        critic: 'fresh',
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?._phaseState).toEqual({
+      architect: 'fresh',
+      builder: 'fresh',
+      critic: 'fresh',
+    });
+  });
+
+  it('accepts valid _phaseState with mixed statuses', () => {
+    const result = metaJsonSchema.safeParse({
+      _phaseState: {
+        architect: 'pending',
+        builder: 'stale',
+        critic: 'failed',
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts _phaseState with running status', () => {
+    const result = metaJsonSchema.safeParse({
+      _phaseState: {
+        architect: 'fresh',
+        builder: 'running',
+        critic: 'stale',
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects _phaseState with invalid status string', () => {
+    const result = metaJsonSchema.safeParse({
+      _phaseState: {
+        architect: 'fresh',
+        builder: 'invalid_status',
+        critic: 'fresh',
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects _phaseState missing a phase key', () => {
+    const result = metaJsonSchema.safeParse({
+      _phaseState: {
+        architect: 'fresh',
+        builder: 'fresh',
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts meta without _phaseState (optional)', () => {
+    const result = metaJsonSchema.safeParse({});
+    expect(result.success).toBe(true);
+    expect(result.data?._phaseState).toBeUndefined();
+  });
 });

--- a/packages/service/src/schema/meta.ts
+++ b/packages/service/src/schema/meta.ts
@@ -11,6 +11,37 @@ import { z } from 'zod';
 
 import { metaErrorSchema } from './error.js';
 
+/** Phase names in pipeline order. */
+export const phaseNames = ['architect', 'builder', 'critic'] as const;
+
+/** A single synthesis phase name. */
+export type PhaseName = (typeof phaseNames)[number];
+
+/** Valid states for a synthesis phase. */
+export const phaseStatuses = [
+  'fresh',
+  'stale',
+  'pending',
+  'running',
+  'failed',
+] as const;
+
+/** A single phase status value. */
+export type PhaseStatus = (typeof phaseStatuses)[number];
+
+/** Per-phase state record. */
+export type PhaseState = Record<PhaseName, PhaseStatus>;
+
+/** Zod schema for a per-phase status value. */
+const phaseStatusSchema = z.enum(phaseStatuses);
+
+/** Zod schema for the per-meta phase state record. */
+export const phaseStateSchema = z.object({
+  architect: phaseStatusSchema,
+  builder: phaseStatusSchema,
+  critic: phaseStatusSchema,
+});
+
 /** Zod schema for the reserved (underscore-prefixed) meta.json properties. */
 export const metaJsonSchema = z
   .object({
@@ -114,6 +145,13 @@ export const metaJsonSchema = z
 
     /** When true, this meta is skipped during staleness scheduling. Manual trigger still works. */
     _disabled: z.boolean().optional(),
+
+    /**
+     * Per-phase state machine record. Engine-managed.
+     * Keyed by phase name (architect, builder, critic) with status values.
+     * Persisted to survive ticks; derived on first load for back-compat.
+     */
+    _phaseState: phaseStateSchema.optional(),
   })
   .loose();
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      '**/.rollup.cache/**',
+    ],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+    },
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,11 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    exclude: [
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/.rollup.cache/**',
-    ],
+    exclude: ['**/node_modules/**', '**/dist/**', '**/.rollup.cache/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],


### PR DESCRIPTION
## Phase-State Machine Implementation

Replaces the full-cycle-per-tick synthesis model with per-phase scheduling, enabling surgical retry, invalidation cascades, and a three-layer queue.

### Core Changes

- **Phase-state model:** Each meta tracks _phaseState with per-phase status (resh/stale/pending/unning/ailed). Back-compatible derivation from legacy metas.
- **Per-phase scheduling:** One phase per tick. Corpus-wide scheduler ranks candidates by priority band (critic > builder > architect) then weighted staleness.
- **Invalidation cascades:** Structure/steer/crossRef changes cascade forward (architect invalidation → builder/critic stale). Builder-only invalidations skip architect.
- **Surgical retry:** Failed phases retry individually without re-running successful predecessors.
- **Three-layer queue:** Automatic (computed from corpus), override (HTTP triggers), current (in-progress). \GET /queue\ returns all three.
- **Abort with phase-state integration:** \POST /synthesize/abort\ writes \_error.code: 'ABORT'\ and transitions phase to \ailed\. Race condition prevented via \executor.aborted\ guard in \unPhase\ catch blocks.
- **Skip-unchanged bump:** \_generatedAt\ bumped via lock-staged write for unchanged metas without altering \_phaseState\.

### Operator Surfaces

- \GET /status\: \phaseStateSummary\ (counts per phase per status) + \
extPhase\ (next scheduled candidate)
- \GET /preview\: \owedPhase\, \priorityBand\, \phaseState\, \stalenessInputs\, \rchitectInvalidators\
- \GET /metas\: \phaseState\ and \owedPhase\ in default projection
- \POST /synthesize\: Returns \owedPhase\ and \status: skipped\ for fully-fresh metas

### Code Quality

- SOLID/DRY refactoring pass: extracted shared test fixtures (\__testUtils.ts\), shared route helpers, \computeAutomaticCandidates()\, \utoRetryFailed()\. Net -448 lines.
- Test audit: 534 tests, no trivial tests, weak assertions strengthened, new coverage for previously untested exports.
- All quality gates green: tests, lint (0 errors/warnings), typecheck, knip, build.

### Documentation

- Root, service, and openclaw READMEs updated
- Service guides: orchestration, scheduling, concepts
- SKILL.md: phase-state awareness, troubleshooting
- Changelogs: 0.15.0 (service) and 0.12.0 (openclaw)

### Remaining for Release (#20)

- \
pm run docs\ (TypeDoc regeneration)
- Version bumps via \elease-it\
- Publish to npm
