### PR TITLE
fix: suppress sub-agent chat replies from synthesis sessions

### DIFF
--- a/packages/service/src/executor/GatewayExecutor.ts
+++ b/packages/service/src/executor/GatewayExecutor.ts
@@ -190,7 +190,7 @@ export class GatewayExecutor implements MetaExecutor {
       'Write your complete output to a file using the Write tool at:\n' +
       outputPath +
       '\n\n' +
-      'Reply with ONLY the file path you wrote to. No other text.';
+      'After writing the file, reply with ONLY: NO_REPLY';
 
     // Step 1: Spawn the sub-agent session (unique label per cycle to avoid
     // "label already in use" errors — gateway labels persist after session completion)


### PR DESCRIPTION
The GatewayExecutor spawns sub-agent sessions for each synthesis phase. Previously the task instructed the sub-agent to reply with the output file path, which leaked to the parent chat channel as unhelpful messages like:

> Done. The output is here:
> C:\Windows\TEMP\jeeves-meta/output-{uuid}.json

The executor already reads output from the staged file on disk, so the chat reply served no purpose.

This changes the OUTPUT DELIVERY instruction to reply with NO_REPLY, which OpenClaw treats as a silent acknowledgment and does not surface to chat.

All 534 tests pass. Typecheck and lint clean.
