### PR TITLE
fix: lint errors and full docs sync with implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Metas can declare explicit cross-references (`_crossRefs`) to other metas, formi
 
 | Package | Description |
 |---------|-------------|
+| [`@karmaniverous/jeeves-meta-core`](packages/core/README.md) | Shared types, schemas, endpoint descriptors, and utilities |
 | [`@karmaniverous/jeeves-meta`](packages/service/README.md) | HTTP service — Fastify API, built-in scheduler, synthesis queue, CLI |
 | [`@karmaniverous/jeeves-meta-openclaw`](packages/openclaw/README.md) | OpenClaw plugin — thin HTTP client, interactive tools, TOOLS.md injection |
 
@@ -78,7 +79,7 @@ Install the plugin package. Twelve tools become available to the agent:
 - `meta_seed` — create `.meta/` directory for a new path (with optional cross-refs and steer)
 - `meta_unlock` — remove stale `.lock` from a meta entity
 - `meta_queue` — queue management: list pending, clear queue, abort current synthesis
-- `meta_update` — update user-settable reserved properties (`_steer`, `_emphasis`, `_depth`, `_crossRefs`, `_disabled`)
+- `meta_update` — update user-settable reserved properties (`_steer`, `_emphasis`, `_depth`, `_crossRefs`, `_disabled`, `_architectTimeout`, `_builderTimeout`, `_criticTimeout`)
 
 ## Configuration
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,59 @@
+# @karmaniverous/jeeves-meta-core
+
+Shared types, schemas, endpoint descriptors, and utilities for the jeeves-meta monorepo. This package is the single source of truth for API contracts consumed by both the [service](../service/) and the [OpenClaw plugin](../openclaw/).
+
+## Install
+
+```bash
+npm install @karmaniverous/jeeves-meta-core
+```
+
+## Exports
+
+### Constants
+
+- **`META_COMPONENT`** — component descriptor (name, default port, packages, dependencies)
+
+### Endpoint Catalog
+
+- **`META_ENDPOINTS`** — 13 endpoint descriptors (name, method, path, description)
+- **`getEndpoint(name)`** — look up an endpoint by name
+- Types: `HttpMethod`, `EndpointDescriptor`, `EndpointName`, `Endpoint<N>`
+
+### Configuration Schema
+
+- **`metaConfigSchema`** — Zod schema for core config fields (watcherUrl, gatewayUrl, timeouts, etc.)
+- Type: `MetaConfig`
+
+### Phase Vocabulary
+
+- **`phaseNames`** — `['architect', 'builder', 'critic']`
+- **`phaseStatuses`** — `['fresh', 'stale', 'pending', 'running', 'failed']`
+- **`phaseStateSchema`** / **`phaseStatusSchema`** — Zod schemas
+- Types: `PhaseName`, `PhaseStatus`, `PhaseState`
+
+### Error Schema
+
+- **`metaErrorSchema`** — Zod schema for `{ step, code, message }`
+- Type: `MetaError`
+
+### HTTP Response Contracts
+
+- `MetaListSummary` — summary stats from `GET /metas`
+- `MetasItem` — per-meta projected item
+- `MetasResponse` — `{ summary, metas }` envelope
+- `DepHealth`, `WatcherDepHealth`, `GatewayDepHealth` — dependency health
+- `ServiceState` — `'idle' | 'synthesizing' | 'waiting' | 'stopping'`
+
+### Utilities
+
+- **`normalizePath(p)`** — converts backslashes to forward slashes
+
+## Requirements
+
+- Node.js >= 22
+- ESM only
+
+## License
+
+BSD-3-Clause

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  */
 
 export { META_COMPONENT } from './constants.js';
-export {
+export type {
   DepHealth,
   GatewayDepHealth,
   MetaListSummary,
@@ -14,23 +14,22 @@ export {
   ServiceState,
   WatcherDepHealth,
 } from './contracts.js';
-export {
+export type {
   Endpoint,
   EndpointDescriptor,
   EndpointName,
-  getEndpoint,
   HttpMethod,
-  META_ENDPOINTS,
 } from './endpoints.js';
-export { MetaError, metaErrorSchema } from './errors.js';
-export { MetaConfig, metaConfigSchema } from './metaConfig.js';
+export { getEndpoint, META_ENDPOINTS } from './endpoints.js';
+export type { MetaError } from './errors.js';
+export { metaErrorSchema } from './errors.js';
+export type { MetaConfig } from './metaConfig.js';
+export { metaConfigSchema } from './metaConfig.js';
 export { normalizePath } from './normalizePath.js';
+export type { PhaseName, PhaseState, PhaseStatus } from './phases.js';
 export {
-  PhaseName,
   phaseNames,
-  PhaseState,
   phaseStateSchema,
-  PhaseStatus,
   phaseStatuses,
   phaseStatusSchema,
 } from './phases.js';

--- a/packages/openclaw/guides/index.md
+++ b/packages/openclaw/guides/index.md
@@ -11,7 +11,7 @@ children:
 # OpenClaw Plugin Guides
 
 - [Plugin Setup](./plugin-setup.md) — Installation, configuration, service URL resolution, and plugin lifecycle.
-- [Tools Reference](./tools-reference.md) — 11 tools: meta_status, meta_config, meta_config_apply, meta_service (standard) + meta_list, meta_detail, meta_trigger, meta_preview, meta_seed, meta_unlock, meta_queue (custom).
+- [Tools Reference](./tools-reference.md) — 12 tools: meta_status, meta_config, meta_config_apply, meta_service (standard) + meta_list, meta_detail, meta_trigger, meta_preview, meta_seed, meta_unlock, meta_queue, meta_update (custom).
 - [Virtual Rules](./virtual-rules.md) — Watcher inference rules registered by the service.
 - [TOOLS.md Injection](./tools-injection.md) — Dynamic prompt generation, refresh cycle, and error handling.
 - [Changelog](../CHANGELOG.md) — Release history for `@karmaniverous/jeeves-meta-openclaw`.

--- a/packages/openclaw/guides/plugin-setup.md
+++ b/packages/openclaw/guides/plugin-setup.md
@@ -51,7 +51,7 @@ The `configRoot` tells `@karmaniverous/jeeves` core where to find the platform c
 On gateway startup:
 
 1. Plugin calls `init({ workspacePath, configRoot })` from `@karmaniverous/jeeves`
-2. Registers 11 tools: 4 standard (`meta_status`, `meta_config`, `meta_config_apply`, `meta_service`) via `createPluginToolset()`, plus 7 custom (`meta_list`, `meta_detail`, `meta_trigger`, `meta_preview`, `meta_seed`, `meta_unlock`, `meta_queue`)
+2. Registers 12 tools: 4 standard (`meta_status`, `meta_config`, `meta_config_apply`, `meta_service`) via `createPluginToolset()`, plus 8 custom (`meta_list`, `meta_detail`, `meta_trigger`, `meta_preview`, `meta_seed`, `meta_unlock`, `meta_queue`, `meta_update`)
 3. Resolves `gatewayUrl` via `loadWorkspaceConfig()` for cleanup escalation
 4. Creates a `ComponentWriter` via `createComponentWriter(descriptor, { gatewayUrl })` with a 73-second prime refresh interval
 5. `ComponentWriter` manages TOOLS.md section writing (section ordering, version stamps, locking), platform content maintenance (SOUL.md/AGENTS.md), and cleanup escalation via the gateway when needed

--- a/packages/openclaw/guides/tools-reference.md
+++ b/packages/openclaw/guides/tools-reference.md
@@ -72,7 +72,7 @@ Dry-run: show what inputs would be gathered for the next synthesis cycle.
 **Parameters:**
 - `path` (string, optional) — specific path, or omit for stalest candidate
 
-**Response:** `{ path, staleness, architectWillRun, architectReason, scope, estimatedTokens }`
+**Response:** `{ path, staleness, architectWillRun, architectReason, scope, estimatedTokens, owedPhase, priorityBand, phaseState }`
 
 ## meta_trigger
 
@@ -81,7 +81,8 @@ Enqueue synthesis for a specific meta or the stalest candidate.
 **Parameters:**
 - `path` (string, optional) — specific path, or omit for stalest candidate
 
-**Response:** `{ status: "accepted", path, queuePosition, alreadyQueued }`
+**Response (path-targeted):** `{ status: "queued"|"skipped", path, owedPhase, queuePosition, alreadyQueued }`
+**Response (corpus-wide):** `{ status: "accepted"|"skipped", path?, message?, queuePosition?, alreadyQueued? }`
 
 ## meta_seed
 
@@ -109,11 +110,11 @@ Queue management: list pending items, clear the queue, or abort current synthesi
 
 **Parameters:**
 - `action` (string, required) — one of `list`, `clear`, `abort`
-  - `list` — show current queue state (current synthesis, pending items)
-  - `clear` — remove all pending queue items
+  - `list` — show current queue state (current with phase, overrides, automatic candidates, pending items)
+  - `clear` — remove all pending queue entries
   - `abort` — stop the currently running synthesis and release its lock
 
-**Response (list):** `{ current, pending, state }`
+**Response (list):** `{ current, overrides, automatic, pending, state }`
 **Response (clear):** `{ cleared: <count> }`
 **Response (abort):** `{ status: "aborted", path }` or 404 if nothing running
 
@@ -123,7 +124,7 @@ Update user-settable reserved properties on a meta entity. Delegates to `PATCH /
 
 **Parameters:**
 - `path` (string, required) — `.meta/` or owner directory path
-- `updates` (object, required) — properties to set. Supported: `_steer`, `_emphasis`, `_depth`, `_crossRefs`, `_disabled`. Set a value to `null` to remove the property.
+- `updates` (object, required) — properties to set. Supported: `_steer`, `_emphasis`, `_depth`, `_crossRefs`, `_disabled`, `_architectTimeout`, `_builderTimeout`, `_criticTimeout`. Set a value to `null` to remove the property.
 
 **Response:** `{ path, meta }` — the updated meta with large generated fields (`_architect`, `_builder`, `_critic`, `_content`, `_feedback`) excluded.
 

--- a/packages/openclaw/guides/virtual-rules.md
+++ b/packages/openclaw/guides/virtual-rules.md
@@ -4,7 +4,7 @@ title: Virtual Rules
 
 # Virtual Rules
 
-The jeeves-meta **service** registers three virtual inference rules with jeeves-watcher at startup. The plugin does not register rules.
+The jeeves-meta **service** registers two virtual inference rules with jeeves-watcher at startup. The plugin does not register rules.
 
 ## meta-current
 
@@ -23,12 +23,6 @@ Renders as Markdown with the `_content` synthesis body.
 Matches: `**/.meta/archive/*.json`
 
 Indexes archived snapshots with `archived` and `archived_at` flags. Renders the archived `_content`.
-
-## meta-config
-
-Matches: `**/jeeves-meta{.config.json,/config.json}`
-
-Indexes the service configuration file with key config fields in frontmatter.
 
 ## Re-registration
 

--- a/packages/openclaw/skills/jeeves-meta/SKILL.md
+++ b/packages/openclaw/skills/jeeves-meta/SKILL.md
@@ -105,7 +105,8 @@ modify `_crossRefs` — without editing `meta.json` directly on the filesystem.
 **Parameters:**
 - `path` (required): `.meta/` or owner directory path.
 - `updates` (required): Object with properties to set. Supported:
-  `_steer`, `_emphasis`, `_depth`, `_crossRefs`, `_disabled`.
+  `_steer`, `_emphasis`, `_depth`, `_crossRefs`, `_disabled`,
+  `_architectTimeout`, `_builderTimeout`, `_criticTimeout`.
   Set a value to `null` to remove the property.
 
 ### meta_queue
@@ -141,6 +142,7 @@ compatibility.
 - **Disabling a meta:** `meta_update` with path and `updates: { _disabled: true }`
 - **Re-enabling a meta:** `meta_update` with path and `updates: { _disabled: null }`
 - **Changing steer via API:** `meta_update` with path and `updates: { _steer: "new focus" }`
+- **Setting per-entity timeouts:** `meta_update` with path and `updates: { _builderTimeout: 600 }`
 - **Reading synthesis output:** Use `watcher_search` filtered by the properties
   configured in `metaProperty` (e.g. `{ "domains": ["meta"] }` in production).
   The default properties are `{ _meta: "current" }` for live metas and
@@ -213,7 +215,9 @@ Key settings:
 
 | `schedule` | `*/30 * * * *` | Cron expression for automatic synthesis scheduling |
 | `serverBaseUrl` | (optional) | Public base URL of the service (e.g. `http://myhost:1938`). When set, progress reports include clickable entity links. |
-| `reportChannel` | (optional) | Gateway channel target for progress messages (e.g. Slack channel ID) |
+| `reportChannel` | (optional) | Gateway channel name (e.g. `slack`). Legacy: also used as target if `reportTarget` is unset. |
+| `reportTarget` | (optional) | Channel/user ID to send progress messages to |
+| `tier2ScanLimit` | 50 | Max all-fresh candidates to scan per tick in Tier 2 invalidation |
 | `logging.level` | `info` | Log level (trace/debug/info/warn/error) |
 | `logging.file` | (optional) | Log file path |
 
@@ -335,7 +339,7 @@ The `autoSeed` config field enables declarative, config-driven `.meta/`
 creation. It is an array of policy rules, each with the shape:
 
 ```json
-{ "match": "<glob>", "steer": "<optional prompt>", "crossRefs": ["<optional paths>"] }
+{ "match": "<glob>", "steer": "<optional>", "crossRefs": ["<optional>"], "parentDepth": 0 }
 ```
 
 - **`match`** (required) — a glob pattern compatible with `watcher.walk()`.
@@ -345,6 +349,14 @@ creation. It is an array of policy rules, each with the shape:
   seeded `meta.json`.
 - **`crossRefs`** (optional) — array of cross-ref owner paths written as
   `_crossRefs` in the seeded `meta.json`.
+- **`parentDepth`** (optional, default 0) — walk up this many extra parent
+  levels from the matched file's directory.
+- **`architectTimeout`** (optional) — per-category timeout override for
+  the architect phase (seconds, min 30).
+- **`builderTimeout`** (optional) — per-category timeout override for
+  the builder phase (seconds, min 30).
+- **`criticTimeout`** (optional) — per-category timeout override for
+  the critic phase (seconds, min 30).
 
 **Evaluation order:** Rules are processed in array order. If multiple rules
 match the same directory, the last match wins for `steer` and `crossRefs`.
@@ -567,7 +579,8 @@ jeeves-meta <command> [options]
 ```
 
 Commands: `start`, `status`, `list`, `detail`, `preview`, `synthesize`,
-`seed`, `unlock`, `config`, `service install|start|stop|status|remove`.
+`seed`, `unlock`, `abort`, `prune`, `config`, `queue list|clear`,
+`service install|start|stop|status|remove`.
 
 Config resolution: `--config` flag → `JEEVES_META_CONFIG` env var → error.
 All client commands support `-p, --port` to specify the service port (default: 1938).

--- a/packages/service/README.md
+++ b/packages/service/README.md
@@ -4,12 +4,12 @@ HTTP service for the Jeeves knowledge synthesis engine. Provides a Fastify API, 
 
 ## Features
 
-- **Fastify HTTP API** — `/status`, `/metas`, `/preview`, `/synthesize`, `/synthesize/abort`, `/seed`, `/unlock`, `/config`, `/config/apply`, `/queue`, `/queue/clear`
+- **Fastify HTTP API** — `/status`, `/metas`, `/metas/:path` (GET + PATCH), `/preview`, `/synthesize`, `/synthesize/abort`, `/seed`, `/unlock`, `/config`, `/config/apply`, `/queue`, `/queue/clear`
 - **Phase-state machine** — per-meta `_phaseState` tracking `{ architect, builder, critic }` × `{ fresh, stale, pending, running, failed }`
 - **Built-in scheduler** — croner-based cron with adaptive backoff; picks one phase per tick across entire corpus
 - **Three-layer synthesis queue** — `current` (running phase) + `overrides` (explicit triggers) + `automatic` (scheduler candidates)
 - **Three-phase orchestration** — architect, builder, critic with surgical retry of failed phases
-- **Discovery via watcher** — filesystem-based meta discovery via `/walk` endpoint (no Qdrant dependency)
+- **Discovery via watcher** — filesystem-based meta discovery (no Qdrant dependency)
 - **Ownership tree** — hierarchical scoping with child meta rollup
 - **Cross-meta references** — `_crossRefs` declares relationships to other metas; referenced `_content` included as architect/builder context
 - **Archive management** — timestamped snapshots with configurable pruning
@@ -55,8 +55,8 @@ jeeves-meta service install --config /path/to/jeeves-meta/config.json
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/status` | Service health, queue state, dependency checks, phase-state summary |
-| GET | `/metas` | List metas with filtering and field projection |
-| GET | `/metas/:path` | Single meta detail with optional archive |
+| GET | `/metas` | List metas with summary stats and per-meta projection. Response includes `_phaseState` and `owedPhase` per meta. |
+| GET | `/metas/:path` | Full detail for a single meta, with optional archive history. Response includes `_phaseState` and `owedPhase`. |
 | GET | `/preview` | Dry-run: preview inputs for next synthesis |
 | POST | `/synthesize` | Enqueue synthesis (stalest or specific path) |
 | POST | `/synthesize/abort` | Abort the currently running synthesis |
@@ -66,7 +66,7 @@ jeeves-meta service install --config /path/to/jeeves-meta/config.json
 | POST | `/config/apply` | Apply a config patch (merge or replace) |
 | GET | `/queue` | Queue state: current (with phase), overrides, automatic, pending |
 | POST | `/queue/clear` | Remove all override queue entries |
-| PATCH | `/metas/:path` | Update user-settable reserved properties (`_steer`, `_emphasis`, `_depth`, `_crossRefs`, `_disabled`) |
+| PATCH | `/metas/:path` | Update user-settable reserved properties (`_steer`, `_emphasis`, `_depth`, `_crossRefs`, `_disabled`, `_architectTimeout`, `_builderTimeout`, `_criticTimeout`) |
 
 ## Configuration
 

--- a/packages/service/guides/architecture.md
+++ b/packages/service/guides/architecture.md
@@ -9,13 +9,13 @@ title: Architecture
 | Component | Responsibility |
 |-----------|---------------|
 | `Scheduler` | Croner-based cron, discovers stalest candidate, enqueues work |
-| `SynthesisQueue` | Single-threaded FIFO with priority support and deduplication |
+| `SynthesisQueue` | Three-layer queue (current + overrides + automatic) with deduplication |
 | `GatewayExecutor` | Spawns LLM sessions via gateway `/tools/invoke`, polls for completion |
 | `ProgressReporter` | Sends synthesis events to a channel via gateway `/tools/invoke` → `message` tool |
-| `RuleRegistrar` | Registers 3 virtual inference rules with watcher at startup |
+| `RuleRegistrar` | Registers 2 virtual inference rules with watcher at startup |
 | `HttpWatcherClient` | Watcher HTTP client with 3-retry exponential backoff |
-| Fastify server | 12 HTTP endpoints across 9 route modules |
-| Config hot-reload | `fs.watchFile` monitors config for schedule/reportChannel/logging changes |
+| Fastify server | 13 HTTP endpoints across 10 route modules |
+| Config hot-reload | `fs.watchFile` monitors config; hot-reloadable fields applied immediately, restart-required fields warn on change |
 | Shutdown handlers | SIGTERM/SIGINT → stop scheduler → release lock → close server |
 
 ## Service Architecture
@@ -26,15 +26,71 @@ title: Architecture
 
 ![Data Flow](./assets/data-flow.png)
 
+## Discovery
+
+The `discoverMetas()` function enumerates all `.meta/meta.json` files via the watcher's `POST /walk` endpoint (no Qdrant dependency). Paths are deduplicated by `.meta/` directory.
+
+The `buildOwnershipTree()` function constructs the parent/child hierarchy:
+
+1. Sort all meta paths by owner path length (shallowest first)
+2. For each node, find the closest ancestor meta (longest owner path match)
+3. Set `treeDepth = parentDepth + 1`; record bidirectional parent/child pointers
+
+A lightweight variant, `buildMinimalNode()`, creates a shallow tree (self + direct children only) for targeted synthesis — avoiding full-tree cost when a specific path is requested.
+
+### Scope Filtering
+
+A meta **owns** its parent directory and all descendants, except subtrees that contain their own `.meta/`. Child `.meta/meta.json` files ARE included as rollup inputs.
+
+`getDeltaFiles()` filters scope files locally by mtime since `_generatedAt`. On first run (no `_generatedAt`), all scope files are returned.
+
+## Auto-Seed
+
+The `autoSeedPass()` function is executed at the start of each scheduler tick (before discovery). It processes configured `autoSeed` rules:
+
+1. For each rule, walk the watcher with the rule's `match` glob
+2. Extract candidate directories (with optional `parentDepth` walking)
+3. Build a map of owner path → effective options (**last match wins** for all fields including timeouts)
+4. Filter out paths that already have a `.meta/` directory
+5. Create `.meta/meta.json` for each new candidate with the matched rule's `steer`, `crossRefs`, and timeout overrides
+
 ## Virtual Rules
 
-Three inference rules are registered with jeeves-watcher:
+Two inference rules are registered with jeeves-watcher:
 
 | Rule | Matches | Purpose |
 |------|---------|---------|
 | `meta-current` | `**/.meta/meta.json` | Index live synthesis with domain tags + extracted fields |
 | `meta-archive` | `**/.meta/archive/*.json` | Index archived snapshots |
-| `meta-config` | `**/jeeves-meta{.config.json,/config.json}` | Index the service configuration |
+
+## Config Hot-Reload
+
+The service monitors its config file via `fs.watchFile`. Fields are divided into two categories:
+
+**Restart-required** (warn on change, no live effect): `port`, `watcherUrl`, `gatewayUrl`, `gatewayApiKey`, `defaultArchitect`, `defaultCritic`.
+
+**Hot-reloadable** (applied immediately): `schedule` (cron reschedule), `logging.level` (Pino level change), and all remaining fields (`reportChannel`, `reportTarget`, `serverBaseUrl`, `watcherHealthIntervalMs`, `tier2ScanLimit`, `autoSeed`, `architectEvery`, `depthWeight`, `maxArchive`, `maxLines`, `architectTimeout`, `builderTimeout`, `criticTimeout`, `thinking`, `skipUnchanged`, `metaProperty`, `metaArchiveProperty`).
+
+## Phase-State Machine
+
+The `src/phaseState/` module implements the per-meta phase-state machine:
+
+| Module | Responsibility |
+|--------|---------------|
+| `derivePhaseState.ts` | Reconstruct `_phaseState` from legacy fields for backward compatibility |
+| `invalidate.ts` | Detect structural/steer/cross-ref changes and mark phases as stale |
+| `phaseTransitions.ts` | Pure functions for all state transitions (invalidation, success, failure, retry) |
+| `phaseScheduler.ts` | Corpus-wide candidate selection: critic > builder > architect, staleness tiebreak |
+
+## Two-Tier Scheduler
+
+The `src/scheduler/` module provides the croner-based tick driver. The `src/scheduling/` module provides staleness computation:
+
+| Module | Responsibility |
+|--------|---------------|
+| `scheduler/index.ts` | Croner cron, adaptive backoff, per-tick orchestration entry point |
+| `scheduling/staleness.ts` | `getStalenessSeconds()` with `MAX_STALENESS_SECONDS` cap (365 days) |
+| `scheduling/weightedFormula.ts` | `effectiveStaleness` formula: `actualStaleness × (normalizedDepth + 1) ^ (depthWeight × emphasis)` |
 
 ## Port Allocation
 

--- a/packages/service/guides/cli.md
+++ b/packages/service/guides/cli.md
@@ -13,7 +13,15 @@ Start the HTTP service.
 ```bash
 jeeves-meta start --config /path/to/config.json
 # or: jeeves-meta start -c /path/to/config.json
+# or: set JEEVES_META_CONFIG env var and omit --config
 ```
+
+The config path is resolved from `--config` / `-c` flag first, then falls back to the `JEEVES_META_CONFIG` environment variable.
+
+### Config Loading
+
+- **`@file:` indirection** — string config values starting with `@file:` are replaced with the contents of the referenced file, resolved relative to the config file's directory. Used for `defaultArchitect` and `defaultCritic` prompts.
+- **`${VAR}` substitution** — all string values undergo environment variable substitution. Unset variables cause a startup error.
 
 ## `jeeves-meta status`
 
@@ -42,6 +50,22 @@ Create a `.meta/` directory with a fresh `meta.json` (containing a new UUID `_id
 ## `jeeves-meta unlock <path>`
 
 Remove a `.lock` file from a meta entity. Use when a lock is stale due to a crashed synthesis.
+
+## `jeeves-meta abort`
+
+Abort the currently running synthesis and release its lock.
+
+## `jeeves-meta prune`
+
+Prune old archive snapshots beyond `maxArchive` for all metas.
+
+## `jeeves-meta queue list`
+
+Show the current queue state (three-layer model: current, overrides, automatic).
+
+## `jeeves-meta queue clear`
+
+Remove all pending items from the override queue.
 
 ## `jeeves-meta config [-c <config-path>]`
 

--- a/packages/service/guides/concepts.md
+++ b/packages/service/guides/concepts.md
@@ -51,6 +51,31 @@ Set `_disabled: true` on a meta to exclude it from automatic staleness schedulin
 
 The builder can populate an opaque `_state` field in `meta.json` to carry forward intermediate progress across cycles. On timeout (`SpawnTimeoutError`), the service attempts to salvage any advanced `_state` from partial output — preserving progress even when the full synthesis fails.
 
+## Per-Entity Timeout Overrides
+
+Each meta can override the global phase timeouts via reserved properties:
+
+- `_architectTimeout` — seconds (min 30), overrides `architectTimeout` config
+- `_builderTimeout` — seconds (min 30), overrides `builderTimeout` config
+- `_criticTimeout` — seconds (min 30), overrides `criticTimeout` config
+
+These are set via `meta_update` or `PATCH /metas/:path` and take effect on the next phase execution.
+
+## Token Tracking
+
+Each meta records token usage from LLM subprocess calls:
+
+- `_architectTokens` (integer) — token count from last architect subprocess call
+- `_builderTokens` (integer) — token count from last builder subprocess call
+- `_criticTokens` (integer) — token count from last critic subprocess call
+- `_architectTokensAvg` (number) — exponential moving average of architect token usage (decay 0.3)
+- `_builderTokensAvg` (number) — exponential moving average of builder token usage (decay 0.3)
+- `_criticTokensAvg` (number) — exponential moving average of critic token usage (decay 0.3)
+
+## Ancestor Builder Hash (`_ancestorBuilderHash`)
+
+SHA-256 hash of the parent meta's `_builder` text at the time of last synthesis. Observability only — no invalidation cascade is triggered by changes.
+
 ## Lock Staging
 
 Synthesis results are staged in a `.lock` file before being committed to `meta.json`. If the process crashes between staging and commit, `meta.json` is untouched — "never write worse."

--- a/packages/service/guides/configuration.md
+++ b/packages/service/guides/configuration.md
@@ -15,13 +15,13 @@ The service reads a JSON config file specified via `--config` flag or `JEEVES_ME
 | `gatewayApiKey` | string | — | Gateway authentication key |
 | `defaultArchitect` | string | (built-in) | Architect system prompt override. Supports `@file:` references. Omit to use built-in default. |
 | `defaultCritic` | string | (built-in) | Critic system prompt override. Supports `@file:` references. Omit to use built-in default. |
-| `architectEvery` | integer | `10` | Run architect every N cycles per meta |
-| `depthWeight` | number | `0.5` | Exponent for depth weighting in staleness formula |
-| `maxArchive` | integer | `20` | Maximum archive snapshots per meta |
-| `maxLines` | integer | `500` | Max context lines in subprocess prompts |
-| `architectTimeout` | integer | `180` | Architect subprocess timeout (seconds) |
-| `builderTimeout` | integer | `360` | Builder subprocess timeout (seconds) |
-| `criticTimeout` | integer | `240` | Critic subprocess timeout (seconds) |
+| `architectEvery` | integer | `10` | Run architect every N cycles per meta (min 1) |
+| `depthWeight` | number | `0.5` | Exponent for depth weighting in staleness formula (min 0) |
+| `maxArchive` | integer | `20` | Maximum archive snapshots per meta (min 1) |
+| `maxLines` | integer | `500` | Max context lines in subprocess prompts (min 50) |
+| `architectTimeout` | integer | `180` | Architect subprocess timeout in seconds (min 30) |
+| `builderTimeout` | integer | `360` | Builder subprocess timeout in seconds (min 60) |
+| `criticTimeout` | integer | `240` | Critic subprocess timeout in seconds (min 30) |
 | `thinking` | string | `"low"` | Thinking level for spawned sessions |
 | `skipUnchanged` | boolean | `true` | Skip candidates with no file changes |
 | `metaProperty` | object | `{ _meta: "current" }` | Watcher metadata for live meta.json files |
@@ -31,15 +31,31 @@ The service reads a JSON config file specified via `--config` flag or `JEEVES_ME
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `port` | integer | `1938` | HTTP listen port |
+| `port` | integer | `1938` | HTTP listen port (min 1, max 65535) |
 
 | `schedule` | string | `*/30 * * * *` | Cron expression for synthesis scheduling |
-| `reportChannel` | string | — | Gateway channel target for progress messages |
-| `watcherHealthIntervalMs` | number | `60000` | Periodic watcher health check interval in ms. 0 = disabled. |
+| `reportChannel` | string | — | Gateway channel name (e.g. `slack`). Legacy: also used as target if `reportTarget` is unset. |
+| `reportTarget` | string | — | Channel/user ID to send progress messages to |
 | `serverBaseUrl` | string | — | Base URL for entity links in progress reports (e.g. `http://myserver:1938`) |
-| `autoSeed` | array | `[]` | Auto-seed policy rules. Each rule: `{ match: string, steer?: string, crossRefs?: string[] }`. Glob patterns matched against `watcher.walk()` results. Rules evaluated in order; last match wins for steer/crossRefs. |
+| `watcherHealthIntervalMs` | integer | `60000` | Periodic watcher health check interval in ms (min 0). 0 = disabled. |
+| `tier2ScanLimit` | integer | `50` | Max all-fresh candidates to scan per tick in Tier 2 invalidation (min 1) |
+| `autoSeed` | array | `[]` | Auto-seed policy rules (see below). Rules evaluated in order; last match wins for steer/crossRefs. |
 | `logging.level` | string | `"info"` | Log level (trace/debug/info/warn/error) |
 | `logging.file` | string | — | Log file path |
+
+### Auto-Seed Rules
+
+Each rule in the `autoSeed` array has the shape:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `match` | string | — | Glob pattern matched against `watcher.walk()` results (required) |
+| `steer` | string | — | Steering prompt written as `_steer` in seeded `meta.json` |
+| `crossRefs` | string[] | — | Cross-ref owner paths written as `_crossRefs` |
+| `parentDepth` | integer | `0` | Walk up this many extra parent levels from the matched file's directory |
+| `architectTimeout` | integer | — | Per-category timeout override for architect phase (seconds, min 30) |
+| `builderTimeout` | integer | — | Per-category timeout override for builder phase (seconds, min 30) |
+| `criticTimeout` | integer | — | Per-category timeout override for critic phase (seconds, min 30) |
 
 ## Hot-Reload
 

--- a/packages/service/guides/index.md
+++ b/packages/service/guides/index.md
@@ -14,7 +14,7 @@ children:
 
 - [Concepts](./concepts.md) — Meta entities, ownership trees, synthesis cycles, cross-references, and progressive synthesis.
 - [Configuration](./configuration.md) — All config fields with defaults, hot-reload behavior, environment variable substitution, and prompt system.
-- [Orchestration](./orchestration.md) — The 13-step synthesis cycle, module structure, error handling, and lock staging.
+- [Orchestration](./orchestration.md) — Phase-state machine transitions, per-tick orchestration, error handling, and lock staging.
 - [Scheduling](./scheduling.md) — Weighted staleness formula, adaptive backoff, and queue processing.
 - [Architecture](./architecture.md) — Service components, data flow, virtual rules, and port allocation.
 - [CLI Reference](./cli.md) — All commands with usage.

--- a/packages/service/guides/orchestration.md
+++ b/packages/service/guides/orchestration.md
@@ -19,12 +19,17 @@ The `orchestratePhase()` function runs **one phase per tick** using the phase-st
 
 Each meta carries `_phaseState: { architect, builder, critic }` where each value is one of: `fresh`, `stale`, `pending`, `running`, `failed`.
 
+**Invariant:** At most one phase is `pending` or `running`, and it is the first non-fresh phase in pipeline order. When `enforceInvariant()` runs after every transition, stale phases that become the first non-fresh phase are promoted to `pending`; non-first `pending` phases are demoted to `stale`.
+
 **Key transitions:**
-- File change detected → `architect: stale` (cascade: `builder: pending`, `critic: pending`)
-- Architect success → `architect: fresh` (cascade: `builder: pending` if was stale)
-- Builder success → `builder: fresh`, `critic: pending`
-- Critic success → `critic: fresh`; if all three fresh → full-cycle complete (archive + increment `_synthesisCount`)
+- Architect invalidated → `architect: pending` (downstream `fresh` phases become `stale`; already non-fresh phases keep their state). Triggers: structure hash change, steer change, cross-refs declaration change, `_synthesisCount` ≥ `architectEvery`, or first run (no `_builder`).
+- **Progressive metas** (`_state` present): structure changes invalidate builder instead of architect, since the cursor handles incremental processing.
+- Builder invalidated (cross-ref content change, when architect is fresh and not first run) → `builder: pending`; `critic` → `stale` if was `fresh`. When architect is not fresh, builder stays `stale` (not promoted to `pending`).
+- Architect success → `architect: fresh`, `builder: pending` (or stays `failed`), `critic` → `stale` if was `fresh`. Also resets `_synthesisCount` to 0.
+- Builder success → `builder: fresh`, `critic: pending` (or stays `failed`). Architect state preserved.
+- Critic success → `critic: fresh`; if all three fresh → full-cycle complete (archive via `createSnapshot()`, `pruneArchive()`, then increment `_synthesisCount`)
 - Any phase failure → that phase: `failed`; other phases untouched (surgical retry)
+- Phase selected for execution → transitions to `running` before executor spawns
 - Next tick → `failed` phases promoted to `pending` for auto-retry
 
 ### Module Structure

--- a/packages/service/guides/scheduling.md
+++ b/packages/service/guides/scheduling.md
@@ -10,7 +10,7 @@ title: Scheduling
 effectiveStaleness = actualStaleness × (normalizedDepth + 1) ^ (depthWeight × emphasis)
 ```
 
-- **actualStaleness**: seconds since `_generatedAt` (Infinity if never synthesized)
+- **actualStaleness**: seconds since `_generatedAt` (capped at `MAX_STALENESS_SECONDS` = 31 536 000 seconds / 365 days if never synthesized or extremely stale). Bounding prevents `Infinity × depthFactor = Infinity` for all depths, which would make staleness-based prioritization meaningless.
 - **normalizedDepth**: tree depth shifted so minimum = 0
 - **depthWeight**: config exponent (default 0.5). Set to 0 for pure staleness ordering
 - **emphasis**: per-meta `_emphasis` multiplier (default 1). Higher = updates more often
@@ -37,9 +37,11 @@ Each tick:
 2. Discover all metas via watcher `/walk` endpoint
 3. **Derive phase state** — reconstruct `_phaseState` for legacy metas without it
 4. **Auto-retry** — promote `failed` → `pending` for all failed phases
-5. **Select phase candidate** — pick the highest-priority owed phase (critic > builder > architect, staleness tiebreak)
-6. Enqueue the selected phase (if no candidates, increase backoff and return)
-7. Check watcher uptime for restart detection → re-register virtual rules if needed
+5. **Tier 1 cheap invalidation** (no I/O) — for metas with persisted `_phaseState`, check `_synthesisCount >= architectEvery` and bump architect to `pending` if needed
+6. **Select phase candidate** — pick the highest-priority owed phase (critic > builder > architect, staleness tiebreak)
+7. **Tier 2 deep invalidation** (with I/O) — for all-fresh metas (up to `tier2ScanLimit`, default 50), walk scope for structure hash changes and check steer/crossRefs changes against archive to detect invalidation
+8. Enqueue the selected phase (if no candidates, increase backoff and return)
+9. Check watcher uptime for restart detection → re-register virtual rules if needed
 
 ## Disabled Metas
 

--- a/packages/service/src/phaseState/invalidate.test.ts
+++ b/packages/service/src/phaseState/invalidate.test.ts
@@ -8,7 +8,7 @@
  * @module phaseState/invalidate.test
  */
 
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -24,7 +24,7 @@ import { computeInvalidation } from './invalidate.js';
 let mockArchive: MetaJson | null = null;
 
 vi.mock('../archive/index.js', () => ({
-  readLatestArchive: vi.fn(async () => mockArchive),
+  readLatestArchive: vi.fn(() => mockArchive),
 }));
 
 // ── Mock DEFAULT prompts to stable strings ──────────────────────────
@@ -40,7 +40,6 @@ const SCOPE_A = ['file-a.md', 'file-b.md'];
 const SCOPE_B = ['file-a.md', 'file-b.md', 'file-c.md'];
 
 const HASH_A = computeStructureHash(SCOPE_A);
-const HASH_B = computeStructureHash(SCOPE_B);
 
 function makeConfig(overrides?: Partial<MetaConfig>): MetaConfig {
   return {


### PR DESCRIPTION
## Summary

Fixes 3 lint errors and 28 documentation discrepancies found during a full source-vs-docs audit.

### Code Quality Fixes
- Remove unused \writeFileSync\ import, unnecessary \sync\, unused \HASH_B\ in \invalidate.test.ts\
- Use \export type\ for type-only re-exports in \core/index.ts\ (fixes typedoc \isolatedModules\ errors)

### Documentation Sync (28 fixes across 14 files)

**New file:**
- \packages/core/README.md\ — documents all core exports

**service/README.md:** Remove phantom \/walk\ endpoint, update \/metas\ descriptions

**concepts.md:** Add 6 token fields (\_architectTokens\, \_builderTokens\, \_criticTokens\ + Avg variants)

**configuration.md:** Add min/max constraints to all 10 config fields from Zod schema

**architecture.md:** Fix route module count (9→10), add phase-state machine section, add two-tier scheduler section, expand config hot-reload scope

**orchestration.md:** Fix builder demotion logic (\stale\ not \pending\ when architect not fresh), add \_synthesisCount\ reset on architect success, add \pruneArchive()\ after snapshot

**scheduling.md:** Fix \Infinity\ → \MAX_STALENESS_SECONDS\ (31,536,000s) with rationale

**cli.md:** Add \JEEVES_META_CONFIG\ env var, \@file:\ indirection, \\\ substitution

**openclaw guides:** Fix tool counts, fix queue clear wording, remove phantom meta-config rule from virtual-rules.md, update SKILL.md