### PR TITLE
fix: wire Tier 2 invalidation loop into scheduler

### DIFF
--- a/packages/service/src/cache.test.ts
+++ b/packages/service/src/cache.test.ts
@@ -41,6 +41,7 @@ function makeConfig(): ServiceConfig {
     port: 1938,
     schedule: '* * * * *',
     watcherHealthIntervalMs: 60000,
+    tier2ScanLimit: 50,
     logging: { level: 'info' },
     autoSeed: [],
   };

--- a/packages/service/src/orchestrator/orchestratePhase.ts
+++ b/packages/service/src/orchestrator/orchestratePhase.ts
@@ -19,12 +19,10 @@ import type { MinimalLogger } from '../logger/index.js';
 import { normalizePath } from '../normalizePath.js';
 import {
   buildPhaseCandidates,
-  computeInvalidation,
   derivePhaseState,
   getOwedPhase,
   retryAllFailed,
   selectPhaseCandidate,
-  selectTier2Candidate,
 } from '../phaseState/index.js';
 import type { ProgressEvent } from '../progress/index.js';
 import { readMetaJson } from '../readMetaJson.js';
@@ -117,15 +115,9 @@ export async function orchestratePhase(
   // Select best phase candidate
   const winner = selectPhaseCandidate(candidates, config.depthWeight);
   if (!winner) {
-    // ── Tier 2 fallback: deep invalidation on stalest all-fresh meta ──
-    return orchestrateTier2(
-      candidates,
-      config,
-      executor,
-      watcher,
-      onProgress,
-      logger,
-    );
+    // Tier 2 is now handled by the scheduler; orchestratePhase only handles
+    // targeted (override) paths and Tier 1 corpus-wide selection.
+    return { executed: false };
   }
 
   // Acquire lock
@@ -242,91 +234,6 @@ async function orchestrateTargeted(
     );
   } finally {
     releaseLock(node.metaPath);
-  }
-}
-
-/**
- * Tier 2 invalidation fallback: pick the stalest all-fresh meta,
- * run computeInvalidation (structure hash, steer, cross-refs), and
- * either execute the owed phase or bump _generatedAt.
- */
-async function orchestrateTier2(
-  candidates: Parameters<typeof selectTier2Candidate>[0],
-  config: MetaConfig,
-  executor: MetaExecutor,
-  watcher: WatcherClient,
-  onProgress?: PhaseProgressCallback,
-  logger?: MinimalLogger,
-): Promise<OrchestratePhaseResult> {
-  const tier2 = selectTier2Candidate(candidates);
-  if (!tier2) return { executed: false };
-
-  if (!acquireLock(tier2.node.metaPath)) {
-    logger?.debug(
-      { path: tier2.node.metaPath },
-      'Tier 2 candidate is locked, skipping',
-    );
-    return { executed: false };
-  }
-
-  try {
-    const currentMeta = await readMetaJson(tier2.node.metaPath);
-    const { scopeFiles } = await getScopeFiles(tier2.node, watcher);
-
-    const { phaseState, structureHash } = await computeInvalidation(
-      currentMeta,
-      scopeFiles,
-      config,
-      tier2.node,
-    );
-
-    const owedPhase = getOwedPhase(phaseState);
-    if (owedPhase) {
-      // Something changed — persist invalidated state and execute owed phase
-      await persistPhaseState(
-        {
-          metaPath: tier2.node.metaPath,
-          current: currentMeta,
-          config,
-          structureHash,
-        },
-        phaseState,
-        {},
-      );
-
-      return await executePhase(
-        tier2.node,
-        currentMeta,
-        phaseState,
-        owedPhase,
-        config,
-        executor,
-        watcher,
-        structureHash,
-        onProgress,
-        logger,
-      );
-    }
-
-    // Nothing changed — bump _generatedAt to delay re-checking
-    await persistPhaseState(
-      {
-        metaPath: tier2.node.metaPath,
-        current: currentMeta,
-        config,
-        structureHash,
-      },
-      phaseState,
-      { _generatedAt: new Date().toISOString() },
-    );
-    logger?.debug(
-      { path: tier2.node.ownerPath },
-      'Tier 2: no invalidation detected, bumped _generatedAt',
-    );
-
-    return { executed: false };
-  } finally {
-    releaseLock(tier2.node.metaPath);
   }
 }
 

--- a/packages/service/src/phaseState/index.ts
+++ b/packages/service/src/phaseState/index.ts
@@ -16,6 +16,7 @@ export {
   type PhaseCandidate,
   type PhaseCandidateInput,
   rankPhaseCandidates,
+  selectAllTier2Candidates,
   selectPhaseCandidate,
   selectTier2Candidate,
   type Tier2Candidate,

--- a/packages/service/src/phaseState/phaseScheduler.test.ts
+++ b/packages/service/src/phaseState/phaseScheduler.test.ts
@@ -6,6 +6,7 @@ import type { MetaJson, PhaseState } from '../schema/meta.js';
 import {
   buildPhaseCandidates,
   rankPhaseCandidates,
+  selectAllTier2Candidates,
   selectPhaseCandidate,
   selectTier2Candidate,
 } from './phaseScheduler.js';
@@ -534,5 +535,77 @@ describe('selectTier2Candidate', () => {
 
   it('returns null for empty input', () => {
     expect(selectTier2Candidate([])).toBeNull();
+  });
+});
+
+describe('selectAllTier2Candidates', () => {
+  it('returns all all-fresh candidates sorted by staleness descending', () => {
+    const metas = [
+      candidate(
+        'a/.meta',
+        { architect: 'fresh', builder: 'fresh', critic: 'fresh' },
+        { actualStaleness: 1000 },
+      ),
+      candidate(
+        'b/.meta',
+        { architect: 'fresh', builder: 'fresh', critic: 'fresh' },
+        { actualStaleness: 5000 },
+      ),
+      candidate(
+        'c/.meta',
+        { architect: 'fresh', builder: 'fresh', critic: 'fresh' },
+        { actualStaleness: 3000 },
+      ),
+    ];
+
+    const result = selectAllTier2Candidates(metas);
+    expect(result).toHaveLength(3);
+    expect(result[0].node.metaPath).toBe('b/.meta');
+    expect(result[1].node.metaPath).toBe('c/.meta');
+    expect(result[2].node.metaPath).toBe('a/.meta');
+  });
+
+  it('filters out locked, disabled, and non-fresh metas', () => {
+    const metas = [
+      candidate(
+        'locked/.meta',
+        { architect: 'fresh', builder: 'fresh', critic: 'fresh' },
+        { actualStaleness: 9000, locked: true },
+      ),
+      candidate(
+        'disabled/.meta',
+        { architect: 'fresh', builder: 'fresh', critic: 'fresh' },
+        { actualStaleness: 8000, disabled: true },
+      ),
+      candidate(
+        'pending/.meta',
+        { architect: 'pending', builder: 'stale', critic: 'stale' },
+        { actualStaleness: 7000 },
+      ),
+      candidate(
+        'eligible/.meta',
+        { architect: 'fresh', builder: 'fresh', critic: 'fresh' },
+        { actualStaleness: 1000 },
+      ),
+    ];
+
+    const result = selectAllTier2Candidates(metas);
+    expect(result).toHaveLength(1);
+    expect(result[0].node.metaPath).toBe('eligible/.meta');
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(selectAllTier2Candidates([])).toEqual([]);
+  });
+
+  it('returns empty array when no all-fresh metas exist', () => {
+    const metas = [
+      candidate('a/.meta', {
+        architect: 'pending',
+        builder: 'stale',
+        critic: 'stale',
+      }),
+    ];
+    expect(selectAllTier2Candidates(metas)).toEqual([]);
   });
 });

--- a/packages/service/src/phaseState/phaseScheduler.ts
+++ b/packages/service/src/phaseState/phaseScheduler.ts
@@ -175,3 +175,16 @@ export function selectTier2Candidate(
 
   return { node: eligible[0].node, meta: eligible[0].meta };
 }
+
+/**
+ * Select all fully-fresh, non-disabled, non-locked metas sorted by staleness
+ * (descending — stalest first) for Tier 2 invalidation scanning.
+ */
+export function selectAllTier2Candidates(
+  metas: PhaseCandidateInput[],
+): Tier2Candidate[] {
+  return metas
+    .filter((m) => !m.locked && !m.disabled && isFullyFresh(m.phaseState))
+    .sort((a, b) => b.actualStaleness - a.actualStaleness)
+    .map((m) => ({ node: m.node, meta: m.meta }));
+}

--- a/packages/service/src/routes/__testUtils.ts
+++ b/packages/service/src/routes/__testUtils.ts
@@ -38,6 +38,7 @@ const DEFAULT_TEST_CONFIG: RouteDeps['config'] = {
   port: 1938,
   schedule: '*/30 * * * *',
   watcherHealthIntervalMs: 60000,
+  tier2ScanLimit: 50,
   logging: { level: 'info' },
   autoSeed: [],
 };

--- a/packages/service/src/scheduler/index.ts
+++ b/packages/service/src/scheduler/index.ts
@@ -9,11 +9,20 @@ import { Cron } from 'croner';
 import type { Logger } from 'pino';
 
 import type { MetaCache } from '../cache.js';
+import { getScopeFiles } from '../discovery/scope.js';
+import { acquireLock, releaseLock } from '../lock.js';
+import { persistPhaseState } from '../orchestrator/runPhase.js';
 import {
   buildPhaseCandidates,
+  computeInvalidation,
+  getOwedPhase,
+  getPriorityBand,
+  type PhaseCandidateInput,
+  selectAllTier2Candidates,
   selectPhaseCandidate,
 } from '../phaseState/index.js';
 import type { SynthesisQueue } from '../queue/index.js';
+import { readMetaJson } from '../readMetaJson.js';
 import type { RuleRegistrar } from '../rules/index.js';
 import type { ServiceConfig } from '../schema/config.js';
 import { autoSeedPass } from '../seed/index.js';
@@ -224,7 +233,7 @@ export class Scheduler {
 
       const winner = selectPhaseCandidate(candidates, this.config.depthWeight);
 
-      if (!winner) return null;
+      if (!winner) return await this.discoverTier2Phase(candidates);
 
       return {
         path: winner.node.metaPath,
@@ -235,5 +244,70 @@ export class Scheduler {
       this.logger.warn({ err }, 'Failed to discover next phase candidate');
       return null;
     }
+  }
+
+  /**
+   * Tier 2 invalidation: iterate all-fresh candidates (stalest first),
+   * run computeInvalidation, and return the first that produces an owed phase.
+   */
+  private async discoverTier2Phase(
+    candidates: PhaseCandidateInput[],
+  ): Promise<TickCandidate | null> {
+    const tier2Candidates = selectAllTier2Candidates(candidates);
+
+    for (const t2 of tier2Candidates) {
+      if (!acquireLock(t2.node.metaPath)) continue;
+
+      try {
+        const currentMeta = await readMetaJson(t2.node.metaPath);
+        const { scopeFiles } = await getScopeFiles(t2.node, this.watcher);
+
+        const result = await computeInvalidation(
+          currentMeta,
+          scopeFiles,
+          this.config,
+          t2.node,
+        );
+
+        const owedPhase = getOwedPhase(result.phaseState);
+
+        if (owedPhase) {
+          await persistPhaseState(
+            {
+              metaPath: t2.node.metaPath,
+              current: currentMeta,
+              config: this.config,
+              structureHash: result.structureHash,
+            },
+            result.phaseState,
+            {},
+          );
+          this.cache.invalidate();
+
+          return {
+            path: t2.node.metaPath,
+            phase: owedPhase,
+            band: getPriorityBand(result.phaseState)!,
+          };
+        }
+
+        // No invalidation — bump _generatedAt to delay re-checking
+        await persistPhaseState(
+          {
+            metaPath: t2.node.metaPath,
+            current: currentMeta,
+            config: this.config,
+            structureHash: result.structureHash,
+          },
+          result.phaseState,
+          { _generatedAt: new Date().toISOString() },
+        );
+        this.cache.invalidate();
+      } finally {
+        releaseLock(t2.node.metaPath);
+      }
+    }
+
+    return null;
   }
 }

--- a/packages/service/src/scheduler/index.ts
+++ b/packages/service/src/scheduler/index.ts
@@ -253,7 +253,19 @@ export class Scheduler {
   private async discoverTier2Phase(
     candidates: PhaseCandidateInput[],
   ): Promise<TickCandidate | null> {
-    const tier2Candidates = selectAllTier2Candidates(candidates);
+    const allTier2 = selectAllTier2Candidates(candidates);
+
+    const limit = this.config.tier2ScanLimit;
+    const tier2Candidates = allTier2.slice(0, limit);
+
+    if (allTier2.length > limit) {
+      this.logger.debug(
+        { total: allTier2.length, limit },
+        'Tier 2 scan limit reached, scanning subset',
+      );
+    }
+
+    let dirty = false;
 
     for (const t2 of tier2Candidates) {
       if (!acquireLock(t2.node.metaPath)) continue;
@@ -302,11 +314,13 @@ export class Scheduler {
           result.phaseState,
           { _generatedAt: new Date().toISOString() },
         );
-        this.cache.invalidate();
+        dirty = true;
       } finally {
         releaseLock(t2.node.metaPath);
       }
     }
+
+    if (dirty) this.cache.invalidate();
 
     return null;
   }

--- a/packages/service/src/scheduler/scheduler.test.ts
+++ b/packages/service/src/scheduler/scheduler.test.ts
@@ -39,6 +39,7 @@ function createTestConfig() {
     port: 1938,
     schedule: '* * * * *',
     watcherHealthIntervalMs: 60000,
+    tier2ScanLimit: 50,
     logging: { level: 'info' },
     autoSeed: [],
   };

--- a/packages/service/src/schema/config.ts
+++ b/packages/service/src/schema/config.ts
@@ -59,6 +59,9 @@ export const serviceConfigSchema = metaConfigSchema.extend({
   /** Logging configuration. */
   logging: loggingSchema.default(() => loggingSchema.parse({})),
 
+  /** Max number of all-fresh candidates to scan per tick in Tier 2 invalidation. */
+  tier2ScanLimit: z.number().int().min(1).default(50),
+
   /**
    * Auto-seed policy: declarative rules for auto-creating .meta/ directories.
    * Rules are evaluated in order; last match wins for steer/crossRefs.


### PR DESCRIPTION
## Summary
- Added `selectAllTier2Candidates()` to `phaseScheduler.ts` — returns all fully-fresh candidates sorted by staleness (descending) for Tier 2 scanning
- Added `discoverTier2Phase()` to the `Scheduler` class — iterates all-fresh candidates, runs `computeInvalidation`, persists invalidated state or bumps `_generatedAt`, and returns the first candidate with an owed phase
- Wired Tier 2 into `discoverNextPhase()` as fallback when Tier 1 finds no candidates
- Removed dead `orchestrateTier2()` from `orchestratePhase.ts` — Tier 2 is now exclusively handled by the scheduler
- Added 4 unit tests for `selectAllTier2Candidates`

Fixes #156

## Dependency updates available (report only)
- eslint ^10.3.0 → ^10.4.0
- knip ^6.13.1 → ^6.14.2
- lefthook ^2.1.6 → ^2.1.8
- typescript-eslint ^8.59.3 → ^8.59.4

## Test plan
- [x] All 533 tests pass
- [x] Build, typecheck, lint, knip all clean
- [x] No eslint-disable usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)