### PR TITLE
fix: stateless gateway session spawning

### DIFF
--- a/packages/service/src/executor/GatewayExecutor.test.ts
+++ b/packages/service/src/executor/GatewayExecutor.test.ts
@@ -118,9 +118,8 @@ describe('GatewayExecutor.spawn', () => {
 
     expect(result.output).toContain('Test synthesis output');
     expect(result.tokens).toBe(5000);
-    expect(invokeSessionKeys.length).toBeGreaterThan(0);
-    expect(new Set(invokeSessionKeys).size).toBe(1);
-    expect(invokeSessionKeys[0]).toMatch(/^agent:main:meta-invoke:/);
+    // Stateless spawning: no parent sessionKey attached to requests
+    expect(invokeSessionKeys.length).toBe(0);
   });
 
   it('throws SpawnTimeoutError when deadline exceeded', async () => {

--- a/packages/service/src/executor/GatewayExecutor.ts
+++ b/packages/service/src/executor/GatewayExecutor.ts
@@ -135,17 +135,12 @@ export class GatewayExecutor implements MetaExecutor {
   /** Look up totalTokens for a session via sessions_list. */
   private async getSessionTokens(
     sessionKey: string,
-    invokeSessionKey?: string,
   ): Promise<number | undefined> {
     try {
-      const result = await this.invoke(
-        'sessions_list',
-        {
-          limit: 20,
-          messageLimit: 0,
-        },
-        invokeSessionKey,
-      );
+      const result = await this.invoke('sessions_list', {
+        limit: 20,
+        messageLimit: 0,
+      });
 
       const sessions = (result.result?.details?.sessions ??
         result.result?.sessions ??
@@ -187,7 +182,6 @@ export class GatewayExecutor implements MetaExecutor {
     // Generate unique output path for file-based output
     const outputId = randomUUID();
     const outputPath = this.workspaceDir + '/output-' + outputId + '.json';
-    const invokeSessionKey = 'agent:main:meta-invoke:' + outputId;
 
     // Append file output instruction to the task
     const taskWithOutput =
@@ -203,17 +197,13 @@ export class GatewayExecutor implements MetaExecutor {
     const labelBase = options?.label ?? 'jeeves-meta-synthesis';
     const label = labelBase + '-' + outputId.slice(0, 8);
 
-    const spawnResult = await this.invoke(
-      'sessions_spawn',
-      {
-        task: taskWithOutput,
-        label,
-        runTimeoutSeconds: timeoutSeconds,
-        ...(options?.thinking ? { thinking: options.thinking } : {}),
-        ...(options?.model ? { model: options.model } : {}),
-      },
-      invokeSessionKey,
-    );
+    const spawnResult = await this.invoke('sessions_spawn', {
+      task: taskWithOutput,
+      label,
+      runTimeoutSeconds: timeoutSeconds,
+      ...(options?.thinking ? { thinking: options.thinking } : {}),
+      ...(options?.model ? { model: options.model } : {}),
+    });
 
     const details = (spawnResult.result?.details ?? spawnResult.result) as
       | Record<string, unknown>
@@ -238,15 +228,11 @@ export class GatewayExecutor implements MetaExecutor {
       }
 
       try {
-        const historyResult = await this.invoke(
-          'sessions_history',
-          {
-            sessionKey,
-            limit: 5,
-            includeTools: false,
-          },
-          invokeSessionKey,
-        );
+        const historyResult = await this.invoke('sessions_history', {
+          sessionKey,
+          limit: 5,
+          includeTools: false,
+        });
 
         const messages =
           historyResult.result?.details?.messages ??
@@ -270,10 +256,7 @@ export class GatewayExecutor implements MetaExecutor {
             lastMsg.stopReason !== 'error'
           ) {
             // Fetch token usage from session metadata
-            const tokens = await this.getSessionTokens(
-              sessionKey,
-              invokeSessionKey,
-            );
+            const tokens = await this.getSessionTokens(sessionKey);
 
             // Read output from file (sub-agent wrote it via Write tool)
             if (existsSync(outputPath)) {


### PR DESCRIPTION
Drops the synthetic parent \sessionKey\ (\gent:main:meta-invoke:<uuid>\) from \GatewayExecutor\, spawning sessions statelessly — the same way runner does successfully.

**Root cause:** Meta's nested parent-child session path triggers a gateway bug where the child session is registered but never starts execution. Runner avoids this by spawning without a parent session key.

**Change:** Removed \invokeSessionKey\ from all \/tools/invoke\ calls in \GatewayExecutor.spawn()\, \sessions_history\ polling, and \sessions_list\ token lookup.

534 tests passing, all gates green.