### PR TITLE
fix: address Gemini review — sessions_list limit and cache invalidation gate

### DIFF
--- a/packages/service/src/bootstrap.ts
+++ b/packages/service/src/bootstrap.ts
@@ -144,8 +144,8 @@ export async function startService(
         logger,
       );
 
-      // Invalidate cache after any phase execution attempt
-      cache.invalidate();
+      // Invalidate cache only when a phase was actually executed
+      if (result.executed) cache.invalidate();
 
       const durationMs = Date.now() - startMs;
 

--- a/packages/service/src/executor/GatewayExecutor.ts
+++ b/packages/service/src/executor/GatewayExecutor.ts
@@ -138,7 +138,7 @@ export class GatewayExecutor implements MetaExecutor {
   ): Promise<{ tokens?: number; completed: boolean }> {
     try {
       const result = await this.invoke('sessions_list', {
-        limit: 20,
+        limit: 200,
         messageLimit: 0,
       });
 
@@ -152,7 +152,10 @@ export class GatewayExecutor implements MetaExecutor {
 
       const match = sessions.find((s) => s.key === sessionKey);
       if (!match) {
-        // Session absent from list — cleaned up after completion
+        // Session absent from list — likely cleaned up after completion.
+        // With limit=200 this is reliable; a false positive here only
+        // means we read the output file slightly early (still correct
+        // if the file exists).
         return { completed: true };
       }
 


### PR DESCRIPTION
Addresses Gemini code review comments on #142:
- Raise sessions_list polling limit from 20 to 200 to prevent false session-absent completion when gateway has many active sessions
- Gate cache.invalidate() on result.executed to skip unnecessary invalidation when meta was locked or already fresh