### PR TITLE
fix: wire Tier 2 invalidation into scheduling path

### DIFF
--- a/packages/service/src/orchestrator/orchestratePhase.ts
+++ b/packages/service/src/orchestrator/orchestratePhase.ts
@@ -19,10 +19,12 @@ import type { MinimalLogger } from '../logger/index.js';
 import { normalizePath } from '../normalizePath.js';
 import {
   buildPhaseCandidates,
+  computeInvalidation,
   derivePhaseState,
   getOwedPhase,
   retryAllFailed,
   selectPhaseCandidate,
+  selectTier2Candidate,
 } from '../phaseState/index.js';
 import type { ProgressEvent } from '../progress/index.js';
 import { readMetaJson } from '../readMetaJson.js';
@@ -115,7 +117,15 @@ export async function orchestratePhase(
   // Select best phase candidate
   const winner = selectPhaseCandidate(candidates, config.depthWeight);
   if (!winner) {
-    return { executed: false };
+    // ── Tier 2 fallback: deep invalidation on stalest all-fresh meta ──
+    return orchestrateTier2(
+      candidates,
+      config,
+      executor,
+      watcher,
+      onProgress,
+      logger,
+    );
   }
 
   // Acquire lock
@@ -232,6 +242,97 @@ async function orchestrateTargeted(
     );
   } finally {
     releaseLock(node.metaPath);
+  }
+}
+
+/**
+ * Tier 2 invalidation fallback: pick the stalest all-fresh meta,
+ * run computeInvalidation (structure hash, steer, cross-refs), and
+ * either execute the owed phase or bump _generatedAt.
+ */
+async function orchestrateTier2(
+  candidates: Parameters<typeof selectTier2Candidate>[0],
+  config: MetaConfig,
+  executor: MetaExecutor,
+  watcher: WatcherClient,
+  onProgress?: PhaseProgressCallback,
+  logger?: MinimalLogger,
+): Promise<OrchestratePhaseResult> {
+  const tier2 = selectTier2Candidate(candidates);
+  if (!tier2) return { executed: false };
+
+  if (!acquireLock(tier2.node.metaPath)) {
+    logger?.debug(
+      { path: tier2.node.metaPath },
+      'Tier 2 candidate is locked, skipping',
+    );
+    return { executed: false };
+  }
+
+  try {
+    const currentMeta = await readMetaJson(tier2.node.metaPath);
+    const { scopeFiles } = await getScopeFiles(tier2.node, watcher);
+    const structureHash = computeStructureHash(scopeFiles);
+
+    const { phaseState, architectInvalidators } = await computeInvalidation(
+      currentMeta,
+      scopeFiles,
+      config,
+      tier2.node,
+    );
+
+    if (architectInvalidators.length > 0) {
+      // Something changed — persist invalidated state and execute owed phase
+      const owedPhase = getOwedPhase(phaseState);
+      if (!owedPhase) {
+        // Shouldn't happen after invalidation, but be safe
+        return { executed: false };
+      }
+
+      await persistPhaseState(
+        {
+          metaPath: tier2.node.metaPath,
+          current: currentMeta,
+          config,
+          structureHash,
+        },
+        phaseState,
+        {},
+      );
+
+      return await executePhase(
+        tier2.node,
+        currentMeta,
+        phaseState,
+        owedPhase,
+        config,
+        executor,
+        watcher,
+        structureHash,
+        onProgress,
+        logger,
+      );
+    }
+
+    // Nothing changed — bump _generatedAt to delay re-checking
+    await persistPhaseState(
+      {
+        metaPath: tier2.node.metaPath,
+        current: currentMeta,
+        config,
+        structureHash,
+      },
+      phaseState,
+      { _generatedAt: new Date().toISOString() },
+    );
+    logger?.debug(
+      { path: tier2.node.ownerPath },
+      'Tier 2: no invalidation detected, bumped _generatedAt',
+    );
+
+    return { executed: false };
+  } finally {
+    releaseLock(tier2.node.metaPath);
   }
 }
 

--- a/packages/service/src/orchestrator/orchestratePhase.ts
+++ b/packages/service/src/orchestrator/orchestratePhase.ts
@@ -272,23 +272,17 @@ async function orchestrateTier2(
   try {
     const currentMeta = await readMetaJson(tier2.node.metaPath);
     const { scopeFiles } = await getScopeFiles(tier2.node, watcher);
-    const structureHash = computeStructureHash(scopeFiles);
 
-    const { phaseState, architectInvalidators } = await computeInvalidation(
+    const { phaseState, structureHash } = await computeInvalidation(
       currentMeta,
       scopeFiles,
       config,
       tier2.node,
     );
 
-    if (architectInvalidators.length > 0) {
+    const owedPhase = getOwedPhase(phaseState);
+    if (owedPhase) {
       // Something changed — persist invalidated state and execute owed phase
-      const owedPhase = getOwedPhase(phaseState);
-      if (!owedPhase) {
-        // Shouldn't happen after invalidation, but be safe
-        return { executed: false };
-      }
-
       await persistPhaseState(
         {
           metaPath: tier2.node.metaPath,

--- a/packages/service/src/phaseState/index.ts
+++ b/packages/service/src/phaseState/index.ts
@@ -17,6 +17,8 @@ export {
   type PhaseCandidateInput,
   rankPhaseCandidates,
   selectPhaseCandidate,
+  selectTier2Candidate,
+  type Tier2Candidate,
 } from './phaseScheduler.js';
 export {
   architectSuccess,

--- a/packages/service/src/phaseState/phaseScheduler.test.ts
+++ b/packages/service/src/phaseState/phaseScheduler.test.ts
@@ -7,6 +7,7 @@ import {
   buildPhaseCandidates,
   rankPhaseCandidates,
   selectPhaseCandidate,
+  selectTier2Candidate,
 } from './phaseScheduler.js';
 
 /** Helper to create a minimal MetaNode stub. */
@@ -462,5 +463,76 @@ describe('rankPhaseCandidates', () => {
     ];
     const ranked = rankPhaseCandidates(metas, 1);
     expect(ranked).toEqual([]);
+  });
+});
+
+describe('selectTier2Candidate', () => {
+  it('picks the stalest all-fresh meta', () => {
+    const metas = [
+      candidate(
+        'a/.meta',
+        { architect: 'fresh', builder: 'fresh', critic: 'fresh' },
+        { actualStaleness: 1000 },
+      ),
+      candidate(
+        'b/.meta',
+        { architect: 'fresh', builder: 'fresh', critic: 'fresh' },
+        { actualStaleness: 5000 },
+      ),
+      candidate(
+        'c/.meta',
+        { architect: 'fresh', builder: 'fresh', critic: 'fresh' },
+        { actualStaleness: 3000 },
+      ),
+    ];
+
+    const result = selectTier2Candidate(metas);
+    expect(result).not.toBeNull();
+    expect(result!.node.metaPath).toBe('b/.meta');
+  });
+
+  it('returns null when no all-fresh metas exist', () => {
+    const metas = [
+      candidate('a/.meta', {
+        architect: 'pending',
+        builder: 'stale',
+        critic: 'stale',
+      }),
+      candidate('b/.meta', {
+        architect: 'fresh',
+        builder: 'pending',
+        critic: 'stale',
+      }),
+    ];
+
+    expect(selectTier2Candidate(metas)).toBeNull();
+  });
+
+  it('skips locked and disabled metas', () => {
+    const metas = [
+      candidate(
+        'locked/.meta',
+        { architect: 'fresh', builder: 'fresh', critic: 'fresh' },
+        { actualStaleness: 9000, locked: true },
+      ),
+      candidate(
+        'disabled/.meta',
+        { architect: 'fresh', builder: 'fresh', critic: 'fresh' },
+        { actualStaleness: 8000, disabled: true },
+      ),
+      candidate(
+        'eligible/.meta',
+        { architect: 'fresh', builder: 'fresh', critic: 'fresh' },
+        { actualStaleness: 1000 },
+      ),
+    ];
+
+    const result = selectTier2Candidate(metas);
+    expect(result).not.toBeNull();
+    expect(result!.node.metaPath).toBe('eligible/.meta');
+  });
+
+  it('returns null for empty input', () => {
+    expect(selectTier2Candidate([])).toBeNull();
   });
 });

--- a/packages/service/src/phaseState/phaseScheduler.ts
+++ b/packages/service/src/phaseState/phaseScheduler.ts
@@ -16,6 +16,7 @@ import { derivePhaseState } from './derivePhaseState.js';
 import {
   getOwedPhase,
   getPriorityBand,
+  isFullyFresh,
   retryAllFailed,
 } from './phaseTransitions.js';
 
@@ -147,4 +148,30 @@ export function selectPhaseCandidate(
   depthWeight: number,
 ): PhaseCandidate | null {
   return rankPhaseCandidates(metas, depthWeight)[0] ?? null;
+}
+
+/** Result of Tier 2 candidate selection. */
+export interface Tier2Candidate {
+  node: MetaNode;
+  meta: MetaJson;
+}
+
+/**
+ * Select the stalest all-fresh, non-disabled, non-locked meta for Tier 2
+ * invalidation. These are metas that Tier 1 considers fully fresh but may
+ * have structural or steer changes detectable only via I/O.
+ *
+ * @param metas - Phase candidate inputs (after Tier 1 filtering).
+ * @returns The stalest all-fresh candidate, or null if none exist.
+ */
+export function selectTier2Candidate(
+  metas: PhaseCandidateInput[],
+): Tier2Candidate | null {
+  const eligible = metas
+    .filter((m) => !m.locked && !m.disabled && isFullyFresh(m.phaseState))
+    .sort((a, b) => b.actualStaleness - a.actualStaleness);
+
+  if (eligible.length === 0) return null;
+
+  return { node: eligible[0].node, meta: eligible[0].meta };
 }


### PR DESCRIPTION
Fixes #154

## Problem

\computeInvalidation()\ — which checks structure hash changes (new/deleted files), steer changes, cross-ref changes, and \rchitectEvery\ cycle count — was only called by the \/preview\ route. The actual scheduling path in \orchestratePhase\ only ran Tier 1 cheap invalidation (no I/O), which just checked \_synthesisCount >= architectEvery\ and missing \_builder\.

Result: once a meta completed a full synthesis cycle, file changes were **never detected**. 877 of 889 metas showed \owedPhase: null\ despite weeks-old file changes.

## Fix

Added a Tier 2 validation fallback to \orchestratePhase\:

1. When \selectPhaseCandidate()\ returns null (no Tier 1 candidates), calls new \selectTier2Candidate()\ to pick the **stalest all-fresh, non-disabled, non-locked** meta
2. Acquires lock, re-reads meta.json, gets scope files from watcher
3. Runs \computeInvalidation()\ — structure hash, steer, cross-refs, architectEvery
4. If invalidators found → persists invalidated \_phaseState\ and executes the owed phase
5. If nothing changed → bumps \_generatedAt\ to delay re-checking

This processes **one Tier 2 validation per tick** (every 15 min), working through the corpus from stalest to freshest.

## Changes

| File | Change |
|------|--------|
| \phaseScheduler.ts\ | Added \selectTier2Candidate()\ + \Tier2Candidate\ interface |
| \orchestratePhase.ts\ | Added \orchestrateTier2()\ fallback when no Tier 1 winner |
| \phaseState/index.ts\ | New exports |
| \phaseScheduler.test.ts\ | 4 new tests for Tier 2 selection |

## Quality

- ✅ typecheck
- ✅ lint (0 warnings)
- ✅ build
- ✅ 529 tests pass