### PR TITLE
fix: pin jeeves-meta-core dependency to ^0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8266,7 +8266,7 @@
     },
     "packages/core": {
       "name": "@karmaniverous/jeeves-meta-core",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "zod": "^4.4"
       },
@@ -9053,11 +9053,11 @@
     },
     "packages/openclaw": {
       "name": "@karmaniverous/jeeves-meta-openclaw",
-      "version": "0.12.3",
+      "version": "0.12.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@karmaniverous/jeeves": "^0.5.10",
-        "@karmaniverous/jeeves-meta-core": "^0.1.0"
+        "@karmaniverous/jeeves-meta-core": "^0.1.1"
       },
       "bin": {
         "jeeves-meta-openclaw": "dist/cli.js"
@@ -9813,11 +9813,11 @@
     },
     "packages/service": {
       "name": "@karmaniverous/jeeves-meta",
-      "version": "0.15.4",
+      "version": "0.15.5",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@karmaniverous/jeeves": "^0.5.10",
-        "@karmaniverous/jeeves-meta-core": "^0.1.0",
+        "@karmaniverous/jeeves-meta-core": "^0.1.1",
         "commander": "^14",
         "croner": "^10",
         "fastify": "^5.8",

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -111,6 +111,6 @@
   },
   "dependencies": {
     "@karmaniverous/jeeves": "^0.5.10",
-    "@karmaniverous/jeeves-meta-core": "^0.1.0"
+    "@karmaniverous/jeeves-meta-core": "^0.1.1"
   }
 }

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@karmaniverous/jeeves": "^0.5.10",
-    "@karmaniverous/jeeves-meta-core": "^0.1.0",
+    "@karmaniverous/jeeves-meta-core": "^0.1.1",
     "commander": "^14",
     "croner": "^10",
     "fastify": "^5.8",


### PR DESCRIPTION
Pin @karmaniverous/jeeves-meta-core dependency from ^0.1.0 to ^0.1.1 in both packages/service and packages/openclaw.