### PR TITLE
feat: jeeves-meta v0.16.0

### DIFF
--- a/packages/core/src/endpoints.ts
+++ b/packages/core/src/endpoints.ts
@@ -1,0 +1,137 @@
+/**
+ * Shared endpoint catalog — single source of truth for the jeeves-meta API.
+ *
+ * Both the CLI service and the OpenClaw plugin derive their registrations
+ * from this declarative catalog, eliminating drift between the two.
+ *
+ */
+
+/** HTTP methods used by the API. */
+export type HttpMethod = 'GET' | 'PATCH' | 'POST';
+
+/** Descriptor for a single API endpoint. */
+export interface EndpointDescriptor {
+  /** Unique endpoint identifier (camelCase). */
+  name: string;
+  /** HTTP method. */
+  method: HttpMethod;
+  /** URL path pattern (e.g. '/metas/:path'). */
+  path: string;
+  /** Human-readable description of the endpoint's purpose. */
+  description: string;
+}
+
+/**
+ * Canonical endpoint catalog for the jeeves-meta API.
+ *
+ * Every entry describes a single HTTP endpoint exposed by the service.
+ * Route handlers, plugin tools, and HTTP clients should reference these
+ * descriptors rather than hard-coding paths and descriptions.
+ */
+export const META_ENDPOINTS = [
+  {
+    name: 'status',
+    method: 'GET',
+    path: '/status',
+    description: 'Service health and status overview.',
+  },
+  {
+    name: 'listMetas',
+    method: 'GET',
+    path: '/metas',
+    description:
+      'List metas with summary stats and per-meta projection. Response includes _phaseState and owedPhase per meta.',
+  },
+  {
+    name: 'metaDetail',
+    method: 'GET',
+    path: '/metas/:path',
+    description:
+      'Full detail for a single meta, with optional archive history. Response includes _phaseState and owedPhase.',
+  },
+  {
+    name: 'updateMeta',
+    method: 'PATCH',
+    path: '/metas/:path',
+    description: 'Update user-settable reserved properties on a meta entity.',
+  },
+  {
+    name: 'synthesize',
+    method: 'POST',
+    path: '/synthesize',
+    description:
+      'Trigger synthesis. Path-targeted creates an override queue entry; returns owedPhase. Fully-fresh metas return status:skipped.',
+  },
+  {
+    name: 'abort',
+    method: 'POST',
+    path: '/synthesize/abort',
+    description: 'Abort the currently running synthesis.',
+  },
+  {
+    name: 'preview',
+    method: 'GET',
+    path: '/preview',
+    description:
+      'Dry-run preview of next synthesis. Returns owedPhase, priorityBand, phaseState, stalenessInputs, and architectInvalidators.',
+  },
+  {
+    name: 'seed',
+    method: 'POST',
+    path: '/seed',
+    description:
+      'Create a .meta/ directory and initial meta.json for a new entity path.',
+  },
+  {
+    name: 'unlock',
+    method: 'POST',
+    path: '/unlock',
+    description: 'Remove a stale .lock from a meta entity that is stuck.',
+  },
+  {
+    name: 'config',
+    method: 'GET',
+    path: '/config',
+    description: 'Query service configuration with optional JSONPath.',
+  },
+  {
+    name: 'configApply',
+    method: 'POST',
+    path: '/config/apply',
+    description: 'Apply a configuration patch.',
+  },
+  {
+    name: 'queue',
+    method: 'GET',
+    path: '/queue',
+    description:
+      'List queued synthesis operations (3-layer model: current, overrides, automatic).',
+  },
+  {
+    name: 'queueClear',
+    method: 'POST',
+    path: '/queue/clear',
+    description: 'Clear override entries from the queue.',
+  },
+] as const satisfies readonly EndpointDescriptor[];
+
+/** Union of all endpoint names. */
+export type EndpointName = (typeof META_ENDPOINTS)[number]['name'];
+
+/** Single entry from the catalog, narrowed by name. */
+export type Endpoint<N extends EndpointName> = Extract<
+  (typeof META_ENDPOINTS)[number],
+  { name: N }
+>;
+
+/**
+ * Look up an endpoint descriptor by name.
+ *
+ * @param name - The endpoint identifier.
+ * @returns The matching {@link EndpointDescriptor}.
+ */
+export function getEndpoint<N extends EndpointName>(name: N): Endpoint<N> {
+  const ep = META_ENDPOINTS.find((e) => e.name === name);
+  if (!ep) throw new Error(`Unknown endpoint: ${name}`);
+  return ep as Endpoint<N>;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,14 @@ export {
   ServiceState,
   WatcherDepHealth,
 } from './contracts.js';
+export {
+  Endpoint,
+  EndpointDescriptor,
+  EndpointName,
+  getEndpoint,
+  HttpMethod,
+  META_ENDPOINTS,
+} from './endpoints.js';
 export { MetaError, metaErrorSchema } from './errors.js';
 export { MetaConfig, metaConfigSchema } from './metaConfig.js';
 export { normalizePath } from './normalizePath.js';

--- a/packages/openclaw/src/customTools.ts
+++ b/packages/openclaw/src/customTools.ts
@@ -13,6 +13,7 @@ import {
   type ToolDescriptor,
   type ToolResult,
 } from '@karmaniverous/jeeves';
+import { getEndpoint } from '@karmaniverous/jeeves-meta-core';
 
 import { PLUGIN_ID } from './constants.js';
 import type { MetaServiceClient } from './serviceClient.js';
@@ -50,8 +51,7 @@ function buildMetaListTool(
 ): ToolDescriptor {
   return {
     name: 'meta_list',
-    description:
-      'List metas with summary stats and per-meta projection. Response includes _phaseState and owedPhase per meta.',
+    description: getEndpoint('listMetas').description,
     parameters: {
       type: 'object',
       properties: {
@@ -101,8 +101,7 @@ function buildMetaDetailTool(
 ): ToolDescriptor {
   return {
     name: 'meta_detail',
-    description:
-      'Full detail for a single meta, with optional archive history. Response includes _phaseState and owedPhase.',
+    description: getEndpoint('metaDetail').description,
     parameters: {
       type: 'object',
       properties: {
@@ -139,8 +138,7 @@ function buildMetaPreviewTool(
 ): ToolDescriptor {
   return {
     name: 'meta_preview',
-    description:
-      'Dry-run preview of next synthesis. Returns owedPhase, priorityBand, phaseState, stalenessInputs, and architectInvalidators.',
+    description: getEndpoint('preview').description,
     parameters: {
       type: 'object',
       properties: {
@@ -162,8 +160,7 @@ function buildMetaTriggerTool(
 ): ToolDescriptor {
   return {
     name: 'meta_trigger',
-    description:
-      'Trigger synthesis. Path-targeted creates an override queue entry; returns owedPhase. Fully-fresh metas return status:skipped.',
+    description: getEndpoint('synthesize').description,
     parameters: {
       type: 'object',
       properties: {
@@ -184,8 +181,7 @@ function buildMetaSeedTool(
 ): ToolDescriptor {
   return {
     name: 'meta_seed',
-    description:
-      'Create a .meta/ directory and initial meta.json for a new entity path.',
+    description: getEndpoint('seed').description,
     parameters: {
       type: 'object',
       properties: {
@@ -237,7 +233,7 @@ function buildMetaUnlockTool(
 ): ToolDescriptor {
   return {
     name: 'meta_unlock',
-    description: 'Remove a stale .lock from a meta entity that is stuck.',
+    description: getEndpoint('unlock').description,
     parameters: {
       type: 'object',
       properties: {
@@ -259,8 +255,7 @@ function buildMetaQueueTool(
 ): ToolDescriptor {
   return {
     name: 'meta_queue',
-    description:
-      'Queue management. list: 3-layer model (current with phase, overrides, automatic, pending). clear: removes overrides only. abort: returns {status,path,phase} or {status:idle}.',
+    description: `Queue management. list: ${getEndpoint('queue').description} clear: ${getEndpoint('queueClear').description} abort: ${getEndpoint('abort').description}`,
     parameters: {
       type: 'object',
       properties: {
@@ -295,7 +290,7 @@ function buildMetaUpdateTool(
 ): ToolDescriptor {
   return {
     name: 'meta_update',
-    description: 'Update user-settable reserved properties on a meta entity.',
+    description: getEndpoint('updateMeta').description,
     parameters: {
       type: 'object',
       properties: {

--- a/packages/openclaw/src/customTools.ts
+++ b/packages/openclaw/src/customTools.ts
@@ -301,7 +301,7 @@ function buildMetaUpdateTool(
         updates: {
           type: 'object',
           description:
-            'Properties to set. Supported: _steer, _emphasis, _depth, _crossRefs, _disabled. Set to null to remove.',
+            'Properties to set. Supported: _steer, _emphasis, _depth, _crossRefs, _disabled, _architectTimeout, _builderTimeout, _criticTimeout. Set to null to remove.',
           properties: {
             _steer: { type: ['string', 'null'] },
             _emphasis: { type: ['number', 'null'] },
@@ -313,6 +313,9 @@ function buildMetaUpdateTool(
               ],
             },
             _disabled: { type: ['boolean', 'null'] },
+            _architectTimeout: { type: ['number', 'null'] },
+            _builderTimeout: { type: ['number', 'null'] },
+            _criticTimeout: { type: ['number', 'null'] },
           },
         },
       },

--- a/packages/openclaw/src/index.ts
+++ b/packages/openclaw/src/index.ts
@@ -45,17 +45,27 @@ export default function register(api: PluginApi): void {
     'The jeeves-meta synthesis engine is initializing...\n\n' +
     'Read the `jeeves-meta` skill for usage guidance, configuration, and troubleshooting.';
 
+  let consecutive503s = 0;
+
   const getContent = createAsyncContentCache({
     fetch: async () => generateMetaMenu(client),
     placeholder,
     onError: (error: unknown) => {
       const msg = error instanceof Error ? error.message : String(error);
       if (/HTTP 503\b/i.test(msg) || /scan.in.progress/i.test(msg)) {
-        console.warn(
-          '[jeeves-meta] Watcher scan still in progress — will retry on next refresh cycle.',
-        );
+        consecutive503s++;
+        if (consecutive503s === 1) {
+          console.warn(
+            '[jeeves-meta] Watcher scan still in progress — will retry on next refresh cycle.',
+          );
+        } else {
+          console.debug(
+            `[jeeves-meta] Watcher scan still in progress (attempt ${String(consecutive503s)}) — suppressing repeated warnings.`,
+          );
+        }
         return;
       }
+      consecutive503s = 0;
       console.warn('[jeeves-meta] Content fetch failed:', msg);
     },
   });

--- a/packages/openclaw/src/index.ts
+++ b/packages/openclaw/src/index.ts
@@ -48,7 +48,11 @@ export default function register(api: PluginApi): void {
   let consecutive503s = 0;
 
   const getContent = createAsyncContentCache({
-    fetch: async () => generateMetaMenu(client),
+    fetch: async () => {
+      const content = await generateMetaMenu(client);
+      consecutive503s = 0;
+      return content;
+    },
     placeholder,
     onError: (error: unknown) => {
       const msg = error instanceof Error ? error.message : String(error);

--- a/packages/openclaw/src/serviceClient.ts
+++ b/packages/openclaw/src/serviceClient.ts
@@ -127,6 +127,9 @@ export class MetaServiceClient {
       _depth?: number | null;
       _crossRefs?: string[] | null;
       _disabled?: boolean | null;
+      _architectTimeout?: number | null;
+      _builderTimeout?: number | null;
+      _criticTimeout?: number | null;
     },
   ): Promise<unknown> {
     const encoded = encodeURIComponent(metaPath);

--- a/packages/openclaw/src/serviceClient.ts
+++ b/packages/openclaw/src/serviceClient.ts
@@ -10,6 +10,7 @@
 import { fetchJson, postJson } from '@karmaniverous/jeeves';
 import {
   type DepHealth,
+  type EndpointName,
   type GatewayDepHealth,
   getEndpoint,
   type MetaListSummary,
@@ -85,9 +86,26 @@ export class MetaServiceClient {
     return postJson(this.baseUrl + path, body) as Promise<T>;
   }
 
+  /**
+   * Interpolate a parameterized endpoint path.
+   * Replaces `:param` placeholders with URI-encoded values.
+   */
+  private endpointPath(
+    name: EndpointName,
+    params?: Record<string, string>,
+  ): string {
+    let p: string = getEndpoint(name).path;
+    if (params) {
+      for (const [key, value] of Object.entries(params)) {
+        p = p.replace(`:${key}`, encodeURIComponent(value));
+      }
+    }
+    return p;
+  }
+
   /** GET /status — service health + queue state. */
   public async status(): Promise<StatusResponse> {
-    return this.get<StatusResponse>(getEndpoint('status').path);
+    return this.get<StatusResponse>(this.endpointPath('status'));
   }
 
   /** GET /metas — list all meta entities with summary. */
@@ -114,7 +132,7 @@ export class MetaServiceClient {
     if (params?.fields?.length) qs.set('fields', params.fields.join(','));
     const query = qs.toString();
     return this.get<MetasResponse>(
-      getEndpoint('listMetas').path + (query ? '?' + query : ''),
+      this.endpointPath('listMetas') + (query ? '?' + query : ''),
     );
   }
 
@@ -132,9 +150,8 @@ export class MetaServiceClient {
       _criticTimeout?: number | null;
     },
   ): Promise<unknown> {
-    const encoded = encodeURIComponent(metaPath);
     return fetchJson(
-      `${this.baseUrl}${getEndpoint('listMetas').path}/${encoded}`,
+      `${this.baseUrl}${this.endpointPath('updateMeta', { path: metaPath })}`,
       {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
@@ -148,14 +165,13 @@ export class MetaServiceClient {
     metaPath: string,
     options?: { includeArchive?: boolean | number; fields?: string[] },
   ): Promise<unknown> {
-    const encoded = encodeURIComponent(metaPath);
     const qs = new URLSearchParams();
     if (options?.includeArchive !== undefined)
       qs.set('includeArchive', String(options.includeArchive));
     if (options?.fields?.length) qs.set('fields', options.fields.join(','));
     const query = qs.toString();
     return this.get(
-      `${getEndpoint('listMetas').path}/${encoded}` +
+      this.endpointPath('metaDetail', { path: metaPath }) +
         (query ? '?' + query : ''),
     );
   }
@@ -163,12 +179,12 @@ export class MetaServiceClient {
   /** GET /preview — dry-run next synthesis candidate. */
   public async preview(path?: string): Promise<unknown> {
     const qs = path ? '?path=' + encodeURIComponent(path) : '';
-    return this.get(getEndpoint('preview').path + qs);
+    return this.get(this.endpointPath('preview') + qs);
   }
 
   /** POST /synthesize — enqueue synthesis. */
   public async synthesize(path?: string): Promise<unknown> {
-    return this.post(getEndpoint('synthesize').path, path ? { path } : {});
+    return this.post(this.endpointPath('synthesize'), path ? { path } : {});
   }
 
   /** POST /seed — create .meta/ for a path. */
@@ -180,32 +196,32 @@ export class MetaServiceClient {
     const body: Record<string, unknown> = { path };
     if (crossRefs !== undefined) body.crossRefs = crossRefs;
     if (steer !== undefined) body.steer = steer;
-    return this.post(getEndpoint('seed').path, body);
+    return this.post(this.endpointPath('seed'), body);
   }
 
   /** POST /unlock — remove .lock from a meta entity. */
   public async unlock(path: string): Promise<unknown> {
-    return this.post(getEndpoint('unlock').path, { path });
+    return this.post(this.endpointPath('unlock'), { path });
   }
 
   /** GET /config — query service config with optional JSONPath. */
   public async config(path?: string): Promise<unknown> {
     const qs = path ? '?path=' + encodeURIComponent(path) : '';
-    return this.get(getEndpoint('config').path + qs);
+    return this.get(this.endpointPath('config') + qs);
   }
 
   /** GET /queue — current queue state. */
   public async queue(): Promise<unknown> {
-    return this.get(getEndpoint('queue').path);
+    return this.get(this.endpointPath('queue'));
   }
 
   /** POST /queue/clear — remove all pending queue items. */
   public async clearQueue(): Promise<unknown> {
-    return this.post(getEndpoint('queueClear').path, {});
+    return this.post(this.endpointPath('queueClear'), {});
   }
 
   /** POST /synthesize/abort — abort current synthesis. */
   public async abort(): Promise<unknown> {
-    return this.post(getEndpoint('abort').path, {});
+    return this.post(this.endpointPath('abort'), {});
   }
 }

--- a/packages/openclaw/src/serviceClient.ts
+++ b/packages/openclaw/src/serviceClient.ts
@@ -8,14 +8,15 @@
  */
 
 import { fetchJson, postJson } from '@karmaniverous/jeeves';
-import type {
-  DepHealth,
-  GatewayDepHealth,
-  MetaListSummary,
-  MetasItem,
-  MetasResponse,
-  ServiceState,
-  WatcherDepHealth,
+import {
+  type DepHealth,
+  type GatewayDepHealth,
+  getEndpoint,
+  type MetaListSummary,
+  type MetasItem,
+  type MetasResponse,
+  type ServiceState,
+  type WatcherDepHealth,
 } from '@karmaniverous/jeeves-meta-core';
 
 // Re-export core types for consumers that import from this module.
@@ -86,7 +87,7 @@ export class MetaServiceClient {
 
   /** GET /status — service health + queue state. */
   public async status(): Promise<StatusResponse> {
-    return this.get<StatusResponse>('/status');
+    return this.get<StatusResponse>(getEndpoint('status').path);
   }
 
   /** GET /metas — list all meta entities with summary. */
@@ -112,7 +113,9 @@ export class MetaServiceClient {
       qs.set('disabled', String(params.disabled));
     if (params?.fields?.length) qs.set('fields', params.fields.join(','));
     const query = qs.toString();
-    return this.get<MetasResponse>('/metas' + (query ? '?' + query : ''));
+    return this.get<MetasResponse>(
+      getEndpoint('listMetas').path + (query ? '?' + query : ''),
+    );
   }
 
   /** PATCH /metas/:path — update user-settable reserved properties. */
@@ -127,11 +130,14 @@ export class MetaServiceClient {
     },
   ): Promise<unknown> {
     const encoded = encodeURIComponent(metaPath);
-    return fetchJson(`${this.baseUrl}/metas/${encoded}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(updates),
-    });
+    return fetchJson(
+      `${this.baseUrl}${getEndpoint('listMetas').path}/${encoded}`,
+      {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(updates),
+      },
+    );
   }
 
   /** GET /metas/:path — detail for a single meta. */
@@ -145,18 +151,21 @@ export class MetaServiceClient {
       qs.set('includeArchive', String(options.includeArchive));
     if (options?.fields?.length) qs.set('fields', options.fields.join(','));
     const query = qs.toString();
-    return this.get(`/metas/${encoded}` + (query ? '?' + query : ''));
+    return this.get(
+      `${getEndpoint('listMetas').path}/${encoded}` +
+        (query ? '?' + query : ''),
+    );
   }
 
   /** GET /preview — dry-run next synthesis candidate. */
   public async preview(path?: string): Promise<unknown> {
     const qs = path ? '?path=' + encodeURIComponent(path) : '';
-    return this.get('/preview' + qs);
+    return this.get(getEndpoint('preview').path + qs);
   }
 
   /** POST /synthesize — enqueue synthesis. */
   public async synthesize(path?: string): Promise<unknown> {
-    return this.post('/synthesize', path ? { path } : {});
+    return this.post(getEndpoint('synthesize').path, path ? { path } : {});
   }
 
   /** POST /seed — create .meta/ for a path. */
@@ -168,32 +177,32 @@ export class MetaServiceClient {
     const body: Record<string, unknown> = { path };
     if (crossRefs !== undefined) body.crossRefs = crossRefs;
     if (steer !== undefined) body.steer = steer;
-    return this.post('/seed', body);
+    return this.post(getEndpoint('seed').path, body);
   }
 
   /** POST /unlock — remove .lock from a meta entity. */
   public async unlock(path: string): Promise<unknown> {
-    return this.post('/unlock', { path });
+    return this.post(getEndpoint('unlock').path, { path });
   }
 
   /** GET /config — query service config with optional JSONPath. */
   public async config(path?: string): Promise<unknown> {
     const qs = path ? '?path=' + encodeURIComponent(path) : '';
-    return this.get('/config' + qs);
+    return this.get(getEndpoint('config').path + qs);
   }
 
   /** GET /queue — current queue state. */
   public async queue(): Promise<unknown> {
-    return this.get('/queue');
+    return this.get(getEndpoint('queue').path);
   }
 
   /** POST /queue/clear — remove all pending queue items. */
   public async clearQueue(): Promise<unknown> {
-    return this.post('/queue/clear', {});
+    return this.post(getEndpoint('queueClear').path, {});
   }
 
   /** POST /synthesize/abort — abort current synthesis. */
   public async abort(): Promise<unknown> {
-    return this.post('/synthesize/abort', {});
+    return this.post(getEndpoint('abort').path, {});
   }
 }

--- a/packages/service/src/bootstrap.ts
+++ b/packages/service/src/bootstrap.ts
@@ -220,9 +220,7 @@ export async function startService(
   void registrar.register().then(
     () => {
       routeDeps.ready = true;
-      if (registrar.isRegistered) {
-        void verifyRuleApplication(watcher, logger);
-      }
+      void verifyRuleApplication(watcher, logger);
     },
     () => {
       // Registration failed after max retries — mark ready anyway

--- a/packages/service/src/discovery/getAncestorMeta.test.ts
+++ b/packages/service/src/discovery/getAncestorMeta.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests for getAncestorMeta — nearest ancestor meta node lookup.
+ *
+ * @module discovery/getAncestorMeta.test
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { getAncestorMeta } from './getAncestorMeta.js';
+import type { MetaNode } from './types.js';
+
+/** Helper to build a minimal MetaNode for testing. */
+function makeNode(metaPath: string, parent: MetaNode | null = null): MetaNode {
+  const ownerPath = metaPath.replace(/\/.meta$/, '');
+  const node: MetaNode = {
+    metaPath,
+    ownerPath,
+    treeDepth: parent ? parent.treeDepth + 1 : 0,
+    children: [],
+    parent,
+  };
+  if (parent) parent.children.push(node);
+  return node;
+}
+
+describe('getAncestorMeta', () => {
+  it('returns null for a root-level meta', () => {
+    const root = makeNode('j:/domains/.meta');
+    expect(getAncestorMeta(root)).toBeNull();
+  });
+
+  it('returns the parent for a direct child meta', () => {
+    const root = makeNode('j:/domains/.meta');
+    const child = makeNode('j:/domains/github/.meta', root);
+    expect(getAncestorMeta(child)).toBe(root);
+  });
+
+  it('returns the immediate parent in a nested tree', () => {
+    const root = makeNode('j:/domains/.meta');
+    const mid = makeNode('j:/domains/github/.meta', root);
+    const leaf = makeNode('j:/domains/github/karmaniverous/.meta', mid);
+    expect(getAncestorMeta(leaf)).toBe(mid);
+    expect(getAncestorMeta(mid)).toBe(root);
+  });
+
+  it('returns null for all roots in a flat tree', () => {
+    const a = makeNode('j:/domains/a/.meta');
+    const b = makeNode('j:/domains/b/.meta');
+    expect(getAncestorMeta(a)).toBeNull();
+    expect(getAncestorMeta(b)).toBeNull();
+  });
+});

--- a/packages/service/src/discovery/getAncestorMeta.ts
+++ b/packages/service/src/discovery/getAncestorMeta.ts
@@ -1,0 +1,20 @@
+/**
+ * Retrieve the nearest ancestor meta node from the ownership tree.
+ *
+ * @module discovery/getAncestorMeta
+ */
+
+import type { MetaNode } from './types.js';
+
+/**
+ * Get the nearest ancestor MetaNode for a given node.
+ *
+ * Walks up the ownership tree (via the parent pointer set by
+ * buildOwnershipTree) to find the closest ancestor .meta/ directory.
+ *
+ * @param node - The meta node to find the ancestor for.
+ * @returns The parent MetaNode, or null for root-level metas.
+ */
+export function getAncestorMeta(node: MetaNode): MetaNode | null {
+  return node.parent;
+}

--- a/packages/service/src/discovery/index.ts
+++ b/packages/service/src/discovery/index.ts
@@ -6,6 +6,7 @@
 
 export { computeSummary } from './computeSummary.js';
 export { discoverMetas } from './discoverMetas.js';
+export { getAncestorMeta } from './getAncestorMeta.js';
 export {
   listMetas,
   type MetaEntry,

--- a/packages/service/src/executor/GatewayExecutor.ts
+++ b/packages/service/src/executor/GatewayExecutor.ts
@@ -203,7 +203,7 @@ export class GatewayExecutor implements MetaExecutor {
       'Write your complete output to a file using the Write tool at:\n' +
       outputPath +
       '\n\n' +
-      'After writing the file, reply with ONLY: NO_REPLY';
+      'After writing the file, your final message must be exactly: ANNOUNCE_SKIP';
 
     // Step 1: Spawn the sub-agent session (unique label per cycle to avoid
     // "label already in use" errors — gateway labels persist after session completion)
@@ -292,7 +292,9 @@ export class GatewayExecutor implements MetaExecutor {
             }
           }
 
-          // Fallback: extract from message content if file wasn't written
+          // Fallback: extract from message content if file wasn't written.
+          // Skip ANNOUNCE_SKIP sentinel messages — the real output is in
+          // a preceding assistant message (the file write).
           for (let i = msgArray.length - 1; i >= 0; i--) {
             const msg = msgArray[i];
             if (msg.role === 'assistant' && msg.content) {
@@ -305,7 +307,8 @@ export class GatewayExecutor implements MetaExecutor {
                         .map((b) => b.text!)
                         .join('\n')
                     : '';
-              if (text) return { output: text, tokens };
+              if (text && text.trim() !== 'ANNOUNCE_SKIP')
+                return { output: text, tokens };
             }
           }
           return { output: '', tokens };

--- a/packages/service/src/interfaces/MetaContext.ts
+++ b/packages/service/src/interfaces/MetaContext.ts
@@ -43,4 +43,7 @@ export interface MetaContext {
 
   /** Archive snapshot file paths (for steer change detection, etc.). */
   archives: string[];
+
+  /** Nearest ancestor meta's _builder output, if available. */
+  ancestorBuilder?: string;
 }

--- a/packages/service/src/logger/index.ts
+++ b/packages/service/src/logger/index.ts
@@ -32,11 +32,16 @@ export function createLogger(config?: LoggerConfig): pino.Logger {
   const level = config?.level ?? 'info';
 
   if (config?.file) {
-    const transport = pino.transport({
-      target: 'pino/file',
-      options: { destination: config.file, mkdir: true },
+    const fileStream = pino.destination({
+      dest: config.file,
+      sync: false,
+      mkdir: true,
     });
-    return pino({ level }, transport);
+    const multistream = pino.multistream([
+      { stream: process.stdout },
+      { stream: fileStream },
+    ]);
+    return pino({ level }, multistream);
   }
 
   return pino({ level });

--- a/packages/service/src/orchestrator/buildTask.ts
+++ b/packages/service/src/orchestrator/buildTask.ts
@@ -142,7 +142,7 @@ export function buildArchitectTask(
   const sections = [
     `# jeeves-meta · ARCHITECT · ${ctx.path}`,
     '',
-    meta._architect ?? config.defaultArchitect ?? DEFAULT_ARCHITECT_PROMPT,
+    config.defaultArchitect ?? DEFAULT_ARCHITECT_PROMPT,
     '',
     '## SCOPE',
     `Path: ${ctx.path}`,
@@ -267,7 +267,7 @@ export function buildCriticTask(
   const sections = [
     `# jeeves-meta · CRITIC · ${ctx.path}`,
     '',
-    meta._critic ?? config.defaultCritic ?? DEFAULT_CRITIC_PROMPT,
+    config.defaultCritic ?? DEFAULT_CRITIC_PROMPT,
     '',
     '## SYNTHESIS TO EVALUATE',
     meta._content ?? '(No content produced)',

--- a/packages/service/src/orchestrator/buildTask.ts
+++ b/packages/service/src/orchestrator/buildTask.ts
@@ -153,6 +153,11 @@ export function buildArchitectTask(
     condenseScopeFiles(ctx.scopeFiles),
   ];
 
+  // Inject nearest ancestor's organizational context
+  if (ctx.ancestorBuilder) {
+    sections.push('', '## PARENT ORGANIZATIONAL CONTEXT', ctx.ancestorBuilder);
+  }
+
   // Inject previous _builder so architect can see its own prior output
   if (meta._builder) {
     sections.push('', '## PREVIOUS TASK BRIEF', meta._builder);
@@ -199,6 +204,11 @@ export function buildBuilderTask(
     `Delta files (${ctx.deltaFiles.length.toString()} changed):`,
     ...ctx.deltaFiles.slice(0, config.maxLines).map((f) => `- ${f}`),
   ];
+
+  // Inject nearest ancestor's organizational context
+  if (ctx.ancestorBuilder) {
+    sections.push('', '## PARENT ORGANIZATIONAL CONTEXT', ctx.ancestorBuilder);
+  }
 
   if (ctx.previousState != null) {
     sections.push(

--- a/packages/service/src/orchestrator/buildTask.ts
+++ b/packages/service/src/orchestrator/buildTask.ts
@@ -78,6 +78,13 @@ function appendMetaSections(
   }
 }
 
+/** Inject nearest ancestor's organizational context, if available. */
+function appendAncestorContext(sections: string[], ctx: MetaContext): void {
+  if (ctx.ancestorBuilder) {
+    sections.push('', '## PARENT ORGANIZATIONAL CONTEXT', ctx.ancestorBuilder);
+  }
+}
+
 /** Append optional context sections shared across all step prompts. */
 function appendSharedSections(
   sections: string[],
@@ -153,10 +160,7 @@ export function buildArchitectTask(
     condenseScopeFiles(ctx.scopeFiles),
   ];
 
-  // Inject nearest ancestor's organizational context
-  if (ctx.ancestorBuilder) {
-    sections.push('', '## PARENT ORGANIZATIONAL CONTEXT', ctx.ancestorBuilder);
-  }
+  appendAncestorContext(sections, ctx);
 
   // Inject previous _builder so architect can see its own prior output
   if (meta._builder) {
@@ -205,10 +209,7 @@ export function buildBuilderTask(
     ...ctx.deltaFiles.slice(0, config.maxLines).map((f) => `- ${f}`),
   ];
 
-  // Inject nearest ancestor's organizational context
-  if (ctx.ancestorBuilder) {
-    sections.push('', '## PARENT ORGANIZATIONAL CONTEXT', ctx.ancestorBuilder);
-  }
+  appendAncestorContext(sections, ctx);
 
   if (ctx.previousState != null) {
     sections.push(

--- a/packages/service/src/orchestrator/contextPackage.ts
+++ b/packages/service/src/orchestrator/contextPackage.ts
@@ -12,6 +12,7 @@ import { join } from 'node:path';
 
 import { listArchiveFiles } from '../archive/index.js';
 import {
+  getAncestorMeta,
   getDeltaFiles,
   getScopeFiles,
   type MetaNode,
@@ -130,6 +131,21 @@ export async function buildContextPackage(
   // Archive paths
   const archives = listArchiveFiles(node.metaPath);
 
+  // Nearest ancestor _builder output
+  let ancestorBuilder: string | undefined;
+  const ancestor = getAncestorMeta(node);
+  if (ancestor) {
+    try {
+      const raw = await readFile(join(ancestor.metaPath, 'meta.json'), 'utf8');
+      const ancestorMeta = JSON.parse(raw) as MetaJson;
+      if (ancestorMeta._builder) {
+        ancestorBuilder = ancestorMeta._builder;
+      }
+    } catch {
+      // Ancestor meta.json unreadable — skip
+    }
+  }
+
   return {
     path: node.metaPath,
     scopeFiles,
@@ -141,5 +157,6 @@ export async function buildContextPackage(
     steer: meta._steer ?? null,
     previousState: meta._state ?? null,
     archives,
+    ancestorBuilder,
   };
 }

--- a/packages/service/src/orchestrator/orchestrator.test.ts
+++ b/packages/service/src/orchestrator/orchestrator.test.ts
@@ -258,6 +258,24 @@ describe('parseArchitectOutput', () => {
   it('trims and returns text', () => {
     expect(parseArchitectOutput('  task brief  \n')).toBe('task brief');
   });
+
+  it('strips trailing ANNOUNCE_SKIP sentinel', () => {
+    expect(parseArchitectOutput('task brief\nANNOUNCE_SKIP')).toBe(
+      'task brief',
+    );
+  });
+
+  it('strips ANNOUNCE_SKIP with surrounding whitespace', () => {
+    expect(parseArchitectOutput('  task brief  \n  ANNOUNCE_SKIP  ')).toBe(
+      'task brief',
+    );
+  });
+
+  it('preserves text when ANNOUNCE_SKIP is not at the end', () => {
+    expect(
+      parseArchitectOutput('ANNOUNCE_SKIP then more text'),
+    ).toBe('ANNOUNCE_SKIP then more text');
+  });
 });
 
 describe('parseBuilderOutput', () => {
@@ -283,6 +301,19 @@ describe('parseBuilderOutput', () => {
     expect(out.fields).toEqual({});
   });
 
+  it('strips trailing ANNOUNCE_SKIP from JSON output', () => {
+    const out = parseBuilderOutput(
+      JSON.stringify({ _content: '# Synthesis' }) + '\nANNOUNCE_SKIP',
+    );
+    expect(out.content).toBe('# Synthesis');
+  });
+
+  it('strips trailing ANNOUNCE_SKIP from plain text output', () => {
+    const out = parseBuilderOutput('Just narrative\nANNOUNCE_SKIP');
+    expect(out.content).toBe('Just narrative');
+    expect(out.fields).toEqual({});
+  });
+
   it('extracts _state from JSON output', () => {
     const out = parseBuilderOutput(
       JSON.stringify({
@@ -305,5 +336,9 @@ describe('parseBuilderOutput', () => {
 describe('parseCriticOutput', () => {
   it('trims and returns text', () => {
     expect(parseCriticOutput('  good work  \n')).toBe('good work');
+  });
+
+  it('strips trailing ANNOUNCE_SKIP sentinel', () => {
+    expect(parseCriticOutput('good work\nANNOUNCE_SKIP')).toBe('good work');
   });
 });

--- a/packages/service/src/orchestrator/orchestrator.test.ts
+++ b/packages/service/src/orchestrator/orchestrator.test.ts
@@ -272,9 +272,9 @@ describe('parseArchitectOutput', () => {
   });
 
   it('preserves text when ANNOUNCE_SKIP is not at the end', () => {
-    expect(
-      parseArchitectOutput('ANNOUNCE_SKIP then more text'),
-    ).toBe('ANNOUNCE_SKIP then more text');
+    expect(parseArchitectOutput('ANNOUNCE_SKIP then more text')).toBe(
+      'ANNOUNCE_SKIP then more text',
+    );
   });
 });
 

--- a/packages/service/src/orchestrator/orchestrator.test.ts
+++ b/packages/service/src/orchestrator/orchestrator.test.ts
@@ -63,14 +63,14 @@ describe('buildArchitectTask', () => {
     expect(task).toContain('Child synthesis content');
   });
 
-  it('uses meta._architect override when present', () => {
+  it('ignores meta._architect snapshot and uses config default', () => {
     const meta: MetaJson = {
       ...sampleMeta,
-      _architect: 'Custom architect prompt',
+      _architect: 'Stale snapshot prompt',
     };
     const task = buildArchitectTask(sampleCtx, meta, sampleConfig);
-    expect(task).toContain('Custom architect prompt');
-    expect(task).not.toContain('You are an architect');
+    expect(task).not.toContain('Stale snapshot prompt');
+    expect(task).toContain('You are an architect');
   });
 });
 

--- a/packages/service/src/orchestrator/parseOutput.ts
+++ b/packages/service/src/orchestrator/parseOutput.ts
@@ -8,6 +8,17 @@
  * @module orchestrator/parseOutput
  */
 
+/** Sentinel appended by synthesis workers to skip the announce turn. */
+const ANNOUNCE_SKIP = 'ANNOUNCE_SKIP';
+
+/** Strip a trailing ANNOUNCE_SKIP sentinel from raw output. */
+function stripSentinel(raw: string): string {
+  const trimmed = raw.trim();
+  return trimmed.endsWith(ANNOUNCE_SKIP)
+    ? trimmed.slice(0, -ANNOUNCE_SKIP.length).trim()
+    : trimmed;
+}
+
 /** Parsed builder output. */
 export interface BuilderOutput {
   /** Narrative synthesis content. */
@@ -25,7 +36,7 @@ export interface BuilderOutput {
  * @returns The task brief string.
  */
 export function parseArchitectOutput(output: string): string {
-  return output.trim();
+  return stripSentinel(output);
 }
 
 /**
@@ -37,7 +48,7 @@ export function parseArchitectOutput(output: string): string {
  * @returns Parsed builder output with content and structured fields.
  */
 export function parseBuilderOutput(output: string): BuilderOutput {
-  const trimmed = output.trim();
+  const trimmed = stripSentinel(output);
 
   // Strategy 1: Try to parse the entire output as JSON directly
   const direct = tryParseJson(trimmed);
@@ -112,5 +123,5 @@ function tryParseJson(str: string): BuilderOutput | null {
  * @returns The feedback string.
  */
 export function parseCriticOutput(output: string): string {
-  return output.trim();
+  return stripSentinel(output);
 }

--- a/packages/service/src/orchestrator/runPhase.ts
+++ b/packages/service/src/orchestrator/runPhase.ts
@@ -48,6 +48,15 @@ import {
   parseCriticOutput,
 } from './parseOutput.js';
 
+/** Compute SHA-256 hash of ancestor _builder text for observability tracking. */
+function hashAncestorBuilder(
+  ancestorBuilder: string | undefined,
+): string | undefined {
+  return ancestorBuilder
+    ? createHash('sha256').update(ancestorBuilder).digest('hex')
+    : undefined;
+}
+
 /** Callback for synthesis progress events. */
 export type ProgressCallback = (event: ProgressEvent) => void | Promise<void>;
 
@@ -145,6 +154,12 @@ export async function runArchitect(
   logger?: MinimalLogger,
 ): Promise<PhaseResult> {
   let ps = phaseRunning(phaseState, 'architect');
+  const base: FinalizeBase = {
+    metaPath: node.metaPath,
+    current: currentMeta,
+    config,
+    structureHash,
+  };
 
   const ctx = await buildContextPackage(node, currentMeta, watcher, logger);
 
@@ -175,17 +190,10 @@ export async function runArchitect(
       _generatedAt: new Date().toISOString(),
       _error: undefined,
     };
-    if (ctx.ancestorBuilder) {
-      architectUpdates._ancestorBuilderHash = createHash('sha256')
-        .update(ctx.ancestorBuilder)
-        .digest('hex');
-    }
+    const ancestorHash = hashAncestorBuilder(ctx.ancestorBuilder);
+    if (ancestorHash) architectUpdates._ancestorBuilderHash = ancestorHash;
 
-    const updatedMeta = await persistPhaseState(
-      { metaPath: node.metaPath, current: currentMeta, config, structureHash },
-      ps,
-      architectUpdates,
-    );
+    const updatedMeta = await persistPhaseState(base, ps, architectUpdates);
 
     await onProgress?.({
       type: 'phase_complete',
@@ -197,12 +205,7 @@ export async function runArchitect(
 
     return { executed: true, phaseState: ps, updatedMeta };
   } catch (err) {
-    return handlePhaseFailure('architect', err, executor, ps, {
-      metaPath: node.metaPath,
-      current: currentMeta,
-      config,
-      structureHash,
-    });
+    return handlePhaseFailure('architect', err, executor, ps, base);
   }
 }
 
@@ -220,6 +223,12 @@ export async function runBuilder(
   logger?: MinimalLogger,
 ): Promise<PhaseResult> {
   let ps = phaseRunning(phaseState, 'builder');
+  const base: FinalizeBase = {
+    metaPath: node.metaPath,
+    current: currentMeta,
+    config,
+    structureHash,
+  };
 
   const ctx = await buildContextPackage(node, currentMeta, watcher, logger);
 
@@ -250,17 +259,10 @@ export async function runBuilder(
       _error: undefined,
       ...builderOutput.fields,
     };
-    if (ctx.ancestorBuilder) {
-      builderUpdates._ancestorBuilderHash = createHash('sha256')
-        .update(ctx.ancestorBuilder)
-        .digest('hex');
-    }
+    const ancestorHash = hashAncestorBuilder(ctx.ancestorBuilder);
+    if (ancestorHash) builderUpdates._ancestorBuilderHash = ancestorHash;
 
-    const updatedMeta = await persistPhaseState(
-      { metaPath: node.metaPath, current: currentMeta, config, structureHash },
-      ps,
-      builderUpdates,
-    );
+    const updatedMeta = await persistPhaseState(base, ps, builderUpdates);
 
     await onProgress?.({
       type: 'phase_complete',
@@ -289,19 +291,7 @@ export async function runBuilder(
       }
     }
 
-    return handlePhaseFailure(
-      'builder',
-      err,
-      executor,
-      ps,
-      {
-        metaPath: node.metaPath,
-        current: currentMeta,
-        config,
-        structureHash,
-      },
-      partialState,
-    );
+    return handlePhaseFailure('builder', err, executor, ps, base, partialState);
   }
 }
 
@@ -319,6 +309,12 @@ export async function runCritic(
   logger?: MinimalLogger,
 ): Promise<PhaseResult> {
   let ps = phaseRunning(phaseState, 'critic');
+  const base: FinalizeBase = {
+    metaPath: node.metaPath,
+    current: currentMeta,
+    config,
+    structureHash,
+  };
 
   const ctx = await buildContextPackage(node, currentMeta, watcher, logger);
 
@@ -358,11 +354,7 @@ export async function runCritic(
       updates._synthesisCount = (currentMeta._synthesisCount ?? 0) + 1;
     }
 
-    const updatedMeta = await persistPhaseState(
-      { metaPath: node.metaPath, current: currentMeta, config, structureHash },
-      ps,
-      updates,
-    );
+    const updatedMeta = await persistPhaseState(base, ps, updates);
 
     // Archive on full-cycle only
     if (cycleComplete) {
@@ -385,11 +377,6 @@ export async function runCritic(
       cycleComplete,
     };
   } catch (err) {
-    return handlePhaseFailure('critic', err, executor, ps, {
-      metaPath: node.metaPath,
-      current: currentMeta,
-      config,
-      structureHash,
-    });
+    return handlePhaseFailure('critic', err, executor, ps, base);
   }
 }

--- a/packages/service/src/orchestrator/runPhase.ts
+++ b/packages/service/src/orchestrator/runPhase.ts
@@ -153,7 +153,7 @@ export async function runArchitect(
     const architectTask = buildArchitectTask(ctx, currentMeta, config);
     const result = await executor.spawn(architectTask, {
       thinking: config.thinking,
-      timeout: config.architectTimeout,
+      timeout: currentMeta._architectTimeout ?? config.architectTimeout,
       label: 'meta-architect',
     });
     const builderBrief = parseArchitectOutput(result.output);
@@ -221,7 +221,7 @@ export async function runBuilder(
     const builderTask = buildBuilderTask(ctx, currentMeta, config);
     const result = await executor.spawn(builderTask, {
       thinking: config.thinking,
-      timeout: config.builderTimeout,
+      timeout: currentMeta._builderTimeout ?? config.builderTimeout,
       label: 'meta-builder',
     });
     const builderOutput = parseBuilderOutput(result.output);
@@ -316,7 +316,7 @@ export async function runCritic(
     const criticTask = buildCriticTask(ctx, metaForCritic, config);
     const result = await executor.spawn(criticTask, {
       thinking: config.thinking,
-      timeout: config.criticTimeout,
+      timeout: currentMeta._criticTimeout ?? config.criticTimeout,
       label: 'meta-critic',
     });
     const feedback = parseCriticOutput(result.output);

--- a/packages/service/src/orchestrator/runPhase.ts
+++ b/packages/service/src/orchestrator/runPhase.ts
@@ -7,6 +7,7 @@
  * @module orchestrator/runPhase
  */
 
+import { createHash } from 'node:crypto';
 import { copyFile, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
@@ -166,17 +167,24 @@ export async function runArchitect(
     // Architect success: architect → fresh, _synthesisCount → 0
     ps = architectSuccess(ps);
 
+    const architectUpdates: Partial<MetaJson> = {
+      _builder: builderBrief,
+      _architect: config.defaultArchitect ?? DEFAULT_ARCHITECT_PROMPT,
+      _synthesisCount: 0,
+      _architectTokens: architectTokens,
+      _generatedAt: new Date().toISOString(),
+      _error: undefined,
+    };
+    if (ctx.ancestorBuilder) {
+      architectUpdates._ancestorBuilderHash = createHash('sha256')
+        .update(ctx.ancestorBuilder)
+        .digest('hex');
+    }
+
     const updatedMeta = await persistPhaseState(
       { metaPath: node.metaPath, current: currentMeta, config, structureHash },
       ps,
-      {
-        _builder: builderBrief,
-        _architect: config.defaultArchitect ?? DEFAULT_ARCHITECT_PROMPT,
-        _synthesisCount: 0,
-        _architectTokens: architectTokens,
-        _generatedAt: new Date().toISOString(),
-        _error: undefined,
-      },
+      architectUpdates,
     );
 
     await onProgress?.({
@@ -234,17 +242,24 @@ export async function runBuilder(
     // Builder success: builder → fresh, critic → pending
     ps = builderSuccess(ps);
 
+    const builderUpdates: Partial<MetaJson> = {
+      _content: builderOutput.content,
+      _state: builderOutput.state,
+      _builderTokens: builderTokens,
+      _generatedAt: new Date().toISOString(),
+      _error: undefined,
+      ...builderOutput.fields,
+    };
+    if (ctx.ancestorBuilder) {
+      builderUpdates._ancestorBuilderHash = createHash('sha256')
+        .update(ctx.ancestorBuilder)
+        .digest('hex');
+    }
+
     const updatedMeta = await persistPhaseState(
       { metaPath: node.metaPath, current: currentMeta, config, structureHash },
       ps,
-      {
-        _content: builderOutput.content,
-        _state: builderOutput.state,
-        _builderTokens: builderTokens,
-        _generatedAt: new Date().toISOString(),
-        _error: undefined,
-        ...builderOutput.fields,
-      },
+      builderUpdates,
     );
 
     await onProgress?.({

--- a/packages/service/src/orchestrator/runPhase.ts
+++ b/packages/service/src/orchestrator/runPhase.ts
@@ -25,6 +25,10 @@ import {
   phaseRunning,
 } from '../phaseState/index.js';
 import type { ProgressEvent } from '../progress/index.js';
+import {
+  DEFAULT_ARCHITECT_PROMPT,
+  DEFAULT_CRITIC_PROMPT,
+} from '../prompts/index.js';
 import type {
   MetaConfig,
   MetaError,
@@ -167,7 +171,7 @@ export async function runArchitect(
       ps,
       {
         _builder: builderBrief,
-        _architect: currentMeta._architect ?? config.defaultArchitect ?? '',
+        _architect: config.defaultArchitect ?? DEFAULT_ARCHITECT_PROMPT,
         _synthesisCount: 0,
         _architectTokens: architectTokens,
         _generatedAt: new Date().toISOString(),
@@ -328,6 +332,7 @@ export async function runCritic(
 
     const updates: Partial<MetaJson> = {
       _feedback: feedback,
+      _critic: config.defaultCritic ?? DEFAULT_CRITIC_PROMPT,
       _criticTokens: criticTokens,
       _error: undefined,
     };

--- a/packages/service/src/phaseState/derivePhaseState.test.ts
+++ b/packages/service/src/phaseState/derivePhaseState.test.ts
@@ -123,7 +123,6 @@ describe('derivePhaseState', () => {
     const result = derivePhaseState(meta, {
       structureChanged: true,
       steerChanged: false,
-      architectChanged: false,
       crossRefsChanged: false,
       architectEvery: 10,
     });
@@ -145,7 +144,6 @@ describe('derivePhaseState', () => {
     const result = derivePhaseState(meta, {
       structureChanged: false,
       steerChanged: false,
-      architectChanged: false,
       crossRefsChanged: false,
       architectEvery: 10,
     });
@@ -163,7 +161,6 @@ describe('derivePhaseState', () => {
     const result = derivePhaseState(meta, {
       structureChanged: true,
       steerChanged: false,
-      architectChanged: false,
       crossRefsChanged: false,
       architectEvery: 10,
     });
@@ -184,7 +181,6 @@ describe('derivePhaseState', () => {
     const result = derivePhaseState(meta, {
       structureChanged: true,
       steerChanged: false,
-      architectChanged: false,
       crossRefsChanged: false,
       architectEvery: 10,
     });

--- a/packages/service/src/phaseState/derivePhaseState.ts
+++ b/packages/service/src/phaseState/derivePhaseState.ts
@@ -17,8 +17,6 @@ export interface DerivationInputs {
   structureChanged: boolean;
   /** Whether _steer changed vs. latest archive. */
   steerChanged: boolean;
-  /** Whether _architect prompt changed. */
-  architectChanged: boolean;
   /** Whether _crossRefs declaration changed. */
   crossRefsChanged: boolean;
   /** architectEvery config value. */
@@ -84,7 +82,6 @@ export function derivePhaseState(
     const architectInvalidated =
       structureInvalidatesArchitect ||
       inputs.steerChanged ||
-      inputs.architectChanged ||
       inputs.crossRefsChanged ||
       (meta._synthesisCount ?? 0) >= inputs.architectEvery;
 

--- a/packages/service/src/phaseState/invalidate.test.ts
+++ b/packages/service/src/phaseState/invalidate.test.ts
@@ -1,0 +1,594 @@
+/**
+ * Unit tests for computeInvalidation.
+ *
+ * Covers every conditional branch: structure hash, steer, crossRefs,
+ * architectEvery, prompt staleness, first run, progressive entities,
+ * cross-ref content changes, and combinations.
+ *
+ * @module phaseState/invalidate.test
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MetaNode } from '../discovery/types.js';
+import type { MetaConfig, MetaJson, PhaseState } from '../schema/index.js';
+import { computeStructureHash } from '../structureHash.js';
+
+import { computeInvalidation } from './invalidate.js';
+
+// ── Mock readLatestArchive ──────────────────────────────────────────
+// We mock at the module level so each test can control the archive return.
+let mockArchive: MetaJson | null = null;
+
+vi.mock('../archive/index.js', () => ({
+  readLatestArchive: vi.fn(async () => mockArchive),
+}));
+
+// ── Mock DEFAULT prompts to stable strings ──────────────────────────
+vi.mock('../prompts/index.js', () => ({
+  DEFAULT_ARCHITECT_PROMPT: 'default-architect-prompt',
+  DEFAULT_CRITIC_PROMPT: 'default-critic-prompt',
+}));
+
+// ── Shared fixtures ─────────────────────────────────────────────────
+
+/** Scope files used throughout; hash is stable per set. */
+const SCOPE_A = ['file-a.md', 'file-b.md'];
+const SCOPE_B = ['file-a.md', 'file-b.md', 'file-c.md'];
+
+const HASH_A = computeStructureHash(SCOPE_A);
+const HASH_B = computeStructureHash(SCOPE_B);
+
+function makeConfig(overrides?: Partial<MetaConfig>): MetaConfig {
+  return {
+    watcherUrl: 'http://localhost:3456',
+    gatewayUrl: 'http://127.0.0.1:18789',
+    architectEvery: 10,
+    depthWeight: 0.5,
+    maxArchive: 20,
+    maxLines: 500,
+    architectTimeout: 120,
+    builderTimeout: 600,
+    criticTimeout: 300,
+    thinking: 'low',
+    defaultArchitect: 'default-architect-prompt',
+    defaultCritic: 'default-critic-prompt',
+    skipUnchanged: true,
+    metaProperty: { _meta: 'current' },
+    metaArchiveProperty: { _meta: 'archive' },
+    ...overrides,
+  };
+}
+
+const freshPhaseState: PhaseState = {
+  architect: 'fresh',
+  builder: 'fresh',
+  critic: 'fresh',
+};
+
+describe('computeInvalidation', () => {
+  let testRoot: string;
+  let metaPath: string;
+  let node: MetaNode;
+
+  beforeEach(() => {
+    testRoot = join(
+      tmpdir(),
+      `invalidate-test-${String(Date.now())}-${Math.random().toString(36).slice(2)}`,
+    );
+    metaPath = join(testRoot, 'owner', '.meta');
+    mkdirSync(metaPath, { recursive: true });
+
+    node = {
+      metaPath,
+      ownerPath: join(testRoot, 'owner'),
+      treeDepth: 0,
+      children: [],
+      parent: null,
+    };
+
+    // Default: archive exists with matching state
+    mockArchive = {
+      _steer: undefined,
+      _crossRefs: [],
+      _builder: 'existing brief',
+      _content: 'existing content',
+    };
+  });
+
+  afterEach(() => {
+    rmSync(testRoot, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  // ── 1. No invalidation needed ───────────────────────────────────
+
+  it('returns unchanged phaseState when fully fresh with no changes', async () => {
+    const meta: MetaJson = {
+      _phaseState: { ...freshPhaseState },
+      _structureHash: HASH_A,
+      _builder: 'existing brief',
+      _content: 'output',
+      _feedback: 'good',
+      _synthesisCount: 3,
+      _generatedAt: new Date().toISOString(),
+    };
+
+    const result = await computeInvalidation(
+      meta,
+      SCOPE_A,
+      makeConfig(),
+      node,
+    );
+
+    expect(result.phaseState).toEqual(freshPhaseState);
+    expect(result.architectInvalidators).toEqual([]);
+    expect(result.stalenessInputs.steerChanged).toBe(false);
+    expect(result.stalenessInputs.crossRefsDeclChanged).toBe(false);
+    expect(result.stalenessInputs.crossRefContentChanged).toBe(false);
+  });
+
+  // ── 2. Structure hash mismatch (non-progressive) ───────────────
+
+  it('invalidates architect on structure hash mismatch (non-progressive)', async () => {
+    const meta: MetaJson = {
+      _phaseState: { ...freshPhaseState },
+      _structureHash: HASH_A,
+      _builder: 'brief',
+      _synthesisCount: 0,
+    };
+
+    const result = await computeInvalidation(
+      meta,
+      SCOPE_B, // different files → different hash
+      makeConfig(),
+      node,
+    );
+
+    expect(result.architectInvalidators).toContain('structureHash');
+    expect(result.phaseState.architect).toBe('pending');
+    expect(result.phaseState.builder).toBe('stale');
+    expect(result.phaseState.critic).toBe('stale');
+  });
+
+  // ── 3. Structure hash mismatch (progressive, _state present) ───
+
+  it('invalidates builder only on structure hash mismatch for progressive entity', async () => {
+    const meta: MetaJson = {
+      _phaseState: { ...freshPhaseState },
+      _structureHash: HASH_A,
+      _builder: 'brief',
+      _state: { cursor: 5 },
+      _synthesisCount: 0,
+    };
+
+    const result = await computeInvalidation(
+      meta,
+      SCOPE_B,
+      makeConfig(),
+      node,
+    );
+
+    // structureHash should NOT be in architectInvalidators for progressive
+    expect(result.architectInvalidators).not.toContain('structureHash');
+    // Builder should be invalidated (pending), architect stays fresh
+    expect(result.phaseState.architect).toBe('fresh');
+    expect(result.phaseState.builder).toBe('pending');
+    expect(result.phaseState.critic).toBe('stale');
+  });
+
+  // ── 4. Steer change ────────────────────────────────────────────
+
+  it('invalidates architect on steer change', async () => {
+    // Archive has no steer, current meta adds steer
+    mockArchive = {
+      _steer: undefined,
+      _crossRefs: [],
+      _builder: 'brief',
+    };
+
+    const meta: MetaJson = {
+      _phaseState: { ...freshPhaseState },
+      _structureHash: HASH_A,
+      _steer: 'focus on performance',
+      _builder: 'brief',
+      _synthesisCount: 0,
+    };
+
+    const result = await computeInvalidation(
+      meta,
+      SCOPE_A,
+      makeConfig(),
+      node,
+    );
+
+    expect(result.architectInvalidators).toContain('steer');
+    expect(result.steerChanged).toBe(true);
+    expect(result.phaseState.architect).toBe('pending');
+  });
+
+  // ── 5. Cross-ref declaration change ────────────────────────────
+
+  it('invalidates architect on cross-ref declaration change', async () => {
+    mockArchive = {
+      _crossRefs: ['ref-a'],
+      _builder: 'brief',
+    };
+
+    const meta: MetaJson = {
+      _phaseState: { ...freshPhaseState },
+      _structureHash: HASH_A,
+      _crossRefs: ['ref-a', 'ref-b'], // added ref-b
+      _builder: 'brief',
+      _synthesisCount: 0,
+    };
+
+    const result = await computeInvalidation(
+      meta,
+      SCOPE_A,
+      makeConfig(),
+      node,
+    );
+
+    expect(result.architectInvalidators).toContain('_crossRefs');
+    expect(result.stalenessInputs.crossRefsDeclChanged).toBe(true);
+    expect(result.phaseState.architect).toBe('pending');
+  });
+
+  // ── 6. _synthesisCount >= architectEvery ────────────────────────
+
+  it('invalidates architect when synthesisCount reaches architectEvery', async () => {
+    const meta: MetaJson = {
+      _phaseState: { ...freshPhaseState },
+      _structureHash: HASH_A,
+      _builder: 'brief',
+      _synthesisCount: 10,
+    };
+
+    const result = await computeInvalidation(
+      meta,
+      SCOPE_A,
+      makeConfig({ architectEvery: 10 }),
+      node,
+    );
+
+    expect(result.architectInvalidators).toContain('architectEvery');
+    expect(result.phaseState.architect).toBe('pending');
+  });
+
+  // ── 7. Prompt staleness — architect snapshot differs ───────────
+
+  it('bumps synthesisCount to architectEvery when architect prompt is stale', async () => {
+    const meta: MetaJson = {
+      _phaseState: { ...freshPhaseState },
+      _structureHash: HASH_A,
+      _builder: 'brief',
+      _architect: 'old-architect-prompt', // differs from config default
+      _synthesisCount: 3,
+    };
+
+    const result = await computeInvalidation(
+      meta,
+      SCOPE_A,
+      makeConfig({ architectEvery: 10 }),
+      node,
+    );
+
+    // Soft invalidation bumps _synthesisCount to architectEvery,
+    // which triggers the architectEvery invalidator
+    expect(meta._synthesisCount).toBe(10);
+    expect(result.architectInvalidators).toContain('architectEvery');
+    expect(result.stalenessInputs.architectChanged).toBe(true);
+  });
+
+  // ── 8. Prompt staleness — critic snapshot differs ──────────────
+
+  it('bumps synthesisCount to architectEvery when critic prompt is stale', async () => {
+    const meta: MetaJson = {
+      _phaseState: { ...freshPhaseState },
+      _structureHash: HASH_A,
+      _builder: 'brief',
+      _critic: 'old-critic-prompt', // differs from config default
+      _synthesisCount: 2,
+    };
+
+    const result = await computeInvalidation(
+      meta,
+      SCOPE_A,
+      makeConfig({ architectEvery: 10 }),
+      node,
+    );
+
+    expect(meta._synthesisCount).toBe(10);
+    expect(result.architectInvalidators).toContain('architectEvery');
+    expect(result.stalenessInputs.architectChanged).toBe(false);
+  });
+
+  // ── 9. First run (no _builder) ─────────────────────────────────
+
+  it('invalidates architect on first run when no _builder exists', async () => {
+    mockArchive = null; // no archive either
+
+    const meta: MetaJson = {
+      _phaseState: { ...freshPhaseState },
+      _structureHash: HASH_A,
+      _synthesisCount: 0,
+      // no _builder
+    };
+
+    const result = await computeInvalidation(
+      meta,
+      SCOPE_A,
+      makeConfig(),
+      node,
+    );
+
+    expect(result.phaseState.architect).toBe('pending');
+    expect(result.phaseState.builder).toBe('stale');
+    expect(result.phaseState.critic).toBe('stale');
+  });
+
+  // ── 10. Cross-ref content change → builder-only invalidation ───
+
+  it('invalidates builder only on cross-ref content change', async () => {
+    const meta: MetaJson = {
+      _phaseState: { ...freshPhaseState },
+      _structureHash: HASH_A,
+      _builder: 'brief',
+      _crossRefs: ['ref-a'],
+      _synthesisCount: 0,
+    };
+
+    // Archive has matching crossRefs declaration
+    mockArchive = {
+      _crossRefs: ['ref-a'],
+      _builder: 'brief',
+    };
+
+    const crossRefMetas = new Map([['ref-a', 'updated content']]);
+    const archiveCrossRefContent = new Map([['ref-a', 'old content']]);
+
+    const result = await computeInvalidation(
+      meta,
+      SCOPE_A,
+      makeConfig(),
+      node,
+      crossRefMetas,
+      archiveCrossRefContent,
+    );
+
+    expect(result.stalenessInputs.crossRefContentChanged).toBe(true);
+    expect(result.architectInvalidators).toEqual([]);
+    expect(result.phaseState.architect).toBe('fresh');
+    expect(result.phaseState.builder).toBe('pending');
+    expect(result.phaseState.critic).toBe('stale');
+  });
+
+  // ── 11. Cross-ref content change suppressed by architect invalidation ──
+
+  it('does not double-cascade cross-ref content change when architect is already invalidated', async () => {
+    const meta: MetaJson = {
+      _phaseState: { ...freshPhaseState },
+      _structureHash: HASH_A,
+      _builder: 'brief',
+      _steer: 'new steer', // will trigger architect invalidation
+      _crossRefs: ['ref-a'],
+      _synthesisCount: 0,
+    };
+
+    // Archive has different steer → architect invalidated
+    mockArchive = {
+      _steer: 'old steer',
+      _crossRefs: ['ref-a'],
+      _builder: 'brief',
+    };
+
+    const crossRefMetas = new Map([['ref-a', 'updated content']]);
+    const archiveCrossRefContent = new Map([['ref-a', 'old content']]);
+
+    const result = await computeInvalidation(
+      meta,
+      SCOPE_A,
+      makeConfig(),
+      node,
+      crossRefMetas,
+      archiveCrossRefContent,
+    );
+
+    // Architect is invalidated (steer change)
+    expect(result.architectInvalidators).toContain('steer');
+    expect(result.stalenessInputs.crossRefContentChanged).toBe(true);
+    // Builder invalidation is via architect cascade, not separately applied
+    expect(result.phaseState.architect).toBe('pending');
+    expect(result.phaseState.builder).toBe('stale');
+    expect(result.phaseState.critic).toBe('stale');
+  });
+
+  // ── 12. Multiple simultaneous invalidators ─────────────────────
+
+  it('collects multiple architect invalidators when several inputs change', async () => {
+    mockArchive = {
+      _steer: 'old steer',
+      _crossRefs: ['ref-a'],
+      _builder: 'brief',
+    };
+
+    const meta: MetaJson = {
+      _phaseState: { ...freshPhaseState },
+      _structureHash: HASH_A,
+      _builder: 'brief',
+      _steer: 'new steer',
+      _crossRefs: ['ref-a', 'ref-b'], // declaration changed
+      _synthesisCount: 10, // at architectEvery
+    };
+
+    const result = await computeInvalidation(
+      meta,
+      SCOPE_B, // structure changed too
+      makeConfig({ architectEvery: 10 }),
+      node,
+    );
+
+    expect(result.architectInvalidators).toContain('structureHash');
+    expect(result.architectInvalidators).toContain('steer');
+    expect(result.architectInvalidators).toContain('_crossRefs');
+    expect(result.architectInvalidators).toContain('architectEvery');
+    expect(result.architectInvalidators).toHaveLength(4);
+    expect(result.phaseState.architect).toBe('pending');
+  });
+
+  // ── Additional edge cases ──────────────────────────────────────
+
+  it('derives default phaseState when meta has no _phaseState', async () => {
+    const meta: MetaJson = {
+      _structureHash: HASH_A,
+      _builder: 'brief',
+      _synthesisCount: 0,
+    };
+
+    const result = await computeInvalidation(
+      meta,
+      SCOPE_A,
+      makeConfig(),
+      node,
+    );
+
+    // Should start with default fresh and remain unchanged
+    expect(result.phaseState).toBeDefined();
+    expect(result.phaseState.architect).toBeDefined();
+  });
+
+  it('treats missing archive with non-empty crossRefs as declaration change', async () => {
+    mockArchive = null; // no archive
+
+    const meta: MetaJson = {
+      _phaseState: { ...freshPhaseState },
+      _structureHash: HASH_A,
+      _crossRefs: ['ref-a'],
+      _synthesisCount: 0,
+      // no _builder → first run takes priority
+    };
+
+    const result = await computeInvalidation(
+      meta,
+      SCOPE_A,
+      makeConfig(),
+      node,
+    );
+
+    expect(result.stalenessInputs.crossRefsDeclChanged).toBe(true);
+  });
+
+  it('does not treat matching prompt snapshots as stale', async () => {
+    const meta: MetaJson = {
+      _phaseState: { ...freshPhaseState },
+      _structureHash: HASH_A,
+      _builder: 'brief',
+      _architect: 'default-architect-prompt', // matches config default
+      _critic: 'default-critic-prompt', // matches config default
+      _synthesisCount: 3,
+    };
+
+    const result = await computeInvalidation(
+      meta,
+      SCOPE_A,
+      makeConfig(),
+      node,
+    );
+
+    // No bump — snapshots match
+    expect(meta._synthesisCount).toBe(3);
+    expect(result.stalenessInputs.architectChanged).toBe(false);
+    expect(result.architectInvalidators).not.toContain('architectEvery');
+  });
+
+  it('does not treat undefined prompt snapshots as stale', async () => {
+    const meta: MetaJson = {
+      _phaseState: { ...freshPhaseState },
+      _structureHash: HASH_A,
+      _builder: 'brief',
+      // _architect and _critic are undefined
+      _synthesisCount: 3,
+    };
+
+    const result = await computeInvalidation(
+      meta,
+      SCOPE_A,
+      makeConfig(),
+      node,
+    );
+
+    // isPromptStale returns false when snapshot is undefined
+    expect(meta._synthesisCount).toBe(3);
+    expect(result.stalenessInputs.architectChanged).toBe(false);
+  });
+
+  it('cross-ref content change does not invalidate builder on first run', async () => {
+    mockArchive = null;
+
+    const meta: MetaJson = {
+      _phaseState: { ...freshPhaseState },
+      _structureHash: HASH_A,
+      // no _builder → first run
+      _synthesisCount: 0,
+    };
+
+    const crossRefMetas = new Map([['ref-a', 'content']]);
+    const archiveCrossRefContent = new Map([['ref-a', 'old content']]);
+
+    const result = await computeInvalidation(
+      meta,
+      SCOPE_A,
+      makeConfig(),
+      node,
+      crossRefMetas,
+      archiveCrossRefContent,
+    );
+
+    // First run triggers architect invalidation; builder cascade comes from
+    // architect, not from cross-ref content change
+    expect(result.phaseState.architect).toBe('pending');
+    expect(result.stalenessInputs.crossRefContentChanged).toBe(true);
+  });
+
+  it('returns correct structureHash in result', async () => {
+    const meta: MetaJson = {
+      _phaseState: { ...freshPhaseState },
+      _structureHash: HASH_A,
+      _builder: 'brief',
+      _synthesisCount: 0,
+    };
+
+    const result = await computeInvalidation(
+      meta,
+      SCOPE_A,
+      makeConfig(),
+      node,
+    );
+
+    expect(result.structureHash).toBe(HASH_A);
+  });
+
+  it('no cross-ref content change when maps are not provided', async () => {
+    const meta: MetaJson = {
+      _phaseState: { ...freshPhaseState },
+      _structureHash: HASH_A,
+      _builder: 'brief',
+      _synthesisCount: 0,
+    };
+
+    const result = await computeInvalidation(
+      meta,
+      SCOPE_A,
+      makeConfig(),
+      node,
+      // no crossRefMetas or archiveCrossRefContent
+    );
+
+    expect(result.stalenessInputs.crossRefContentChanged).toBe(false);
+  });
+});

--- a/packages/service/src/phaseState/invalidate.test.ts
+++ b/packages/service/src/phaseState/invalidate.test.ts
@@ -278,9 +278,10 @@ describe('computeInvalidation', () => {
       node,
     );
 
-    // Soft invalidation bumps _synthesisCount to architectEvery,
+    // Soft invalidation signals synthesisCountOverride without mutating meta,
     // which triggers the architectEvery invalidator
-    expect(meta._synthesisCount).toBe(10);
+    expect(meta._synthesisCount).toBe(3); // original value unchanged
+    expect(result.synthesisCountOverride).toBe(10);
     expect(result.architectInvalidators).toContain('architectEvery');
     expect(result.stalenessInputs.architectChanged).toBe(true);
   });
@@ -303,7 +304,8 @@ describe('computeInvalidation', () => {
       node,
     );
 
-    expect(meta._synthesisCount).toBe(10);
+    expect(meta._synthesisCount).toBe(2); // original value unchanged
+    expect(result.synthesisCountOverride).toBe(10);
     expect(result.architectInvalidators).toContain('architectEvery');
     expect(result.stalenessInputs.architectChanged).toBe(false);
   });
@@ -502,6 +504,7 @@ describe('computeInvalidation', () => {
 
     // No bump — snapshots match
     expect(meta._synthesisCount).toBe(3);
+    expect(result.synthesisCountOverride).toBeNull();
     expect(result.stalenessInputs.architectChanged).toBe(false);
     expect(result.architectInvalidators).not.toContain('architectEvery');
   });
@@ -524,6 +527,7 @@ describe('computeInvalidation', () => {
 
     // isPromptStale returns false when snapshot is undefined
     expect(meta._synthesisCount).toBe(3);
+    expect(result.synthesisCountOverride).toBeNull();
     expect(result.stalenessInputs.architectChanged).toBe(false);
   });
 

--- a/packages/service/src/phaseState/invalidate.ts
+++ b/packages/service/src/phaseState/invalidate.ts
@@ -9,6 +9,10 @@
 
 import { readLatestArchive } from '../archive/index.js';
 import type { MetaNode } from '../discovery/types.js';
+import {
+  DEFAULT_ARCHITECT_PROMPT,
+  DEFAULT_CRITIC_PROMPT,
+} from '../prompts/index.js';
 import { hasSteerChanged } from '../scheduling/staleness.js';
 import type { MetaConfig, MetaJson, PhaseState } from '../schema/index.js';
 import { computeStructureHash } from '../structureHash.js';
@@ -18,7 +22,6 @@ import { invalidateArchitect, invalidateBuilder } from './phaseTransitions.js';
 export type ArchitectInvalidator =
   | 'structureHash'
   | 'steer'
-  | '_architect'
   | '_crossRefs'
   | 'architectEvery';
 
@@ -77,10 +80,23 @@ export async function computeInvalidation(
     Boolean(latestArchive),
   );
 
-  // _architect change: compare current vs. archive
-  const architectChanged = latestArchive
-    ? (meta._architect ?? '') !== (latestArchive._architect ?? '')
-    : Boolean(meta._architect);
+  // Soft invalidation: compare _architect snapshot against currently-resolved prompt.
+  // On mismatch, bump _synthesisCount to architectEvery so architect runs on the
+  // next natural cycle — but do NOT hard-cascade via invalidateArchitect.
+  const resolvedArchitect = config.defaultArchitect ?? DEFAULT_ARCHITECT_PROMPT;
+  const architectChanged =
+    meta._architect !== undefined && meta._architect !== resolvedArchitect;
+  if (architectChanged) {
+    meta._synthesisCount = config.architectEvery;
+  }
+
+  // Same soft invalidation for _critic prompt mismatch.
+  const resolvedCritic = config.defaultCritic ?? DEFAULT_CRITIC_PROMPT;
+  const criticChanged =
+    meta._critic !== undefined && meta._critic !== resolvedCritic;
+  if (criticChanged) {
+    meta._synthesisCount = config.architectEvery;
+  }
 
   // _crossRefs declaration change
   const currentRefs = (meta._crossRefs ?? []).slice().sort().join(',');
@@ -102,7 +118,6 @@ export async function computeInvalidation(
     }
   }
   if (steerChanged) architectInvalidators.push('steer');
-  if (architectChanged) architectInvalidators.push('_architect');
   if (crossRefsDeclChanged) architectInvalidators.push('_crossRefs');
   if ((meta._synthesisCount ?? 0) >= config.architectEvery) {
     architectInvalidators.push('architectEvery');

--- a/packages/service/src/phaseState/invalidate.ts
+++ b/packages/service/src/phaseState/invalidate.ts
@@ -18,6 +18,17 @@ import type { MetaConfig, MetaJson, PhaseState } from '../schema/index.js';
 import { computeStructureHash } from '../structureHash.js';
 import { invalidateArchitect, invalidateBuilder } from './phaseTransitions.js';
 
+/**
+ * Check whether a persisted prompt snapshot mismatches the currently-resolved prompt.
+ * Returns true when soft invalidation should bump _synthesisCount.
+ */
+function isPromptStale(
+  snapshot: string | undefined,
+  resolved: string,
+): boolean {
+  return snapshot !== undefined && snapshot !== resolved;
+}
+
 /** Architect-level invalidation reasons. */
 export type ArchitectInvalidator =
   | 'structureHash'
@@ -80,21 +91,18 @@ export async function computeInvalidation(
     Boolean(latestArchive),
   );
 
-  // Soft invalidation: compare _architect snapshot against currently-resolved prompt.
+  // Soft invalidation: compare prompt snapshots against currently-resolved prompts.
   // On mismatch, bump _synthesisCount to architectEvery so architect runs on the
   // next natural cycle — but do NOT hard-cascade via invalidateArchitect.
-  const resolvedArchitect = config.defaultArchitect ?? DEFAULT_ARCHITECT_PROMPT;
-  const architectChanged =
-    meta._architect !== undefined && meta._architect !== resolvedArchitect;
-  if (architectChanged) {
-    meta._synthesisCount = config.architectEvery;
-  }
-
-  // Same soft invalidation for _critic prompt mismatch.
-  const resolvedCritic = config.defaultCritic ?? DEFAULT_CRITIC_PROMPT;
-  const criticChanged =
-    meta._critic !== undefined && meta._critic !== resolvedCritic;
-  if (criticChanged) {
+  const architectChanged = isPromptStale(
+    meta._architect,
+    config.defaultArchitect ?? DEFAULT_ARCHITECT_PROMPT,
+  );
+  const criticChanged = isPromptStale(
+    meta._critic,
+    config.defaultCritic ?? DEFAULT_CRITIC_PROMPT,
+  );
+  if (architectChanged || criticChanged) {
     meta._synthesisCount = config.architectEvery;
   }
 

--- a/packages/service/src/phaseState/invalidate.ts
+++ b/packages/service/src/phaseState/invalidate.ts
@@ -53,6 +53,8 @@ export interface InvalidationResult {
   stalenessInputs: StalenessInputs;
   structureHash: string;
   steerChanged: boolean;
+  /** When non-null, callers that persist should set meta._synthesisCount to this value. */
+  synthesisCountOverride: number | null;
 }
 
 /**
@@ -92,8 +94,9 @@ export async function computeInvalidation(
   );
 
   // Soft invalidation: compare prompt snapshots against currently-resolved prompts.
-  // On mismatch, bump _synthesisCount to architectEvery so architect runs on the
-  // next natural cycle — but do NOT hard-cascade via invalidateArchitect.
+  // On mismatch, signal that _synthesisCount should be bumped to architectEvery so
+  // architect runs on the next natural cycle — but do NOT hard-cascade via
+  // invalidateArchitect and do NOT mutate the input meta.
   const architectChanged = isPromptStale(
     meta._architect,
     config.defaultArchitect ?? DEFAULT_ARCHITECT_PROMPT,
@@ -102,9 +105,10 @@ export async function computeInvalidation(
     meta._critic,
     config.defaultCritic ?? DEFAULT_CRITIC_PROMPT,
   );
-  if (architectChanged || criticChanged) {
-    meta._synthesisCount = config.architectEvery;
-  }
+  const synthesisCountOverride =
+    architectChanged || criticChanged ? config.architectEvery : null;
+  const effectiveSynthesisCount =
+    synthesisCountOverride ?? (meta._synthesisCount ?? 0);
 
   // _crossRefs declaration change
   const currentRefs = (meta._crossRefs ?? []).slice().sort().join(',');
@@ -127,7 +131,7 @@ export async function computeInvalidation(
   }
   if (steerChanged) architectInvalidators.push('steer');
   if (crossRefsDeclChanged) architectInvalidators.push('_crossRefs');
-  if ((meta._synthesisCount ?? 0) >= config.architectEvery) {
+  if (effectiveSynthesisCount >= config.architectEvery) {
     architectInvalidators.push('architectEvery');
   }
 
@@ -180,5 +184,6 @@ export async function computeInvalidation(
     },
     structureHash,
     steerChanged,
+    synthesisCountOverride,
   };
 }

--- a/packages/service/src/phaseState/phaseState.integration.test.ts
+++ b/packages/service/src/phaseState/phaseState.integration.test.ts
@@ -134,30 +134,12 @@ describe('migration verification (Task #14)', () => {
     const ps = derivePhaseState(meta, {
       structureChanged: false,
       steerChanged: true,
-      architectChanged: false,
       crossRefsChanged: false,
       architectEvery: 10,
     });
     expect(ps.architect).toBe('pending');
     expect(ps.builder).toBe('stale');
     expect(ps.critic).toBe('stale');
-  });
-
-  it('architect invalidation via architectChanged', () => {
-    const meta: MetaJson = {
-      _builder: 'brief',
-      _content: 'content',
-      _feedback: 'ok',
-      _generatedAt: new Date().toISOString(),
-    };
-    const ps = derivePhaseState(meta, {
-      structureChanged: false,
-      steerChanged: false,
-      architectChanged: true,
-      crossRefsChanged: false,
-      architectEvery: 10,
-    });
-    expect(ps.architect).toBe('pending');
   });
 
   it('architect invalidation via crossRefsChanged', () => {
@@ -170,7 +152,6 @@ describe('migration verification (Task #14)', () => {
     const ps = derivePhaseState(meta, {
       structureChanged: false,
       steerChanged: false,
-      architectChanged: false,
       crossRefsChanged: true,
       architectEvery: 10,
     });

--- a/packages/service/src/routes/config.ts
+++ b/packages/service/src/routes/config.ts
@@ -8,6 +8,7 @@
  */
 
 import { createConfigQueryHandler } from '@karmaniverous/jeeves';
+import { getEndpoint } from '@karmaniverous/jeeves-meta-core';
 import type { FastifyInstance } from 'fastify';
 
 import type { ServiceConfig } from '../schema/config.js';
@@ -29,7 +30,7 @@ export function registerConfigRoute(
     sanitizeConfig(deps.config),
   );
 
-  app.get('/config', async (request, reply) => {
+  app.get(getEndpoint('config').path, async (request, reply) => {
     const { path } = request.query as { path?: string };
     const result = await configHandler({ path });
     return reply.status(result.status).send(result.body);

--- a/packages/service/src/routes/configApply.ts
+++ b/packages/service/src/routes/configApply.ts
@@ -12,6 +12,7 @@
 import { readFileSync } from 'node:fs';
 
 import { atomicWrite } from '@karmaniverous/jeeves';
+import { getEndpoint } from '@karmaniverous/jeeves-meta-core';
 import type { FastifyInstance } from 'fastify';
 
 import {
@@ -25,7 +26,7 @@ export function registerConfigApplyRoute(
   app: FastifyInstance,
   configPath?: string,
 ): void {
-  app.post('/config/apply', async (request, reply) => {
+  app.post(getEndpoint('configApply').path, async (request, reply) => {
     if (!configPath) {
       return reply
         .status(500)

--- a/packages/service/src/routes/metas.ts
+++ b/packages/service/src/routes/metas.ts
@@ -24,29 +24,20 @@ import { derivePhaseState, getOwedPhase } from '../phaseState/index.js';
 import { computeStalenessScore } from '../scheduling/index.js';
 import { DEFAULT_EXCLUDE_FIELDS, type RouteDeps } from './index.js';
 
+/** Reusable Zod schema for boolean query string parameters ('true'/'false'). */
+const boolQueryParam = z.enum(['true', 'false']).transform((v) => v === 'true');
+
 const metasQuerySchema = z.object({
   pathPrefix: z.string().optional(),
-  hasError: z
-    .enum(['true', 'false'])
-    .transform((v) => v === 'true')
-    .optional(),
+  hasError: boolQueryParam.optional(),
   staleHours: z
     .string()
     .transform(Number)
     .pipe(z.number().positive())
     .optional(),
-  neverSynthesized: z
-    .enum(['true', 'false'])
-    .transform((v) => v === 'true')
-    .optional(),
-  locked: z
-    .enum(['true', 'false'])
-    .transform((v) => v === 'true')
-    .optional(),
-  disabled: z
-    .enum(['true', 'false'])
-    .transform((v) => v === 'true')
-    .optional(),
+  neverSynthesized: boolQueryParam.optional(),
+  locked: boolQueryParam.optional(),
+  disabled: boolQueryParam.optional(),
   fields: z.string().optional(),
 });
 
@@ -54,7 +45,7 @@ const metaDetailQuerySchema = z.object({
   fields: z.string().optional(),
   includeArchive: z
     .union([
-      z.enum(['true', 'false']).transform((v) => v === 'true'),
+      boolQueryParam,
       z.string().transform(Number).pipe(z.number().int().nonnegative()),
     ])
     .optional(),

--- a/packages/service/src/routes/metas.ts
+++ b/packages/service/src/routes/metas.ts
@@ -8,6 +8,7 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
+import { getEndpoint } from '@karmaniverous/jeeves-meta-core';
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 
@@ -63,7 +64,7 @@ export function registerMetasRoutes(
   app: FastifyInstance,
   deps: RouteDeps,
 ): void {
-  app.get('/metas', async (request) => {
+  app.get(getEndpoint('listMetas').path, async (request) => {
     const query = metasQuerySchema.parse(request.query);
     const { config, watcher } = deps;
 
@@ -147,7 +148,7 @@ export function registerMetasRoutes(
   });
 
   app.get<{ Params: { path: string } }>(
-    '/metas/:path',
+    getEndpoint('metaDetail').path,
     async (request, reply) => {
       const query = metaDetailQuerySchema.parse(request.query);
       const { config, watcher } = deps;

--- a/packages/service/src/routes/metasUpdate.ts
+++ b/packages/service/src/routes/metasUpdate.ts
@@ -65,16 +65,9 @@ export function registerMetasUpdateRoute(
 
       const metaJsonPath = join(metaDir, 'meta.json');
 
-      const KEYS = [
-        '_steer',
-        '_emphasis',
-        '_depth',
-        '_crossRefs',
-        '_disabled',
-        '_architectTimeout',
-        '_builderTimeout',
-        '_criticTimeout',
-      ] as const;
+      const KEYS = Object.keys(
+        updateBodySchema.shape,
+      ) as (keyof typeof updates)[];
       const toDelete = new Set<string>();
       const toSet: Record<string, unknown> = {};
       for (const key of KEYS) {

--- a/packages/service/src/routes/metasUpdate.ts
+++ b/packages/service/src/routes/metasUpdate.ts
@@ -10,6 +10,7 @@
 import { writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
+import { getEndpoint } from '@karmaniverous/jeeves-meta-core';
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 
@@ -35,7 +36,7 @@ export function registerMetasUpdateRoute(
   void deps; // Signature matches other route registrars; deps unused for direct-read route
 
   app.patch<{ Params: { path: string } }>(
-    '/metas/:path',
+    getEndpoint('updateMeta').path,
     async (request, reply) => {
       const parseResult = updateBodySchema.safeParse(request.body);
       if (!parseResult.success) {

--- a/packages/service/src/routes/metasUpdate.ts
+++ b/packages/service/src/routes/metasUpdate.ts
@@ -1,7 +1,7 @@
 /**
  * PATCH /metas/:path — update user-settable reserved properties on a meta.
  *
- * Supported fields: _steer, _emphasis, _depth, _crossRefs, _disabled.
+ * Supported fields: _steer, _emphasis, _depth, _crossRefs, _disabled, _architectTimeout, _builderTimeout, _criticTimeout.
  * Set a field to null to remove it. Unknown keys are rejected.
  *
  * @module routes/metasUpdate
@@ -26,6 +26,9 @@ const updateBodySchema = z
     _depth: z.union([z.number(), z.null()]).optional(),
     _crossRefs: z.union([z.array(z.string()), z.null()]).optional(),
     _disabled: z.union([z.boolean(), z.null()]).optional(),
+    _architectTimeout: z.union([z.number().int().min(30), z.null()]).optional(),
+    _builderTimeout: z.union([z.number().int().min(30), z.null()]).optional(),
+    _criticTimeout: z.union([z.number().int().min(30), z.null()]).optional(),
   })
   .strict();
 
@@ -68,6 +71,9 @@ export function registerMetasUpdateRoute(
         '_depth',
         '_crossRefs',
         '_disabled',
+        '_architectTimeout',
+        '_builderTimeout',
+        '_criticTimeout',
       ] as const;
       const toDelete = new Set<string>();
       const toSet: Record<string, unknown> = {};

--- a/packages/service/src/routes/preview.ts
+++ b/packages/service/src/routes/preview.ts
@@ -4,6 +4,7 @@
  * @module routes/preview
  */
 
+import { getEndpoint } from '@karmaniverous/jeeves-meta-core';
 import type { FastifyInstance } from 'fastify';
 
 import { findNode, getDeltaFiles, getScopeFiles } from '../discovery/index.js';
@@ -27,7 +28,7 @@ export function registerPreviewRoute(
   app: FastifyInstance,
   deps: RouteDeps,
 ): void {
-  app.get('/preview', async (request, reply) => {
+  app.get(getEndpoint('preview').path, async (request, reply) => {
     const { config, watcher, cache } = deps;
     const query = request.query as { path?: string };
 

--- a/packages/service/src/routes/preview.ts
+++ b/packages/service/src/routes/preview.ts
@@ -18,10 +18,7 @@ import {
   selectPhaseCandidate,
 } from '../phaseState/index.js';
 import { readMetaJson } from '../readMetaJson.js';
-import {
-  computeStalenessScore,
-  isArchitectTriggered,
-} from '../scheduling/index.js';
+import { computeStalenessScore } from '../scheduling/index.js';
 import type { RouteDeps } from './index.js';
 
 export function registerPreviewRoute(
@@ -83,12 +80,15 @@ export function registerPreviewRoute(
     const { steerChanged } = invalidation;
     const { crossRefsDeclChanged } = stalenessInputs;
 
-    const architectTriggered = isArchitectTriggered(
-      meta,
-      structureChanged,
-      steerChanged,
-      config.architectEvery,
-    );
+    // Use invalidation result for architectEvery check since computeInvalidation
+    // accounts for prompt staleness without mutating meta._synthesisCount.
+    const effectiveSynthesisCount =
+      invalidation.synthesisCountOverride ?? (meta._synthesisCount ?? 0);
+    const architectTriggered =
+      !meta._builder ||
+      structureChanged ||
+      steerChanged ||
+      effectiveSynthesisCount >= config.architectEvery;
 
     // Delta files
     const deltaFiles = getDeltaFiles(meta._generatedAt, scopeFiles);
@@ -133,7 +133,7 @@ export function registerPreviewRoute(
           ...(!meta._builder ? ['no cached builder (first run)'] : []),
           ...(structureChanged ? ['structure changed'] : []),
           ...(steerChanged ? ['steer changed'] : []),
-          ...((meta._synthesisCount ?? 0) >= config.architectEvery
+          ...(effectiveSynthesisCount >= config.architectEvery
             ? ['periodic refresh']
             : []),
         ].join(', ') || 'not triggered',

--- a/packages/service/src/routes/preview.ts
+++ b/packages/service/src/routes/preview.ts
@@ -81,7 +81,7 @@ export function registerPreviewRoute(
     const { structureHash } = invalidation;
     const structureChanged = structureHash !== meta._structureHash;
     const { steerChanged } = invalidation;
-    const { architectChanged, crossRefsDeclChanged } = stalenessInputs;
+    const { crossRefsDeclChanged } = stalenessInputs;
 
     const architectTriggered = isArchitectTriggered(
       meta,
@@ -115,7 +115,6 @@ export function registerPreviewRoute(
     const phaseState = derivePhaseState(meta, {
       structureChanged,
       steerChanged,
-      architectChanged,
       crossRefsChanged: crossRefsDeclChanged,
       architectEvery: config.architectEvery,
     });

--- a/packages/service/src/routes/queue.ts
+++ b/packages/service/src/routes/queue.ts
@@ -11,6 +11,7 @@
 import { copyFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
+import { getEndpoint } from '@karmaniverous/jeeves-meta-core';
 import type { FastifyInstance } from 'fastify';
 
 import { releaseLock, resolveMetaDir } from '../lock.js';
@@ -31,7 +32,7 @@ export function registerQueueRoutes(
 ): void {
   const { queue } = deps;
 
-  app.get('/queue', async () => {
+  app.get(getEndpoint('queue').path, async () => {
     const currentPhase = queue.currentPhase;
     const overrides = queue.overrides;
 
@@ -120,12 +121,12 @@ export function registerQueueRoutes(
     };
   });
 
-  app.post('/queue/clear', () => {
+  app.post(getEndpoint('queueClear').path, () => {
     const removed = queue.clearOverrides();
     return { cleared: removed };
   });
 
-  app.post('/synthesize/abort', async (_request, reply) => {
+  app.post(getEndpoint('abort').path, async (_request, reply) => {
     // Check 3-layer current first
     const currentPhase = queue.currentPhase;
     const current = currentPhase ?? queue.current;

--- a/packages/service/src/routes/seed.ts
+++ b/packages/service/src/routes/seed.ts
@@ -4,6 +4,7 @@
  * @module routes/seed
  */
 
+import { getEndpoint } from '@karmaniverous/jeeves-meta-core';
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 
@@ -17,7 +18,7 @@ const seedBodySchema = z.object({
 });
 
 export function registerSeedRoute(app: FastifyInstance, deps: RouteDeps): void {
-  app.post('/seed', async (request, reply) => {
+  app.post(getEndpoint('seed').path, async (request, reply) => {
     const body = seedBodySchema.parse(request.body);
 
     if (metaExists(body.path)) {

--- a/packages/service/src/routes/status.ts
+++ b/packages/service/src/routes/status.ts
@@ -161,7 +161,7 @@ export function registerStatusRoute(
         dependencies: {
           watcher: {
             ...watcherHealth,
-            rulesRegistered: deps.registrar?.isRegistered ?? false,
+            rulesRegistered: true,
           },
           gateway: gatewayHealth,
         },

--- a/packages/service/src/routes/status.ts
+++ b/packages/service/src/routes/status.ts
@@ -8,11 +8,12 @@
  */
 
 import { createStatusHandler } from '@karmaniverous/jeeves';
-import type {
-  DepHealth,
-  PhaseName,
-  PhaseStatus,
-  ServiceState,
+import {
+  type DepHealth,
+  getEndpoint,
+  type PhaseName,
+  type PhaseStatus,
+  type ServiceState,
 } from '@karmaniverous/jeeves-meta-core';
 import type { FastifyInstance } from 'fastify';
 
@@ -170,7 +171,7 @@ export function registerStatusRoute(
     },
   });
 
-  app.get('/status', async (_request, reply) => {
+  app.get(getEndpoint('status').path, async (_request, reply) => {
     const result = await statusHandler();
     return reply.status(result.status).send(result.body);
   });

--- a/packages/service/src/routes/synthesize.test.ts
+++ b/packages/service/src/routes/synthesize.test.ts
@@ -233,6 +233,54 @@ describe('POST /synthesize', () => {
     expect(queue.overrides).toHaveLength(1);
   });
 
+  it('recomputes invalidation instead of trusting cached _phaseState (#160)', async () => {
+    // Create a meta that looks fully fresh in _phaseState but has a stale
+    // structure hash (simulating new files added to scope).
+    const owner = join(synthRoot, 'stale-hash');
+    createTestMeta(owner, {
+      _id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+      _content: '# Old synthesis',
+      _builder: 'Old brief',
+      _feedback: 'Old feedback',
+      _generatedAt: new Date(Date.now() - 3600_000).toISOString(),
+      _structureHash: 'outdated-hash-value',
+      _phaseState: {
+        architect: 'fresh',
+        builder: 'fresh',
+        critic: 'fresh',
+      },
+    });
+
+    // The watcher returns a file list that will produce a DIFFERENT structure
+    // hash than the one stored in meta.json.
+    const metaDir = join(owner, '.meta');
+    const watcher = makeTestWatcher([
+      join(metaDir, 'meta.json').replace(/\\/g, '/'),
+      join(owner, 'new-file.md').replace(/\\/g, '/'),
+    ]);
+    const logger = makeTestLogger();
+    const queue = new SynthesisQueue(logger);
+
+    const deps = makeTestDeps({ queue, watcher });
+    app = Fastify();
+    registerSynthesizeRoute(app, deps);
+    await app.ready();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/synthesize',
+      payload: { path: owner },
+    });
+
+    // Should be queued (not skipped) because computeInvalidation detects
+    // the structure hash mismatch and invalidates the architect.
+    expect(res.statusCode).toBe(202);
+    const body = res.json<{ status: string; owedPhase: string | null }>();
+    expect(body.status).toBe('queued');
+    expect(body.owedPhase).toBe('architect');
+    expect(queue.overrides).toHaveLength(1);
+  });
+
   it('returns 503 when watcher unreachable and no path provided', async () => {
     const logger = makeTestLogger();
     const queue = new SynthesisQueue(logger);

--- a/packages/service/src/routes/synthesize.ts
+++ b/packages/service/src/routes/synthesize.ts
@@ -11,10 +11,14 @@ import { getEndpoint } from '@karmaniverous/jeeves-meta-core';
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 
+import { buildMinimalNode } from '../discovery/buildMinimalNode.js';
+import { getScopeFiles } from '../discovery/index.js';
 import { resolveMetaDir } from '../lock.js';
+import { normalizePath } from '../normalizePath.js';
+import { persistPhaseState } from '../orchestrator/runPhase.js';
 import {
   buildPhaseCandidates,
-  derivePhaseState,
+  computeInvalidation,
   getOwedPhase,
   selectPhaseCandidate,
 } from '../phaseState/index.js';
@@ -38,18 +42,47 @@ export function registerSynthesizeRoute(
       // Path-targeted trigger: create override entry
       const targetPath = resolveMetaDir(body.path);
 
-      // Read meta to determine owed phase
+      // Read meta and recompute invalidation against current inputs
+      // (structure hash, steer, cross-refs, prompt snapshots) rather than
+      // trusting the cached _phaseState. Fixes #160.
       let owedPhase: string | null = null;
       let meta;
       try {
         meta = await readMetaJson(targetPath);
-        const phaseState = derivePhaseState(meta);
-        owedPhase = getOwedPhase(phaseState);
+        const node = await buildMinimalNode(normalizePath(targetPath), watcher);
+        const { scopeFiles } = await getScopeFiles(node, watcher);
+        const invalidation = await computeInvalidation(
+          meta,
+          scopeFiles,
+          config,
+          node,
+        );
+
+        // Persist updated phase state if invalidation changed it
+        if (
+          JSON.stringify(invalidation.phaseState) !==
+          JSON.stringify(meta._phaseState)
+        ) {
+          await persistPhaseState(
+            {
+              metaPath: targetPath,
+              current: meta,
+              config,
+              structureHash: invalidation.structureHash,
+            },
+            invalidation.phaseState,
+            {},
+          );
+          cache.invalidate();
+        }
+
+        owedPhase = getOwedPhase(invalidation.phaseState);
       } catch {
-        // Meta unreadable — proceed, phase will be evaluated at dequeue time
+        // Meta unreadable or watcher unavailable — proceed,
+        // phase will be evaluated at dequeue time
       }
 
-      // Fully fresh meta → skip (reuse meta already read above)
+      // Fully fresh meta → skip
       if (owedPhase === null && meta && (meta._phaseState || meta._content)) {
         return await reply.code(200).send({
           status: 'skipped',

--- a/packages/service/src/routes/synthesize.ts
+++ b/packages/service/src/routes/synthesize.ts
@@ -7,6 +7,7 @@
  * @module routes/synthesize
  */
 
+import { getEndpoint } from '@karmaniverous/jeeves-meta-core';
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 
@@ -29,7 +30,7 @@ export function registerSynthesizeRoute(
   app: FastifyInstance,
   deps: RouteDeps,
 ): void {
-  app.post('/synthesize', async (request, reply) => {
+  app.post(getEndpoint('synthesize').path, async (request, reply) => {
     const body = synthesizeBodySchema.parse(request.body);
     const { config, watcher, queue, cache } = deps;
 

--- a/packages/service/src/routes/synthesize.ts
+++ b/packages/service/src/routes/synthesize.ts
@@ -72,7 +72,9 @@ export function registerSynthesizeRoute(
               structureHash: invalidation.structureHash,
             },
             invalidation.phaseState,
-            {},
+            invalidation.synthesisCountOverride !== null
+              ? { _synthesisCount: invalidation.synthesisCountOverride }
+              : {},
           );
           cache.invalidate();
         }

--- a/packages/service/src/routes/synthesize.ts
+++ b/packages/service/src/routes/synthesize.ts
@@ -58,11 +58,12 @@ export function registerSynthesizeRoute(
           node,
         );
 
-        // Persist updated phase state if invalidation changed it
-        if (
-          JSON.stringify(invalidation.phaseState) !==
-          JSON.stringify(meta._phaseState)
-        ) {
+        owedPhase = getOwedPhase(invalidation.phaseState);
+
+        // Persist recomputed phase state + structure hash when stale.
+        // Matches the scheduler's Tier 2 pattern: always persist so the
+        // stored _phaseState reflects reality for subsequent reads.
+        if (owedPhase) {
           await persistPhaseState(
             {
               metaPath: targetPath,
@@ -75,8 +76,6 @@ export function registerSynthesizeRoute(
           );
           cache.invalidate();
         }
-
-        owedPhase = getOwedPhase(invalidation.phaseState);
       } catch {
         // Meta unreadable or watcher unavailable — proceed,
         // phase will be evaluated at dequeue time

--- a/packages/service/src/routes/unlock.ts
+++ b/packages/service/src/routes/unlock.ts
@@ -7,6 +7,7 @@
 import { existsSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { getEndpoint } from '@karmaniverous/jeeves-meta-core';
 import type { FastifyInstance } from 'fastify';
 import { z } from 'zod';
 
@@ -21,7 +22,7 @@ export function registerUnlockRoute(
   app: FastifyInstance,
   deps: RouteDeps,
 ): void {
-  app.post('/unlock', (request, reply) => {
+  app.post(getEndpoint('unlock').path, (request, reply) => {
     const body = unlockBodySchema.parse(request.body);
     const metaDir = resolveMetaDir(body.path);
     const lockPath = join(metaDir, '.lock');

--- a/packages/service/src/rules/healthCheck.test.ts
+++ b/packages/service/src/rules/healthCheck.test.ts
@@ -109,7 +109,6 @@ describe('WatcherHealthCheck', () => {
     // Initial registration
     mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
     await registrar.register();
-    expect(registrar.isRegistered).toBe(true);
     mockFetch.mockReset();
 
     const hc = new WatcherHealthCheck({
@@ -159,8 +158,10 @@ describe('WatcherHealthCheck', () => {
     hc.start();
     await vi.advanceTimersByTimeAsync(10_000);
 
-    // Should not throw, registrar state unchanged
-    expect(registrar.isRegistered).toBe(true);
+    // Should not throw; registerRules not called again on network error
+    expect(
+      (watcher.registerRules as Mock).mock.calls.length,
+    ).toBeLessThanOrEqual(1);
     hc.stop();
   });
 });

--- a/packages/service/src/rules/healthCheck.ts
+++ b/packages/service/src/rules/healthCheck.ts
@@ -89,10 +89,6 @@ export class WatcherHealthCheck {
 
       const data = (await res.json()) as WatcherStatusResponse;
 
-      // Unconditionally re-register on every health check cycle.
-      // register() is idempotent and guards against concurrent calls.
-      await this.registrar.register();
-
       await this.registrar.checkAndReregister(data.uptime);
     } catch (err) {
       this.logger.debug(

--- a/packages/service/src/rules/healthCheck.ts
+++ b/packages/service/src/rules/healthCheck.ts
@@ -89,12 +89,9 @@ export class WatcherHealthCheck {
 
       const data = (await res.json()) as WatcherStatusResponse;
 
-      // If rules were never successfully registered (startup failure),
-      // attempt registration now that the watcher is reachable.
-      if (!this.registrar.isRegistered) {
-        this.logger.info('Rules not registered — attempting registration');
-        await this.registrar.register();
-      }
+      // Unconditionally re-register on every health check cycle.
+      // register() is idempotent and guards against concurrent calls.
+      await this.registrar.register();
 
       await this.registrar.checkAndReregister(data.uptime);
     } catch (err) {

--- a/packages/service/src/rules/index.ts
+++ b/packages/service/src/rules/index.ts
@@ -155,7 +155,7 @@ export class RuleRegistrar {
   private readonly logger: Logger;
   private readonly watcherClient: WatcherClient;
   private lastWatcherUptime: number | null = null;
-  private registered = false;
+  private registering = false;
 
   public constructor(
     config: MetaConfig,
@@ -167,37 +167,38 @@ export class RuleRegistrar {
     this.watcherClient = watcher;
   }
 
-  /** Whether rules have been successfully registered. */
-  public get isRegistered(): boolean {
-    return this.registered;
-  }
-
   /**
    * Register rules with watcher. Retries with exponential backoff.
    * Non-blocking — logs errors but never throws.
    */
   public async register(): Promise<void> {
-    const rules = buildMetaRules(this.config);
+    if (this.registering) return;
+    this.registering = true;
 
-    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-      try {
-        await this.watcherClient.registerRules(SOURCE, rules);
-        this.registered = true;
-        this.logger.info('Virtual rules registered with watcher');
-        return;
-      } catch (err) {
-        const delayMs = RETRY_BASE_MS * Math.pow(2, attempt);
-        this.logger.warn(
-          { attempt: attempt + 1, delayMs, err },
-          'Rule registration failed, retrying',
-        );
-        await new Promise((r) => setTimeout(r, delayMs));
+    try {
+      const rules = buildMetaRules(this.config);
+
+      for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+        try {
+          await this.watcherClient.registerRules(SOURCE, rules);
+          this.logger.info('Virtual rules registered with watcher');
+          return;
+        } catch (err) {
+          const delayMs = RETRY_BASE_MS * Math.pow(2, attempt);
+          this.logger.warn(
+            { attempt: attempt + 1, delayMs, err },
+            'Rule registration failed, retrying',
+          );
+          await new Promise((r) => setTimeout(r, delayMs));
+        }
       }
-    }
 
-    this.logger.error(
-      'Rule registration failed after max retries — service degraded',
-    );
+      this.logger.error(
+        'Rule registration failed after max retries — service degraded',
+      );
+    } finally {
+      this.registering = false;
+    }
   }
 
   /**
@@ -214,7 +215,6 @@ export class RuleRegistrar {
         { previous: this.lastWatcherUptime, current: currentUptime },
         'Watcher restart detected — re-registering rules',
       );
-      this.registered = false;
       await this.register();
     }
     this.lastWatcherUptime = currentUptime;

--- a/packages/service/src/scheduler/index.ts
+++ b/packages/service/src/scheduler/index.ts
@@ -292,7 +292,9 @@ export class Scheduler {
               structureHash: result.structureHash,
             },
             result.phaseState,
-            {},
+            result.synthesisCountOverride !== null
+              ? { _synthesisCount: result.synthesisCountOverride }
+              : {},
           );
           this.cache.invalidate();
 
@@ -312,7 +314,12 @@ export class Scheduler {
             structureHash: result.structureHash,
           },
           result.phaseState,
-          { _generatedAt: new Date().toISOString() },
+          {
+            _generatedAt: new Date().toISOString(),
+            ...(result.synthesisCountOverride !== null
+              ? { _synthesisCount: result.synthesisCountOverride }
+              : {}),
+          },
         );
         dirty = true;
       } finally {

--- a/packages/service/src/schema/config.ts
+++ b/packages/service/src/schema/config.ts
@@ -31,6 +31,8 @@ const autoSeedRuleSchema = z.object({
   steer: z.string().optional(),
   /** Optional cross-references for seeded metas. */
   crossRefs: z.array(z.string()).optional(),
+  /** Walk up this many extra parent levels from the matched file's directory. Default 0. */
+  parentDepth: z.number().int().min(0).optional(),
 });
 
 /** Inferred type for an auto-seed rule. */

--- a/packages/service/src/schema/config.ts
+++ b/packages/service/src/schema/config.ts
@@ -33,6 +33,12 @@ const autoSeedRuleSchema = z.object({
   crossRefs: z.array(z.string()).optional(),
   /** Walk up this many extra parent levels from the matched file's directory. Default 0. */
   parentDepth: z.number().int().min(0).optional(),
+  /** Per-category timeout override for the architect phase (seconds, min 30). */
+  architectTimeout: z.number().int().min(30).optional(),
+  /** Per-category timeout override for the builder phase (seconds, min 30). */
+  builderTimeout: z.number().int().min(30).optional(),
+  /** Per-category timeout override for the critic phase (seconds, min 30). */
+  criticTimeout: z.number().int().min(30).optional(),
 });
 
 /** Inferred type for an auto-seed rule. */

--- a/packages/service/src/schema/meta.ts
+++ b/packages/service/src/schema/meta.ts
@@ -133,6 +133,15 @@ export const metaJsonSchema = z
     /** When true, this meta is skipped during staleness scheduling. Manual trigger still works. */
     _disabled: z.boolean().optional(),
 
+    /** Per-entity timeout override for the architect phase (seconds, min 30). */
+    _architectTimeout: z.number().int().min(30).optional(),
+
+    /** Per-entity timeout override for the builder phase (seconds, min 30). */
+    _builderTimeout: z.number().int().min(30).optional(),
+
+    /** Per-entity timeout override for the critic phase (seconds, min 30). */
+    _criticTimeout: z.number().int().min(30).optional(),
+
     /**
      * Per-phase state machine record. Engine-managed.
      * Keyed by phase name (architect, builder, critic) with status values.

--- a/packages/service/src/schema/meta.ts
+++ b/packages/service/src/schema/meta.ts
@@ -143,6 +143,12 @@ export const metaJsonSchema = z
     _criticTimeout: z.number().int().min(30).optional(),
 
     /**
+     * SHA-256 hash of ancestor _builder text at last synthesis.
+     * Observability only — no invalidation cascade.
+     */
+    _ancestorBuilderHash: z.string().optional(),
+
+    /**
      * Per-phase state machine record. Engine-managed.
      * Keyed by phase name (architect, builder, critic) with status values.
      * Persisted to survive ticks; derived on first load for back-compat.

--- a/packages/service/src/seed/autoSeed.test.ts
+++ b/packages/service/src/seed/autoSeed.test.ts
@@ -127,6 +127,48 @@ describe('autoSeedPass', () => {
     expect(meta._crossRefs).toEqual(['j:/ref2']);
   });
 
+  it('walks up parentDepth levels from matched file directory', async () => {
+    // Structure: testRoot/a/b/c/file.md → with parentDepth=1 should seed testRoot/a/b (not c)
+    const dirABC = join(testRoot, 'a', 'b', 'c');
+    const dirAB = join(testRoot, 'a', 'b');
+    mkdirSync(dirABC, { recursive: true });
+
+    const rootFwd = testRoot.replace(/\\/g, '/');
+    const watcher = createMockWatcher({
+      [`${testRoot}/**/*.md`]: [`${rootFwd}/a/b/c/file.md`],
+    });
+
+    const rules: AutoSeedRule[] = [
+      { match: `${testRoot}/**/*.md`, parentDepth: 1 },
+    ];
+    const result = await autoSeedPass(rules, watcher);
+
+    expect(result.seeded).toBe(1);
+    expect(result.paths).toEqual([`${rootFwd}/a/b`]);
+    expect(existsSync(join(dirAB, '.meta', 'meta.json'))).toBe(true);
+    // Should NOT have seeded the immediate parent (c)
+    expect(existsSync(join(dirABC, '.meta', 'meta.json'))).toBe(false);
+  });
+
+  it('clamps parentDepth at filesystem root', async () => {
+    // Even with a huge parentDepth, should not error
+    const dirA = join(testRoot, 'a');
+    mkdirSync(dirA, { recursive: true });
+
+    const rootFwd = testRoot.replace(/\\/g, '/');
+    const watcher = createMockWatcher({
+      [`${testRoot}/**/*.md`]: [`${rootFwd}/a/file.md`],
+    });
+
+    const rules: AutoSeedRule[] = [
+      { match: `${testRoot}/**/*.md`, parentDepth: 999 },
+    ];
+    const result = await autoSeedPass(rules, watcher);
+
+    // Should produce 0 seeds because walking up 999 levels reaches '/' which is filtered out
+    expect(result.seeded).toBe(0);
+  });
+
   it('returns empty result when autoSeed is empty', async () => {
     const walkSpy = vi.fn().mockResolvedValue([]);
     const watcher: WatcherClient = {

--- a/packages/service/src/seed/autoSeed.ts
+++ b/packages/service/src/seed/autoSeed.ts
@@ -16,7 +16,11 @@ import type { WatcherClient } from '../interfaces/index.js';
 import type { MinimalLogger } from '../logger/index.js';
 import { normalizePath } from '../normalizePath.js';
 import type { AutoSeedRule } from '../schema/config.js';
-import { createMeta, metaExists } from './createMeta.js';
+import {
+  createMeta,
+  type CreateMetaOptions,
+  metaExists,
+} from './createMeta.js';
 
 /** Result of a single auto-seed pass. */
 export interface AutoSeedResult {
@@ -81,16 +85,7 @@ export async function autoSeedPass(
   if (rules.length === 0) return { seeded: 0, paths: [] };
 
   // Build a map of ownerPath → effective options (last match wins)
-  const candidates = new Map<
-    string,
-    {
-      steer?: string;
-      crossRefs?: string[];
-      architectTimeout?: number;
-      builderTimeout?: number;
-      criticTimeout?: number;
-    }
-  >();
+  const candidates = new Map<string, CreateMetaOptions>();
 
   for (const rule of rules) {
     const files = await watcher.walk([rule.match]);
@@ -107,14 +102,7 @@ export async function autoSeedPass(
   }
 
   // Filter out paths that already have .meta/meta.json
-  const toSeed: Array<{
-    path: string;
-    steer?: string;
-    crossRefs?: string[];
-    architectTimeout?: number;
-    builderTimeout?: number;
-    criticTimeout?: number;
-  }> = [];
+  const toSeed: Array<{ path: string } & CreateMetaOptions> = [];
   for (const [path, opts] of candidates) {
     if (!metaExists(path)) {
       toSeed.push({ path, ...opts });
@@ -125,13 +113,7 @@ export async function autoSeedPass(
   const seededPaths: string[] = [];
   for (const candidate of toSeed) {
     try {
-      await createMeta(candidate.path, {
-        steer: candidate.steer,
-        crossRefs: candidate.crossRefs,
-        architectTimeout: candidate.architectTimeout,
-        builderTimeout: candidate.builderTimeout,
-        criticTimeout: candidate.criticTimeout,
-      });
+      await createMeta(candidate.path, candidate);
       seededPaths.push(candidate.path);
       logger?.info({ path: candidate.path }, 'auto-seeded meta');
     } catch (err) {

--- a/packages/service/src/seed/autoSeed.ts
+++ b/packages/service/src/seed/autoSeed.ts
@@ -83,7 +83,13 @@ export async function autoSeedPass(
   // Build a map of ownerPath → effective options (last match wins)
   const candidates = new Map<
     string,
-    { steer?: string; crossRefs?: string[] }
+    {
+      steer?: string;
+      crossRefs?: string[];
+      architectTimeout?: number;
+      builderTimeout?: number;
+      criticTimeout?: number;
+    }
   >();
 
   for (const rule of rules) {
@@ -93,6 +99,9 @@ export async function autoSeedPass(
       candidates.set(dir, {
         steer: rule.steer,
         crossRefs: rule.crossRefs,
+        architectTimeout: rule.architectTimeout,
+        builderTimeout: rule.builderTimeout,
+        criticTimeout: rule.criticTimeout,
       });
     }
   }
@@ -102,6 +111,9 @@ export async function autoSeedPass(
     path: string;
     steer?: string;
     crossRefs?: string[];
+    architectTimeout?: number;
+    builderTimeout?: number;
+    criticTimeout?: number;
   }> = [];
   for (const [path, opts] of candidates) {
     if (!metaExists(path)) {
@@ -116,6 +128,9 @@ export async function autoSeedPass(
       await createMeta(candidate.path, {
         steer: candidate.steer,
         crossRefs: candidate.crossRefs,
+        architectTimeout: candidate.architectTimeout,
+        builderTimeout: candidate.builderTimeout,
+        criticTimeout: candidate.criticTimeout,
       });
       seededPaths.push(candidate.path);
       logger?.info({ path: candidate.path }, 'auto-seeded meta');

--- a/packages/service/src/seed/autoSeed.ts
+++ b/packages/service/src/seed/autoSeed.ts
@@ -29,18 +29,29 @@ export interface AutoSeedResult {
 /**
  * Extract parent directory paths from watcher walk results.
  *
- * Walk returns file paths; we need the unique set of immediate parent
- * directories that could be owners.
+ * Walk returns file paths; we need the unique set of parent directories that
+ * could be owners. When {@link parentDepth} is specified, walk up that many
+ * additional levels from each file's immediate parent. The walk is clamped at
+ * the filesystem root to prevent escaping the watched scope.
  */
 function extractDirectories(
   filePaths: string[],
+  parentDepth = 0,
   logger?: MinimalLogger,
 ): string[] {
   const dirs = new Set<string>();
   for (const fp of filePaths) {
     // Normalize backslash paths (Windows) to forward slashes before posix.dirname
     const normalized = normalizePath(fp);
-    const dir = path.dirname(normalized);
+    let dir = path.dirname(normalized);
+
+    // Walk up parentDepth additional levels, clamping at filesystem root
+    for (let i = 0; i < parentDepth; i++) {
+      const parent = path.dirname(dir);
+      if (parent === dir) break; // reached root
+      dir = parent;
+    }
+
     if (dir !== '.' && dir !== '/') {
       dirs.add(dir);
     }
@@ -77,7 +88,7 @@ export async function autoSeedPass(
 
   for (const rule of rules) {
     const files = await watcher.walk([rule.match]);
-    const dirs = extractDirectories(files, logger);
+    const dirs = extractDirectories(files, rule.parentDepth, logger);
     for (const dir of dirs) {
       candidates.set(dir, {
         steer: rule.steer,

--- a/packages/service/src/seed/createMeta.ts
+++ b/packages/service/src/seed/createMeta.ts
@@ -19,6 +19,12 @@ export interface CreateMetaOptions {
   crossRefs?: string[];
   /** Steering prompt for the meta. */
   steer?: string;
+  /** Per-entity timeout override for the architect phase (seconds). */
+  architectTimeout?: number;
+  /** Per-entity timeout override for the builder phase (seconds). */
+  builderTimeout?: number;
+  /** Per-entity timeout override for the critic phase (seconds). */
+  criticTimeout?: number;
 }
 
 /** Result of creating a new meta. */
@@ -49,6 +55,12 @@ export async function createMeta(
   const metaJson: Record<string, unknown> = { _id };
   if (options?.crossRefs !== undefined) metaJson._crossRefs = options.crossRefs;
   if (options?.steer !== undefined) metaJson._steer = options.steer;
+  if (options?.architectTimeout !== undefined)
+    metaJson._architectTimeout = options.architectTimeout;
+  if (options?.builderTimeout !== undefined)
+    metaJson._builderTimeout = options.builderTimeout;
+  if (options?.criticTimeout !== undefined)
+    metaJson._criticTimeout = options.criticTimeout;
 
   const metaJsonPath = join(metaDir, 'meta.json');
   await writeFile(metaJsonPath, JSON.stringify(metaJson, null, 2) + '\n');


### PR DESCRIPTION
## Summary

Release candidate for jeeves-meta v0.16.0. Covers 10 issues across service, plugin, and core packages.

## Changes

### Features
- **Shared endpoint catalog** — centralized route definitions in \@karmaniverous/jeeves-meta-core\ (#150)
- **File logging support** — configurable file-based log output (#153)
- **autoSeed parentDepth** — walk up N parent dirs from matched files when auto-seeding (#152)
- **Per-entity timeout overrides** — \_architectTimeout\, \_builderTimeout\, \_criticTimeout\ on meta.json (#122)
- **Ancestor meta context injection** — synthesis prompts include nearest ancestor meta content (#158)
- **ANNOUNCE_SKIP sentinel** — synthesis workers can emit sentinel to suppress announce (#148)

### Fixes
- **Recompute invalidation on targeted trigger** — \POST /synthesize\ with a path now runs full \computeInvalidation()\ instead of trusting cached \_phaseState\ (#160)
- **Prompt resolution and soft invalidation** — detect prompt snapshot drift and bump \_synthesisCount\ (#159)
- **Watcher 503 transient backoff** — plugin treats watcher 503 as transient with exponential backoff (#102)
- **Periodic virtual rule re-registration** — health check detects watcher restart and re-registers inference rules (#117)

### Refactors
- SOLID/DRY pass — extracted helpers, fixed endpoint semantics, derived schema keys
- Simplified trigger persist to match scheduler Tier 2 pattern (#160)

### Tests
- Dedicated \computeInvalidation\ coverage — 19 tests for all branches (#160)
- ANNOUNCE_SKIP sentinel stripping coverage (#148)

## Closes

Closes #102, #117, #122, #148, #150, #152, #153, #158, #159, #160