### PR TITLE
fix: decouple prompt staleness from invalidation cascade (#163)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Metas can declare explicit cross-references (`_crossRefs`) to other metas, formi
 
 | Package | Description |
 |---------|-------------|
+| [`@karmaniverous/jeeves-meta-core`](packages/core/README.md) | Shared types, schemas, endpoint descriptors, and utilities |
 | [`@karmaniverous/jeeves-meta`](packages/service/README.md) | HTTP service — Fastify API, built-in scheduler, synthesis queue, CLI |
 | [`@karmaniverous/jeeves-meta-openclaw`](packages/openclaw/README.md) | OpenClaw plugin — thin HTTP client, interactive tools, TOOLS.md injection |
 
@@ -78,7 +79,7 @@ Install the plugin package. Twelve tools become available to the agent:
 - `meta_seed` — create `.meta/` directory for a new path (with optional cross-refs and steer)
 - `meta_unlock` — remove stale `.lock` from a meta entity
 - `meta_queue` — queue management: list pending, clear queue, abort current synthesis
-- `meta_update` — update user-settable reserved properties (`_steer`, `_emphasis`, `_depth`, `_crossRefs`, `_disabled`)
+- `meta_update` — update user-settable reserved properties (`_steer`, `_emphasis`, `_depth`, `_crossRefs`, `_disabled`, `_architectTimeout`, `_builderTimeout`, `_criticTimeout`)
 
 ## Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,15 +104,16 @@
       }
     },
     "node_modules/@dotenvx/dotenvx": {
-      "version": "1.65.0",
-      "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.65.0.tgz",
-      "integrity": "sha512-v4FA/Lw3pTEloLxBqTOaYDX6MNo0Jo7lGBsPZhwnJBqRJp0AzQg1ZZNxrFsh6HVC6QWeWrfIKLn0y2eyIXaVDg==",
+      "version": "1.69.1",
+      "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.69.1.tgz",
+      "integrity": "sha512-kwQB5KcAegxw/+NGUgXAo5ovyOSjlMhoXSSnSEpDhoHJwzMcMO0HE1U0VCYZ7jbAeCMGamed9XdWzOA5ixtTNg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "commander": "^11.1.0",
         "dotenv": "^17.2.1",
         "eciesjs": "^0.4.10",
+        "enquirer": "^2.4.1",
         "execa": "^5.1.1",
         "fdir": "^6.2.0",
         "ignore": "^5.3.0",
@@ -490,9 +491,9 @@
       }
     },
     "node_modules/@karmaniverous/jeeves": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@karmaniverous/jeeves/-/jeeves-0.5.10.tgz",
-      "integrity": "sha512-8SZGtCVgTzUIqc3q/ABrUxK9yPpYie1s21TUpON1G81VDtPep3VSMOgqU/LnV8NiXNnHDDWkzAbXdGQpa3bLaQ==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@karmaniverous/jeeves/-/jeeves-0.5.11.tgz",
+      "integrity": "sha512-nb2d/BSqAmDMpTXw8v85PLKNq01f3ukiYITxQVdDAjXchEL95/SXwypHgTdJRNPgvJmkL77BooFXgSJ8qkpHyA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "commander": "^14.0.3",
@@ -500,7 +501,7 @@
         "jsonpath-plus": "^10.4.0",
         "package-directory": "^8.2.0",
         "proper-lockfile": "^4.1.2",
-        "semver": "^7.8.0",
+        "semver": "^7.8.1",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -1912,9 +1913,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
-      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
       "cpu": [
         "arm"
       ],
@@ -1926,9 +1927,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
-      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
       "cpu": [
         "arm64"
       ],
@@ -1940,9 +1941,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
-      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
       "cpu": [
         "arm64"
       ],
@@ -1954,9 +1955,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
-      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
       "cpu": [
         "x64"
       ],
@@ -1968,9 +1969,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
-      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
       "cpu": [
         "arm64"
       ],
@@ -1982,9 +1983,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
-      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
       "cpu": [
         "x64"
       ],
@@ -1996,13 +1997,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
-      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2010,13 +2014,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
-      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2024,13 +2031,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
-      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2038,13 +2048,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
-      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2052,13 +2065,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
-      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2066,13 +2082,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
-      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2080,13 +2099,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
-      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2094,13 +2116,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
-      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2108,13 +2133,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
-      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2122,13 +2150,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
-      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2136,13 +2167,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
-      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2150,13 +2184,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
-      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2164,13 +2201,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
-      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2178,9 +2218,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
-      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
       "cpu": [
         "x64"
       ],
@@ -2192,9 +2232,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
-      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
       "cpu": [
         "arm64"
       ],
@@ -2206,9 +2246,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
-      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
       "cpu": [
         "arm64"
       ],
@@ -2220,9 +2260,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
-      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
       "cpu": [
         "ia32"
       ],
@@ -2234,9 +2274,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
-      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
       "cpu": [
         "x64"
       ],
@@ -2248,9 +2288,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
-      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
       "cpu": [
         "x64"
       ],
@@ -2426,13 +2466,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
-      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.21.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/parse-path": {
@@ -2703,37 +2743,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
-      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.6",
-        "ast-v8-to-istanbul": "^1.0.0",
-        "istanbul-lib-coverage": "^3.2.2",
-        "istanbul-lib-report": "^3.0.1",
-        "istanbul-reports": "^3.2.0",
-        "magicast": "^0.5.2",
-        "obug": "^2.1.1",
-        "std-env": "^4.0.0-rc.1",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@vitest/browser": "4.1.6",
-        "vitest": "4.1.6"
-      },
-      "peerDependenciesMeta": {
-        "@vitest/browser": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@vitest/eslint-plugin": {
       "version": "1.6.17",
       "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.17.tgz",
@@ -2763,129 +2772,6 @@
         "vitest": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@vitest/expect": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
-      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.1.0",
-        "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
-        "chai": "^6.2.2",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/mocker": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
-      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.1.6",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitest/mocker/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
-    "node_modules/@vitest/pretty-format": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
-      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/runner": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
-      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/utils": "4.1.6",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/snapshot": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
-      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/utils": "4.1.6",
-        "magic-string": "^0.30.21",
-        "pathe": "^2.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/spy": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
-      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/utils": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
-      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.1.6",
-        "convert-source-map": "^2.0.0",
-        "tinyrainbow": "^3.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/abstract-logging": {
@@ -2948,6 +2834,16 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ansi-regex": {
@@ -3555,6 +3451,43 @@
         "bun": ">=1",
         "deno": ">=2",
         "node": ">=16"
+      }
+    },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/enquirer/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/enquirer/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/entities": {
@@ -7319,9 +7252,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
-      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7335,31 +7268,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.3",
-        "@rollup/rollup-android-arm64": "4.60.3",
-        "@rollup/rollup-darwin-arm64": "4.60.3",
-        "@rollup/rollup-darwin-x64": "4.60.3",
-        "@rollup/rollup-freebsd-arm64": "4.60.3",
-        "@rollup/rollup-freebsd-x64": "4.60.3",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
-        "@rollup/rollup-linux-arm64-musl": "4.60.3",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
-        "@rollup/rollup-linux-loong64-musl": "4.60.3",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
-        "@rollup/rollup-linux-x64-gnu": "4.60.3",
-        "@rollup/rollup-linux-x64-musl": "4.60.3",
-        "@rollup/rollup-openbsd-x64": "4.60.3",
-        "@rollup/rollup-openharmony-arm64": "4.60.3",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
-        "@rollup/rollup-win32-x64-gnu": "4.60.3",
-        "@rollup/rollup-win32-x64-msvc": "4.60.3",
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
         "fsevents": "~2.3.2"
       }
     },
@@ -7445,9 +7378,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7933,9 +7866,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
-      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },
@@ -8067,96 +8000,6 @@
         }
       }
     },
-    "node_modules/vitest": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
-      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/expect": "4.1.6",
-        "@vitest/mocker": "4.1.6",
-        "@vitest/pretty-format": "4.1.6",
-        "@vitest/runner": "4.1.6",
-        "@vitest/snapshot": "4.1.6",
-        "@vitest/spy": "4.1.6",
-        "@vitest/utils": "4.1.6",
-        "es-module-lexer": "^2.0.0",
-        "expect-type": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "obug": "^2.1.1",
-        "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
-        "std-env": "^4.0.0-rc.1",
-        "tinybench": "^2.9.0",
-        "tinyexec": "^1.0.2",
-        "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.1.0",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
-        "why-is-node-running": "^2.3.0"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@opentelemetry/api": "^1.9.0",
-        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.6",
-        "@vitest/browser-preview": "4.1.6",
-        "@vitest/browser-webdriverio": "4.1.6",
-        "@vitest/coverage-istanbul": "4.1.6",
-        "@vitest/coverage-v8": "4.1.6",
-        "@vitest/ui": "4.1.6",
-        "happy-dom": "*",
-        "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@types/node": {
-          "optional": true
-        },
-        "@vitest/browser-playwright": {
-          "optional": true
-        },
-        "@vitest/browser-preview": {
-          "optional": true
-        },
-        "@vitest/browser-webdriverio": {
-          "optional": true
-        },
-        "@vitest/coverage-istanbul": {
-          "optional": true
-        },
-        "@vitest/coverage-v8": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        },
-        "vite": {
-          "optional": false
-        }
-      }
-    },
     "node_modules/which": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
@@ -8271,15 +8114,15 @@
         "zod": "^4.4"
       },
       "devDependencies": {
-        "@dotenvx/dotenvx": "^1.65.0",
+        "@dotenvx/dotenvx": "^1.69.1",
         "@rollup/plugin-commonjs": "^29.0.2",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-typescript": "^12.3.0",
         "cross-env": "^10.1.0",
         "release-it": "^20.0.1",
-        "rollup": "^4.60.3",
+        "rollup": "^4.60.4",
         "tslib": "^2.8.1",
-        "vitest": "^4.1.6"
+        "vitest": "^4.1.7"
       },
       "engines": {
         "node": ">=22"
@@ -8629,6 +8472,119 @@
         }
       }
     },
+    "packages/core/node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/core/node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "packages/core/node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/core/node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/core/node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/core/node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/core/node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "packages/core/node_modules/agent-base": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-8.0.0.tgz",
@@ -8665,6 +8621,16 @@
       },
       "peerDependencies": {
         "quickjs-wasi": "^0.0.1"
+      }
+    },
+    "packages/core/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "packages/core/node_modules/eta": {
@@ -8963,6 +8929,96 @@
         "node": ">=20.18.1"
       }
     },
+    "packages/core/node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "packages/core/node_modules/windows-release": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-7.1.1.tgz",
@@ -9056,22 +9112,22 @@
       "version": "0.12.5",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@karmaniverous/jeeves": "^0.5.10",
+        "@karmaniverous/jeeves": "^0.5.11",
         "@karmaniverous/jeeves-meta-core": "^0.1.2"
       },
       "bin": {
         "jeeves-meta-openclaw": "dist/cli.js"
       },
       "devDependencies": {
-        "@dotenvx/dotenvx": "^1.65.0",
+        "@dotenvx/dotenvx": "^1.69.1",
         "@rollup/plugin-commonjs": "^29.0.2",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-typescript": "^12.3.0",
         "cross-env": "^10.1.0",
         "release-it": "^20.0.1",
-        "rollup": "^4.60.3",
+        "rollup": "^4.60.4",
         "tslib": "^2.8.1",
-        "vitest": "^4.1.6"
+        "vitest": "^4.1.7"
       },
       "engines": {
         "node": ">=22"
@@ -9421,6 +9477,119 @@
         }
       }
     },
+    "packages/openclaw/node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/openclaw/node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "packages/openclaw/node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/openclaw/node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/openclaw/node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/openclaw/node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/openclaw/node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "packages/openclaw/node_modules/agent-base": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-8.0.0.tgz",
@@ -9457,6 +9626,16 @@
       },
       "peerDependencies": {
         "quickjs-wasi": "^0.0.1"
+      }
+    },
+    "packages/openclaw/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "packages/openclaw/node_modules/eta": {
@@ -9755,6 +9934,96 @@
         "node": ">=20.18.1"
       }
     },
+    "packages/openclaw/node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "packages/openclaw/node_modules/windows-release": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-7.1.1.tgz",
@@ -9816,7 +10085,7 @@
       "version": "0.15.8",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@karmaniverous/jeeves": "^0.5.10",
+        "@karmaniverous/jeeves": "^0.5.11",
         "@karmaniverous/jeeves-meta-core": "^0.1.2",
         "commander": "^14",
         "croner": "^10",
@@ -9830,19 +10099,19 @@
         "jeeves-meta": "dist/cli/jeeves-meta/index.js"
       },
       "devDependencies": {
-        "@dotenvx/dotenvx": "^1.65.0",
+        "@dotenvx/dotenvx": "^1.69.1",
         "@rollup/plugin-commonjs": "^29.0.2",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-typescript": "^12.3.0",
-        "@types/node": "^25.7.0",
-        "@vitest/coverage-v8": "^4.1.6",
+        "@types/node": "^25.9.1",
+        "@vitest/coverage-v8": "^4.1.7",
         "cross-env": "^10.1.0",
         "release-it": "^20.0.1",
-        "rollup": "^4.60.3",
+        "rollup": "^4.60.4",
         "rollup-plugin-copy": "^3.5.0",
         "tslib": "^2.8.1",
-        "vitest": "^4.1.6"
+        "vitest": "^4.1.7"
       },
       "engines": {
         "node": ">=22"
@@ -10192,6 +10461,150 @@
         }
       }
     },
+    "packages/service/node_modules/@vitest/coverage-v8": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz",
+      "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.7",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.7",
+        "vitest": "4.1.7"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "packages/service/node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/service/node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "packages/service/node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/service/node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/service/node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/service/node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/service/node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "packages/service/node_modules/agent-base": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-8.0.0.tgz",
@@ -10228,6 +10641,16 @@
       },
       "peerDependencies": {
         "quickjs-wasi": "^0.0.1"
+      }
+    },
+    "packages/service/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
       }
     },
     "packages/service/node_modules/eta": {
@@ -10524,6 +10947,96 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
+      }
+    },
+    "packages/service/node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
       }
     },
     "packages/service/node_modules/windows-release": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,59 @@
+# @karmaniverous/jeeves-meta-core
+
+Shared types, schemas, endpoint descriptors, and utilities for the jeeves-meta monorepo. This package is the single source of truth for API contracts consumed by both the [service](../service/) and the [OpenClaw plugin](../openclaw/).
+
+## Install
+
+```bash
+npm install @karmaniverous/jeeves-meta-core
+```
+
+## Exports
+
+### Constants
+
+- **`META_COMPONENT`** — component descriptor (name, default port, packages, dependencies)
+
+### Endpoint Catalog
+
+- **`META_ENDPOINTS`** — 13 endpoint descriptors (name, method, path, description)
+- **`getEndpoint(name)`** — look up an endpoint by name
+- Types: `HttpMethod`, `EndpointDescriptor`, `EndpointName`, `Endpoint<N>`
+
+### Configuration Schema
+
+- **`metaConfigSchema`** — Zod schema for core config fields (watcherUrl, gatewayUrl, timeouts, etc.)
+- Type: `MetaConfig`
+
+### Phase Vocabulary
+
+- **`phaseNames`** — `['architect', 'builder', 'critic']`
+- **`phaseStatuses`** — `['fresh', 'stale', 'pending', 'running', 'failed']`
+- **`phaseStateSchema`** / **`phaseStatusSchema`** — Zod schemas
+- Types: `PhaseName`, `PhaseStatus`, `PhaseState`
+
+### Error Schema
+
+- **`metaErrorSchema`** — Zod schema for `{ step, code, message }`
+- Type: `MetaError`
+
+### HTTP Response Contracts
+
+- `MetaListSummary` — summary stats from `GET /metas`
+- `MetasItem` — per-meta projected item
+- `MetasResponse` — `{ summary, metas }` envelope
+- `DepHealth`, `WatcherDepHealth`, `GatewayDepHealth` — dependency health
+- `ServiceState` — `'idle' | 'synthesizing' | 'waiting' | 'stopping'`
+
+### Utilities
+
+- **`normalizePath(p)`** — converts backslashes to forward slashes
+
+## Requirements
+
+- Node.js >= 22
+- ESM only
+
+## License
+
+BSD-3-Clause

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,15 +3,15 @@
     "zod": "^4.4"
   },
   "devDependencies": {
-    "@dotenvx/dotenvx": "^1.65.0",
+    "@dotenvx/dotenvx": "^1.69.1",
     "@rollup/plugin-commonjs": "^29.0.2",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-typescript": "^12.3.0",
     "cross-env": "^10.1.0",
     "release-it": "^20.0.1",
-    "rollup": "^4.60.3",
+    "rollup": "^4.60.4",
     "tslib": "^2.8.1",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.7"
   },
   "engines": {
     "node": ">=22"

--- a/packages/core/src/endpoints.ts
+++ b/packages/core/src/endpoints.ts
@@ -73,7 +73,7 @@ export const META_ENDPOINTS = [
     method: 'GET',
     path: '/preview',
     description:
-      'Dry-run preview of next synthesis. Returns owedPhase, priorityBand, phaseState, stalenessInputs, and architectInvalidators.',
+      'Dry-run preview of next synthesis. Returns owedPhase, priorityBand, phaseState, inputStatus, and architectInvalidators.',
   },
   {
     name: 'seed',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,7 +5,7 @@
  */
 
 export { META_COMPONENT } from './constants.js';
-export {
+export type {
   DepHealth,
   GatewayDepHealth,
   MetaListSummary,
@@ -14,23 +14,22 @@ export {
   ServiceState,
   WatcherDepHealth,
 } from './contracts.js';
-export {
+export type {
   Endpoint,
   EndpointDescriptor,
   EndpointName,
-  getEndpoint,
   HttpMethod,
-  META_ENDPOINTS,
 } from './endpoints.js';
-export { MetaError, metaErrorSchema } from './errors.js';
-export { MetaConfig, metaConfigSchema } from './metaConfig.js';
+export { getEndpoint, META_ENDPOINTS } from './endpoints.js';
+export type { MetaError } from './errors.js';
+export { metaErrorSchema } from './errors.js';
+export type { MetaConfig } from './metaConfig.js';
+export { metaConfigSchema } from './metaConfig.js';
 export { normalizePath } from './normalizePath.js';
+export type { PhaseName, PhaseState, PhaseStatus } from './phases.js';
 export {
-  PhaseName,
   phaseNames,
-  PhaseState,
   phaseStateSchema,
-  PhaseStatus,
   phaseStatuses,
   phaseStatusSchema,
 } from './phases.js';

--- a/packages/openclaw/guides/index.md
+++ b/packages/openclaw/guides/index.md
@@ -11,7 +11,7 @@ children:
 # OpenClaw Plugin Guides
 
 - [Plugin Setup](./plugin-setup.md) — Installation, configuration, service URL resolution, and plugin lifecycle.
-- [Tools Reference](./tools-reference.md) — 11 tools: meta_status, meta_config, meta_config_apply, meta_service (standard) + meta_list, meta_detail, meta_trigger, meta_preview, meta_seed, meta_unlock, meta_queue (custom).
+- [Tools Reference](./tools-reference.md) — 12 tools: meta_status, meta_config, meta_config_apply, meta_service (standard) + meta_list, meta_detail, meta_trigger, meta_preview, meta_seed, meta_unlock, meta_queue, meta_update (custom).
 - [Virtual Rules](./virtual-rules.md) — Watcher inference rules registered by the service.
 - [TOOLS.md Injection](./tools-injection.md) — Dynamic prompt generation, refresh cycle, and error handling.
 - [Changelog](../CHANGELOG.md) — Release history for `@karmaniverous/jeeves-meta-openclaw`.

--- a/packages/openclaw/guides/plugin-setup.md
+++ b/packages/openclaw/guides/plugin-setup.md
@@ -51,7 +51,7 @@ The `configRoot` tells `@karmaniverous/jeeves` core where to find the platform c
 On gateway startup:
 
 1. Plugin calls `init({ workspacePath, configRoot })` from `@karmaniverous/jeeves`
-2. Registers 11 tools: 4 standard (`meta_status`, `meta_config`, `meta_config_apply`, `meta_service`) via `createPluginToolset()`, plus 7 custom (`meta_list`, `meta_detail`, `meta_trigger`, `meta_preview`, `meta_seed`, `meta_unlock`, `meta_queue`)
+2. Registers 12 tools: 4 standard (`meta_status`, `meta_config`, `meta_config_apply`, `meta_service`) via `createPluginToolset()`, plus 8 custom (`meta_list`, `meta_detail`, `meta_trigger`, `meta_preview`, `meta_seed`, `meta_unlock`, `meta_queue`, `meta_update`)
 3. Resolves `gatewayUrl` via `loadWorkspaceConfig()` for cleanup escalation
 4. Creates a `ComponentWriter` via `createComponentWriter(descriptor, { gatewayUrl })` with a 73-second prime refresh interval
 5. `ComponentWriter` manages TOOLS.md section writing (section ordering, version stamps, locking), platform content maintenance (SOUL.md/AGENTS.md), and cleanup escalation via the gateway when needed

--- a/packages/openclaw/guides/tools-reference.md
+++ b/packages/openclaw/guides/tools-reference.md
@@ -72,7 +72,7 @@ Dry-run: show what inputs would be gathered for the next synthesis cycle.
 **Parameters:**
 - `path` (string, optional) — specific path, or omit for stalest candidate
 
-**Response:** `{ path, staleness, architectWillRun, architectReason, scope, estimatedTokens, owedPhase, priorityBand, phaseState }`
+**Response:** `{ path, staleness, architectWillRun, architectReason, scope, estimatedTokens, owedPhase, priorityBand, phaseState, inputStatus, architectInvalidators }`
 
 ## meta_trigger
 

--- a/packages/openclaw/guides/tools-reference.md
+++ b/packages/openclaw/guides/tools-reference.md
@@ -72,7 +72,7 @@ Dry-run: show what inputs would be gathered for the next synthesis cycle.
 **Parameters:**
 - `path` (string, optional) — specific path, or omit for stalest candidate
 
-**Response:** `{ path, staleness, architectWillRun, architectReason, scope, estimatedTokens }`
+**Response:** `{ path, staleness, architectWillRun, architectReason, scope, estimatedTokens, owedPhase, priorityBand, phaseState }`
 
 ## meta_trigger
 
@@ -81,7 +81,8 @@ Enqueue synthesis for a specific meta or the stalest candidate.
 **Parameters:**
 - `path` (string, optional) — specific path, or omit for stalest candidate
 
-**Response:** `{ status: "accepted", path, queuePosition, alreadyQueued }`
+**Response (path-targeted):** `{ status: "queued"|"skipped", path, owedPhase, queuePosition, alreadyQueued }`
+**Response (corpus-wide):** `{ status: "accepted"|"skipped", path?, message?, queuePosition?, alreadyQueued? }`
 
 ## meta_seed
 
@@ -109,11 +110,11 @@ Queue management: list pending items, clear the queue, or abort current synthesi
 
 **Parameters:**
 - `action` (string, required) — one of `list`, `clear`, `abort`
-  - `list` — show current queue state (current synthesis, pending items)
-  - `clear` — remove all pending queue items
+  - `list` — show current queue state (current with phase, overrides, automatic candidates, pending items)
+  - `clear` — remove all pending queue entries
   - `abort` — stop the currently running synthesis and release its lock
 
-**Response (list):** `{ current, pending, state }`
+**Response (list):** `{ current, overrides, automatic, pending, state }`
 **Response (clear):** `{ cleared: <count> }`
 **Response (abort):** `{ status: "aborted", path }` or 404 if nothing running
 
@@ -123,7 +124,7 @@ Update user-settable reserved properties on a meta entity. Delegates to `PATCH /
 
 **Parameters:**
 - `path` (string, required) — `.meta/` or owner directory path
-- `updates` (object, required) — properties to set. Supported: `_steer`, `_emphasis`, `_depth`, `_crossRefs`, `_disabled`. Set a value to `null` to remove the property.
+- `updates` (object, required) — properties to set. Supported: `_steer`, `_emphasis`, `_depth`, `_crossRefs`, `_disabled`, `_architectTimeout`, `_builderTimeout`, `_criticTimeout`. Set a value to `null` to remove the property.
 
 **Response:** `{ path, meta }` — the updated meta with large generated fields (`_architect`, `_builder`, `_critic`, `_content`, `_feedback`) excluded.
 

--- a/packages/openclaw/guides/virtual-rules.md
+++ b/packages/openclaw/guides/virtual-rules.md
@@ -4,7 +4,7 @@ title: Virtual Rules
 
 # Virtual Rules
 
-The jeeves-meta **service** registers three virtual inference rules with jeeves-watcher at startup. The plugin does not register rules.
+The jeeves-meta **service** registers two virtual inference rules with jeeves-watcher at startup. The plugin does not register rules.
 
 ## meta-current
 
@@ -23,12 +23,6 @@ Renders as Markdown with the `_content` synthesis body.
 Matches: `**/.meta/archive/*.json`
 
 Indexes archived snapshots with `archived` and `archived_at` flags. Renders the archived `_content`.
-
-## meta-config
-
-Matches: `**/jeeves-meta{.config.json,/config.json}`
-
-Indexes the service configuration file with key config fields in frontmatter.
 
 ## Re-registration
 

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -7,20 +7,20 @@
     "url": "https://github.com/karmaniverous/jeeves-meta/issues"
   },
   "dependencies": {
-    "@karmaniverous/jeeves": "^0.5.10",
+    "@karmaniverous/jeeves": "^0.5.11",
     "@karmaniverous/jeeves-meta-core": "^0.1.2"
   },
   "description": "OpenClaw plugin for jeeves-meta — synthesis tools and virtual rule registration",
   "devDependencies": {
-    "@dotenvx/dotenvx": "^1.65.0",
+    "@dotenvx/dotenvx": "^1.69.1",
     "@rollup/plugin-commonjs": "^29.0.2",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-typescript": "^12.3.0",
     "cross-env": "^10.1.0",
     "release-it": "^20.0.1",
-    "rollup": "^4.60.3",
+    "rollup": "^4.60.4",
     "tslib": "^2.8.1",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.7"
   },
   "engines": {
     "node": ">=22"

--- a/packages/openclaw/skills/jeeves-meta/SKILL.md
+++ b/packages/openclaw/skills/jeeves-meta/SKILL.md
@@ -105,7 +105,8 @@ modify `_crossRefs` — without editing `meta.json` directly on the filesystem.
 **Parameters:**
 - `path` (required): `.meta/` or owner directory path.
 - `updates` (required): Object with properties to set. Supported:
-  `_steer`, `_emphasis`, `_depth`, `_crossRefs`, `_disabled`.
+  `_steer`, `_emphasis`, `_depth`, `_crossRefs`, `_disabled`,
+  `_architectTimeout`, `_builderTimeout`, `_criticTimeout`.
   Set a value to `null` to remove the property.
 
 ### meta_queue
@@ -141,6 +142,7 @@ compatibility.
 - **Disabling a meta:** `meta_update` with path and `updates: { _disabled: true }`
 - **Re-enabling a meta:** `meta_update` with path and `updates: { _disabled: null }`
 - **Changing steer via API:** `meta_update` with path and `updates: { _steer: "new focus" }`
+- **Setting per-entity timeouts:** `meta_update` with path and `updates: { _builderTimeout: 600 }`
 - **Reading synthesis output:** Use `watcher_search` filtered by the properties
   configured in `metaProperty` (e.g. `{ "domains": ["meta"] }` in production).
   The default properties are `{ _meta: "current" }` for live metas and
@@ -213,7 +215,9 @@ Key settings:
 
 | `schedule` | `*/30 * * * *` | Cron expression for automatic synthesis scheduling |
 | `serverBaseUrl` | (optional) | Public base URL of the service (e.g. `http://myhost:1938`). When set, progress reports include clickable entity links. |
-| `reportChannel` | (optional) | Gateway channel target for progress messages (e.g. Slack channel ID) |
+| `reportChannel` | (optional) | Gateway channel name (e.g. `slack`). Legacy: also used as target if `reportTarget` is unset. |
+| `reportTarget` | (optional) | Channel/user ID to send progress messages to |
+| `tier2ScanLimit` | 50 | Max all-fresh candidates to scan per tick in Tier 2 invalidation |
 | `logging.level` | `info` | Log level (trace/debug/info/warn/error) |
 | `logging.file` | (optional) | Log file path |
 
@@ -335,7 +339,7 @@ The `autoSeed` config field enables declarative, config-driven `.meta/`
 creation. It is an array of policy rules, each with the shape:
 
 ```json
-{ "match": "<glob>", "steer": "<optional prompt>", "crossRefs": ["<optional paths>"] }
+{ "match": "<glob>", "steer": "<optional>", "crossRefs": ["<optional>"], "parentDepth": 0 }
 ```
 
 - **`match`** (required) — a glob pattern compatible with `watcher.walk()`.
@@ -345,6 +349,14 @@ creation. It is an array of policy rules, each with the shape:
   seeded `meta.json`.
 - **`crossRefs`** (optional) — array of cross-ref owner paths written as
   `_crossRefs` in the seeded `meta.json`.
+- **`parentDepth`** (optional, default 0) — walk up this many extra parent
+  levels from the matched file's directory.
+- **`architectTimeout`** (optional) — per-category timeout override for
+  the architect phase (seconds, min 30).
+- **`builderTimeout`** (optional) — per-category timeout override for
+  the builder phase (seconds, min 30).
+- **`criticTimeout`** (optional) — per-category timeout override for
+  the critic phase (seconds, min 30).
 
 **Evaluation order:** Rules are processed in array order. If multiple rules
 match the same directory, the last match wins for `steer` and `crossRefs`.
@@ -567,7 +579,8 @@ jeeves-meta <command> [options]
 ```
 
 Commands: `start`, `status`, `list`, `detail`, `preview`, `synthesize`,
-`seed`, `unlock`, `config`, `service install|start|stop|status|remove`.
+`seed`, `unlock`, `abort`, `prune`, `config`, `queue list|clear`,
+`service install|start|stop|status|remove`.
 
 Config resolution: `--config` flag → `JEEVES_META_CONFIG` env var → error.
 All client commands support `-p, --port` to specify the service port (default: 1938).

--- a/packages/openclaw/skills/jeeves-meta/SKILL.md
+++ b/packages/openclaw/skills/jeeves-meta/SKILL.md
@@ -48,8 +48,12 @@ Full detail for a single meta, with optional archive history. Includes
 Dry-run for the next synthesis candidate. Shows scope files, delta files,
 architect trigger reasons, steer status, structure changes, and the
 phase that would execute next — without running any LLM calls. Includes
-`phaseState` and `owedPhase` (the phase that would run). Use before
-`meta_trigger` to understand what will happen.
+`phaseState`, `owedPhase` (the phase that would run), `inputStatus`
+(informational flags: structureHash, steerChanged, architectChanged,
+criticChanged, crossRefsDeclChanged, crossRefContentChanged), and
+`architectInvalidators` (list of reasons architect was triggered, e.g.
+`structureHash`, `steer`, `_crossRefs`, `firstRun`, `architectEvery`).
+Use before `meta_trigger` to understand what will happen.
 
 **Parameters:**
 - `path` (optional): Specific `.meta/` or owner directory path. If omitted,

--- a/packages/service/README.md
+++ b/packages/service/README.md
@@ -4,12 +4,12 @@ HTTP service for the Jeeves knowledge synthesis engine. Provides a Fastify API, 
 
 ## Features
 
-- **Fastify HTTP API** — `/status`, `/metas`, `/preview`, `/synthesize`, `/synthesize/abort`, `/seed`, `/unlock`, `/config`, `/config/apply`, `/queue`, `/queue/clear`
+- **Fastify HTTP API** — `/status`, `/metas`, `/metas/:path` (GET + PATCH), `/preview`, `/synthesize`, `/synthesize/abort`, `/seed`, `/unlock`, `/config`, `/config/apply`, `/queue`, `/queue/clear`
 - **Phase-state machine** — per-meta `_phaseState` tracking `{ architect, builder, critic }` × `{ fresh, stale, pending, running, failed }`
 - **Built-in scheduler** — croner-based cron with adaptive backoff; picks one phase per tick across entire corpus
 - **Three-layer synthesis queue** — `current` (running phase) + `overrides` (explicit triggers) + `automatic` (scheduler candidates)
 - **Three-phase orchestration** — architect, builder, critic with surgical retry of failed phases
-- **Discovery via watcher** — filesystem-based meta discovery via `/walk` endpoint (no Qdrant dependency)
+- **Discovery via watcher** — filesystem-based meta discovery (no Qdrant dependency)
 - **Ownership tree** — hierarchical scoping with child meta rollup
 - **Cross-meta references** — `_crossRefs` declares relationships to other metas; referenced `_content` included as architect/builder context
 - **Archive management** — timestamped snapshots with configurable pruning
@@ -55,8 +55,8 @@ jeeves-meta service install --config /path/to/jeeves-meta/config.json
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/status` | Service health, queue state, dependency checks, phase-state summary |
-| GET | `/metas` | List metas with filtering and field projection |
-| GET | `/metas/:path` | Single meta detail with optional archive |
+| GET | `/metas` | List metas with summary stats and per-meta projection. Response includes `_phaseState` and `owedPhase` per meta. |
+| GET | `/metas/:path` | Full detail for a single meta, with optional archive history. Response includes `_phaseState` and `owedPhase`. |
 | GET | `/preview` | Dry-run: preview inputs for next synthesis |
 | POST | `/synthesize` | Enqueue synthesis (stalest or specific path) |
 | POST | `/synthesize/abort` | Abort the currently running synthesis |
@@ -66,7 +66,7 @@ jeeves-meta service install --config /path/to/jeeves-meta/config.json
 | POST | `/config/apply` | Apply a config patch (merge or replace) |
 | GET | `/queue` | Queue state: current (with phase), overrides, automatic, pending |
 | POST | `/queue/clear` | Remove all override queue entries |
-| PATCH | `/metas/:path` | Update user-settable reserved properties (`_steer`, `_emphasis`, `_depth`, `_crossRefs`, `_disabled`) |
+| PATCH | `/metas/:path` | Update user-settable reserved properties (`_steer`, `_emphasis`, `_depth`, `_crossRefs`, `_disabled`, `_architectTimeout`, `_builderTimeout`, `_criticTimeout`) |
 
 ## Configuration
 

--- a/packages/service/guides/architecture.md
+++ b/packages/service/guides/architecture.md
@@ -9,13 +9,13 @@ title: Architecture
 | Component | Responsibility |
 |-----------|---------------|
 | `Scheduler` | Croner-based cron, discovers stalest candidate, enqueues work |
-| `SynthesisQueue` | Single-threaded FIFO with priority support and deduplication |
+| `SynthesisQueue` | Three-layer queue (current + overrides + automatic) with deduplication |
 | `GatewayExecutor` | Spawns LLM sessions via gateway `/tools/invoke`, polls for completion |
 | `ProgressReporter` | Sends synthesis events to a channel via gateway `/tools/invoke` → `message` tool |
-| `RuleRegistrar` | Registers 3 virtual inference rules with watcher at startup |
+| `RuleRegistrar` | Registers 2 virtual inference rules with watcher at startup |
 | `HttpWatcherClient` | Watcher HTTP client with 3-retry exponential backoff |
-| Fastify server | 12 HTTP endpoints across 9 route modules |
-| Config hot-reload | `fs.watchFile` monitors config for schedule/reportChannel/logging changes |
+| Fastify server | 13 HTTP endpoints across 10 route modules |
+| Config hot-reload | `fs.watchFile` monitors config; hot-reloadable fields applied immediately, restart-required fields warn on change |
 | Shutdown handlers | SIGTERM/SIGINT → stop scheduler → release lock → close server |
 
 ## Service Architecture
@@ -26,15 +26,71 @@ title: Architecture
 
 ![Data Flow](./assets/data-flow.png)
 
+## Discovery
+
+The `discoverMetas()` function enumerates all `.meta/meta.json` files via the watcher's `POST /walk` endpoint (no Qdrant dependency). Paths are deduplicated by `.meta/` directory.
+
+The `buildOwnershipTree()` function constructs the parent/child hierarchy:
+
+1. Sort all meta paths by owner path length (shallowest first)
+2. For each node, find the closest ancestor meta (longest owner path match)
+3. Set `treeDepth = parentDepth + 1`; record bidirectional parent/child pointers
+
+A lightweight variant, `buildMinimalNode()`, creates a shallow tree (self + direct children only) for targeted synthesis — avoiding full-tree cost when a specific path is requested.
+
+### Scope Filtering
+
+A meta **owns** its parent directory and all descendants, except subtrees that contain their own `.meta/`. Child `.meta/meta.json` files ARE included as rollup inputs.
+
+`getDeltaFiles()` filters scope files locally by mtime since `_generatedAt`. On first run (no `_generatedAt`), all scope files are returned.
+
+## Auto-Seed
+
+The `autoSeedPass()` function is executed at the start of each scheduler tick (before discovery). It processes configured `autoSeed` rules:
+
+1. For each rule, walk the watcher with the rule's `match` glob
+2. Extract candidate directories (with optional `parentDepth` walking)
+3. Build a map of owner path → effective options (**last match wins** for all fields including timeouts)
+4. Filter out paths that already have a `.meta/` directory
+5. Create `.meta/meta.json` for each new candidate with the matched rule's `steer`, `crossRefs`, and timeout overrides
+
 ## Virtual Rules
 
-Three inference rules are registered with jeeves-watcher:
+Two inference rules are registered with jeeves-watcher:
 
 | Rule | Matches | Purpose |
 |------|---------|---------|
 | `meta-current` | `**/.meta/meta.json` | Index live synthesis with domain tags + extracted fields |
 | `meta-archive` | `**/.meta/archive/*.json` | Index archived snapshots |
-| `meta-config` | `**/jeeves-meta{.config.json,/config.json}` | Index the service configuration |
+
+## Config Hot-Reload
+
+The service monitors its config file via `fs.watchFile`. Fields are divided into two categories:
+
+**Restart-required** (warn on change, no live effect): `port`, `watcherUrl`, `gatewayUrl`, `gatewayApiKey`, `defaultArchitect`, `defaultCritic`.
+
+**Hot-reloadable** (applied immediately): `schedule` (cron reschedule), `logging.level` (Pino level change), and all remaining fields (`reportChannel`, `reportTarget`, `serverBaseUrl`, `watcherHealthIntervalMs`, `tier2ScanLimit`, `autoSeed`, `architectEvery`, `depthWeight`, `maxArchive`, `maxLines`, `architectTimeout`, `builderTimeout`, `criticTimeout`, `thinking`, `skipUnchanged`, `metaProperty`, `metaArchiveProperty`).
+
+## Phase-State Machine
+
+The `src/phaseState/` module implements the per-meta phase-state machine:
+
+| Module | Responsibility |
+|--------|---------------|
+| `derivePhaseState.ts` | Reconstruct `_phaseState` from legacy fields for backward compatibility |
+| `invalidate.ts` | Detect structural/steer/cross-ref changes and mark phases as stale |
+| `phaseTransitions.ts` | Pure functions for all state transitions (invalidation, success, failure, retry) |
+| `phaseScheduler.ts` | Corpus-wide candidate selection: critic > builder > architect, staleness tiebreak |
+
+## Two-Tier Scheduler
+
+The `src/scheduler/` module provides the croner-based tick driver. The `src/scheduling/` module provides staleness computation:
+
+| Module | Responsibility |
+|--------|---------------|
+| `scheduler/index.ts` | Croner cron, adaptive backoff, per-tick orchestration entry point |
+| `scheduling/staleness.ts` | `getStalenessSeconds()` with `MAX_STALENESS_SECONDS` cap (365 days) |
+| `scheduling/weightedFormula.ts` | `effectiveStaleness` formula: `actualStaleness × (normalizedDepth + 1) ^ (depthWeight × emphasis)` |
 
 ## Port Allocation
 

--- a/packages/service/guides/cli.md
+++ b/packages/service/guides/cli.md
@@ -13,7 +13,15 @@ Start the HTTP service.
 ```bash
 jeeves-meta start --config /path/to/config.json
 # or: jeeves-meta start -c /path/to/config.json
+# or: set JEEVES_META_CONFIG env var and omit --config
 ```
+
+The config path is resolved from `--config` / `-c` flag first, then falls back to the `JEEVES_META_CONFIG` environment variable.
+
+### Config Loading
+
+- **`@file:` indirection** — string config values starting with `@file:` are replaced with the contents of the referenced file, resolved relative to the config file's directory. Used for `defaultArchitect` and `defaultCritic` prompts.
+- **`${VAR}` substitution** — all string values undergo environment variable substitution. Unset variables cause a startup error.
 
 ## `jeeves-meta status`
 
@@ -42,6 +50,22 @@ Create a `.meta/` directory with a fresh `meta.json` (containing a new UUID `_id
 ## `jeeves-meta unlock <path>`
 
 Remove a `.lock` file from a meta entity. Use when a lock is stale due to a crashed synthesis.
+
+## `jeeves-meta abort`
+
+Abort the currently running synthesis and release its lock.
+
+## `jeeves-meta prune`
+
+Prune old archive snapshots beyond `maxArchive` for all metas.
+
+## `jeeves-meta queue list`
+
+Show the current queue state (three-layer model: current, overrides, automatic).
+
+## `jeeves-meta queue clear`
+
+Remove all pending items from the override queue.
 
 ## `jeeves-meta config [-c <config-path>]`
 

--- a/packages/service/guides/concepts.md
+++ b/packages/service/guides/concepts.md
@@ -51,6 +51,31 @@ Set `_disabled: true` on a meta to exclude it from automatic staleness schedulin
 
 The builder can populate an opaque `_state` field in `meta.json` to carry forward intermediate progress across cycles. On timeout (`SpawnTimeoutError`), the service attempts to salvage any advanced `_state` from partial output — preserving progress even when the full synthesis fails.
 
+## Per-Entity Timeout Overrides
+
+Each meta can override the global phase timeouts via reserved properties:
+
+- `_architectTimeout` — seconds (min 30), overrides `architectTimeout` config
+- `_builderTimeout` — seconds (min 30), overrides `builderTimeout` config
+- `_criticTimeout` — seconds (min 30), overrides `criticTimeout` config
+
+These are set via `meta_update` or `PATCH /metas/:path` and take effect on the next phase execution.
+
+## Token Tracking
+
+Each meta records token usage from LLM subprocess calls:
+
+- `_architectTokens` (integer) — token count from last architect subprocess call
+- `_builderTokens` (integer) — token count from last builder subprocess call
+- `_criticTokens` (integer) — token count from last critic subprocess call
+- `_architectTokensAvg` (number) — exponential moving average of architect token usage (decay 0.3)
+- `_builderTokensAvg` (number) — exponential moving average of builder token usage (decay 0.3)
+- `_criticTokensAvg` (number) — exponential moving average of critic token usage (decay 0.3)
+
+## Ancestor Builder Hash (`_ancestorBuilderHash`)
+
+SHA-256 hash of the parent meta's `_builder` text at the time of last synthesis. Observability only — no invalidation cascade is triggered by changes.
+
 ## Lock Staging
 
 Synthesis results are staged in a `.lock` file before being committed to `meta.json`. If the process crashes between staging and commit, `meta.json` is untouched — "never write worse."

--- a/packages/service/guides/configuration.md
+++ b/packages/service/guides/configuration.md
@@ -15,13 +15,13 @@ The service reads a JSON config file specified via `--config` flag or `JEEVES_ME
 | `gatewayApiKey` | string | — | Gateway authentication key |
 | `defaultArchitect` | string | (built-in) | Architect system prompt override. Supports `@file:` references. Omit to use built-in default. |
 | `defaultCritic` | string | (built-in) | Critic system prompt override. Supports `@file:` references. Omit to use built-in default. |
-| `architectEvery` | integer | `10` | Run architect every N cycles per meta |
-| `depthWeight` | number | `0.5` | Exponent for depth weighting in staleness formula |
-| `maxArchive` | integer | `20` | Maximum archive snapshots per meta |
-| `maxLines` | integer | `500` | Max context lines in subprocess prompts |
-| `architectTimeout` | integer | `180` | Architect subprocess timeout (seconds) |
-| `builderTimeout` | integer | `360` | Builder subprocess timeout (seconds) |
-| `criticTimeout` | integer | `240` | Critic subprocess timeout (seconds) |
+| `architectEvery` | integer | `10` | Run architect every N cycles per meta (min 1) |
+| `depthWeight` | number | `0.5` | Exponent for depth weighting in staleness formula (min 0) |
+| `maxArchive` | integer | `20` | Maximum archive snapshots per meta (min 1) |
+| `maxLines` | integer | `500` | Max context lines in subprocess prompts (min 50) |
+| `architectTimeout` | integer | `180` | Architect subprocess timeout in seconds (min 30) |
+| `builderTimeout` | integer | `360` | Builder subprocess timeout in seconds (min 60) |
+| `criticTimeout` | integer | `240` | Critic subprocess timeout in seconds (min 30) |
 | `thinking` | string | `"low"` | Thinking level for spawned sessions |
 | `skipUnchanged` | boolean | `true` | Skip candidates with no file changes |
 | `metaProperty` | object | `{ _meta: "current" }` | Watcher metadata for live meta.json files |
@@ -31,15 +31,31 @@ The service reads a JSON config file specified via `--config` flag or `JEEVES_ME
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `port` | integer | `1938` | HTTP listen port |
+| `port` | integer | `1938` | HTTP listen port (min 1, max 65535) |
 
 | `schedule` | string | `*/30 * * * *` | Cron expression for synthesis scheduling |
-| `reportChannel` | string | — | Gateway channel target for progress messages |
-| `watcherHealthIntervalMs` | number | `60000` | Periodic watcher health check interval in ms. 0 = disabled. |
+| `reportChannel` | string | — | Gateway channel name (e.g. `slack`). Legacy: also used as target if `reportTarget` is unset. |
+| `reportTarget` | string | — | Channel/user ID to send progress messages to |
 | `serverBaseUrl` | string | — | Base URL for entity links in progress reports (e.g. `http://myserver:1938`) |
-| `autoSeed` | array | `[]` | Auto-seed policy rules. Each rule: `{ match: string, steer?: string, crossRefs?: string[] }`. Glob patterns matched against `watcher.walk()` results. Rules evaluated in order; last match wins for steer/crossRefs. |
+| `watcherHealthIntervalMs` | integer | `60000` | Periodic watcher health check interval in ms (min 0). 0 = disabled. |
+| `tier2ScanLimit` | integer | `50` | Max all-fresh candidates to scan per tick in Tier 2 invalidation (min 1) |
+| `autoSeed` | array | `[]` | Auto-seed policy rules (see below). Rules evaluated in order; last match wins for steer/crossRefs. |
 | `logging.level` | string | `"info"` | Log level (trace/debug/info/warn/error) |
 | `logging.file` | string | — | Log file path |
+
+### Auto-Seed Rules
+
+Each rule in the `autoSeed` array has the shape:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `match` | string | — | Glob pattern matched against `watcher.walk()` results (required) |
+| `steer` | string | — | Steering prompt written as `_steer` in seeded `meta.json` |
+| `crossRefs` | string[] | — | Cross-ref owner paths written as `_crossRefs` |
+| `parentDepth` | integer | `0` | Walk up this many extra parent levels from the matched file's directory |
+| `architectTimeout` | integer | — | Per-category timeout override for architect phase (seconds, min 30) |
+| `builderTimeout` | integer | — | Per-category timeout override for builder phase (seconds, min 30) |
+| `criticTimeout` | integer | — | Per-category timeout override for critic phase (seconds, min 30) |
 
 ## Hot-Reload
 

--- a/packages/service/guides/index.md
+++ b/packages/service/guides/index.md
@@ -14,7 +14,7 @@ children:
 
 - [Concepts](./concepts.md) — Meta entities, ownership trees, synthesis cycles, cross-references, and progressive synthesis.
 - [Configuration](./configuration.md) — All config fields with defaults, hot-reload behavior, environment variable substitution, and prompt system.
-- [Orchestration](./orchestration.md) — The 13-step synthesis cycle, module structure, error handling, and lock staging.
+- [Orchestration](./orchestration.md) — Phase-state machine transitions, per-tick orchestration, error handling, and lock staging.
 - [Scheduling](./scheduling.md) — Weighted staleness formula, adaptive backoff, and queue processing.
 - [Architecture](./architecture.md) — Service components, data flow, virtual rules, and port allocation.
 - [CLI Reference](./cli.md) — All commands with usage.

--- a/packages/service/guides/orchestration.md
+++ b/packages/service/guides/orchestration.md
@@ -19,12 +19,17 @@ The `orchestratePhase()` function runs **one phase per tick** using the phase-st
 
 Each meta carries `_phaseState: { architect, builder, critic }` where each value is one of: `fresh`, `stale`, `pending`, `running`, `failed`.
 
+**Invariant:** At most one phase is `pending` or `running`, and it is the first non-fresh phase in pipeline order. When `enforceInvariant()` runs after every transition, stale phases that become the first non-fresh phase are promoted to `pending`; non-first `pending` phases are demoted to `stale`.
+
 **Key transitions:**
-- File change detected → `architect: stale` (cascade: `builder: pending`, `critic: pending`)
-- Architect success → `architect: fresh` (cascade: `builder: pending` if was stale)
-- Builder success → `builder: fresh`, `critic: pending`
-- Critic success → `critic: fresh`; if all three fresh → full-cycle complete (archive + increment `_synthesisCount`)
+- Architect invalidated → `architect: pending` (downstream `fresh` phases become `stale`; already non-fresh phases keep their state). Triggers: structure hash change, steer change, cross-refs declaration change, `_synthesisCount` ≥ `architectEvery`, or first run (no `_builder`).
+- **Progressive metas** (`_state` present): structure changes invalidate builder instead of architect, since the cursor handles incremental processing.
+- Builder invalidated (cross-ref content change, when architect is fresh and not first run) → `builder: pending`; `critic` → `stale` if was `fresh`. When architect is not fresh, builder stays `stale` (not promoted to `pending`).
+- Architect success → `architect: fresh`, `builder: pending` (or stays `failed`), `critic` → `stale` if was `fresh`. Also resets `_synthesisCount` to 0.
+- Builder success → `builder: fresh`, `critic: pending` (or stays `failed`). Architect state preserved.
+- Critic success → `critic: fresh`; if all three fresh → full-cycle complete (archive via `createSnapshot()`, `pruneArchive()`, then increment `_synthesisCount`)
 - Any phase failure → that phase: `failed`; other phases untouched (surgical retry)
+- Phase selected for execution → transitions to `running` before executor spawns
 - Next tick → `failed` phases promoted to `pending` for auto-retry
 
 ### Module Structure

--- a/packages/service/guides/orchestration.md
+++ b/packages/service/guides/orchestration.md
@@ -37,9 +37,7 @@ Each meta carries `_phaseState: { architect, builder, critic }` where each value
 | Module | Responsibility |
 |--------|---------------|
 | `orchestratePhase.ts` | Per-tick driver: discover → derive → select → execute one phase |
-| `runPhase.ts` | Per-phase executors: `runArchitect`, `runBuilder`, `runCritic` |
-| `synthesizeNode.ts` | Legacy single-node full pipeline (retained for compatibility) |
-| `finalizeCycle.ts` | Legacy lock-staged writes |
+| `runPhase.ts` | Per-phase executors: `runArchitect`, `runBuilder`, `runCritic`; lock-staged persistence via `persistPhaseState()` |
 
 ### Error Handling
 

--- a/packages/service/guides/scheduling.md
+++ b/packages/service/guides/scheduling.md
@@ -10,7 +10,7 @@ title: Scheduling
 effectiveStaleness = actualStaleness × (normalizedDepth + 1) ^ (depthWeight × emphasis)
 ```
 
-- **actualStaleness**: seconds since `_generatedAt` (Infinity if never synthesized)
+- **actualStaleness**: seconds since `_generatedAt` (capped at `MAX_STALENESS_SECONDS` = 31 536 000 seconds / 365 days if never synthesized or extremely stale). Bounding prevents `Infinity × depthFactor = Infinity` for all depths, which would make staleness-based prioritization meaningless.
 - **normalizedDepth**: tree depth shifted so minimum = 0
 - **depthWeight**: config exponent (default 0.5). Set to 0 for pure staleness ordering
 - **emphasis**: per-meta `_emphasis` multiplier (default 1). Higher = updates more often
@@ -37,9 +37,11 @@ Each tick:
 2. Discover all metas via watcher `/walk` endpoint
 3. **Derive phase state** — reconstruct `_phaseState` for legacy metas without it
 4. **Auto-retry** — promote `failed` → `pending` for all failed phases
-5. **Select phase candidate** — pick the highest-priority owed phase (critic > builder > architect, staleness tiebreak)
-6. Enqueue the selected phase (if no candidates, increase backoff and return)
-7. Check watcher uptime for restart detection → re-register virtual rules if needed
+5. **Tier 1 cheap invalidation** (no I/O) — for metas with persisted `_phaseState`, check `_synthesisCount >= architectEvery` and bump architect to `pending` if needed
+6. **Select phase candidate** — pick the highest-priority owed phase (critic > builder > architect, staleness tiebreak)
+7. **Tier 2 deep invalidation** (with I/O) — for all-fresh metas (up to `tier2ScanLimit`, default 50), walk scope for structure hash changes and check steer/crossRefs changes against archive to detect invalidation
+8. Enqueue the selected phase (if no candidates, increase backoff and return)
+9. Check watcher uptime for restart detection → re-register virtual rules if needed
 
 ## Disabled Metas
 

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/karmaniverous/jeeves-meta/issues"
   },
   "dependencies": {
-    "@karmaniverous/jeeves": "^0.5.10",
+    "@karmaniverous/jeeves": "^0.5.11",
     "@karmaniverous/jeeves-meta-core": "^0.1.2",
     "commander": "^14",
     "croner": "^10",
@@ -19,19 +19,19 @@
   },
   "description": "Fastify HTTP service for the Jeeves Meta synthesis engine",
   "devDependencies": {
-    "@dotenvx/dotenvx": "^1.65.0",
+    "@dotenvx/dotenvx": "^1.69.1",
     "@rollup/plugin-commonjs": "^29.0.2",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-typescript": "^12.3.0",
-    "@types/node": "^25.7.0",
-    "@vitest/coverage-v8": "^4.1.6",
+    "@types/node": "^25.9.1",
+    "@vitest/coverage-v8": "^4.1.7",
     "cross-env": "^10.1.0",
     "release-it": "^20.0.1",
-    "rollup": "^4.60.3",
+    "rollup": "^4.60.4",
     "rollup-plugin-copy": "^3.5.0",
     "tslib": "^2.8.1",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.7"
   },
   "engines": {
     "node": ">=22"

--- a/packages/service/src/phaseState/index.ts
+++ b/packages/service/src/phaseState/index.ts
@@ -9,7 +9,7 @@ export {
   type ArchitectInvalidator,
   computeInvalidation,
   type InvalidationResult,
-  type StalenessInputs,
+  type InputStatus,
 } from './invalidate.js';
 export {
   buildPhaseCandidates,

--- a/packages/service/src/phaseState/index.ts
+++ b/packages/service/src/phaseState/index.ts
@@ -8,8 +8,8 @@ export { type DerivationInputs, derivePhaseState } from './derivePhaseState.js';
 export {
   type ArchitectInvalidator,
   computeInvalidation,
-  type InvalidationResult,
   type InputStatus,
+  type InvalidationResult,
 } from './invalidate.js';
 export {
   buildPhaseCandidates,

--- a/packages/service/src/phaseState/invalidate.test.ts
+++ b/packages/service/src/phaseState/invalidate.test.ts
@@ -261,6 +261,7 @@ describe('computeInvalidation', () => {
     expect(result.architectInvalidators).not.toContain('architectEvery');
     expect(result.phaseState).toEqual(freshPhaseState);
     expect(result.inputStatus.architectChanged).toBe(true);
+    expect(result.inputStatus.criticChanged).toBe(false);
   });
 
   // ── 8. Prompt staleness — critic snapshot differs ──────────────
@@ -286,6 +287,7 @@ describe('computeInvalidation', () => {
     expect(result.architectInvalidators).not.toContain('architectEvery');
     expect(result.phaseState).toEqual(freshPhaseState);
     expect(result.inputStatus.architectChanged).toBe(false);
+    expect(result.inputStatus.criticChanged).toBe(true);
   });
 
   // ── 9. First run (no _builder) ─────────────────────────────────
@@ -428,9 +430,9 @@ describe('computeInvalidation', () => {
 
     const result = await computeInvalidation(meta, SCOPE_A, makeConfig(), node);
 
-    // Should start with default fresh and remain unchanged
-    expect(result.phaseState).toBeDefined();
-    expect(result.phaseState.architect).toBeDefined();
+    // No changes detected — default phase state should remain fully fresh
+    expect(result.phaseState).toEqual(freshPhaseState);
+    expect(result.architectInvalidators).toEqual([]);
   });
 
   it('treats missing archive with non-empty crossRefs as declaration change', async () => {
@@ -465,6 +467,7 @@ describe('computeInvalidation', () => {
     // No change — snapshots match
     expect(meta._synthesisCount).toBe(3);
     expect(result.inputStatus.architectChanged).toBe(false);
+    expect(result.inputStatus.criticChanged).toBe(false);
     expect(result.architectInvalidators).not.toContain('architectEvery');
   });
 
@@ -482,6 +485,50 @@ describe('computeInvalidation', () => {
     // isPromptStale returns false when snapshot is undefined
     expect(meta._synthesisCount).toBe(3);
     expect(result.inputStatus.architectChanged).toBe(false);
+    expect(result.inputStatus.criticChanged).toBe(false);
+  });
+
+  it('uses DEFAULT prompts when config overrides are undefined', async () => {
+    const meta: MetaJson = {
+      _phaseState: { ...freshPhaseState },
+      _structureHash: HASH_A,
+      _builder: 'brief',
+      _architect: 'default-architect-prompt', // matches DEFAULT_ARCHITECT_PROMPT mock
+      _critic: 'default-critic-prompt',       // matches DEFAULT_CRITIC_PROMPT mock
+      _synthesisCount: 3,
+    };
+
+    // Config with undefined prompts — should fall back to DEFAULT constants
+    const result = await computeInvalidation(
+      meta,
+      SCOPE_A,
+      makeConfig({ defaultArchitect: undefined, defaultCritic: undefined }),
+      node,
+    );
+
+    // Snapshots match the DEFAULT prompts, so no staleness
+    expect(result.inputStatus.architectChanged).toBe(false);
+    expect(result.inputStatus.criticChanged).toBe(false);
+  });
+
+  it('treats undefined _synthesisCount as 0 for architectEvery', async () => {
+    const meta: MetaJson = {
+      _phaseState: { ...freshPhaseState },
+      _structureHash: HASH_A,
+      _builder: 'brief',
+      // _synthesisCount intentionally omitted (undefined)
+    };
+
+    const result = await computeInvalidation(
+      meta,
+      SCOPE_A,
+      makeConfig({ architectEvery: 10 }),
+      node,
+    );
+
+    // undefined ?? 0 = 0, which is < 10, so architectEvery should NOT trigger
+    expect(result.architectInvalidators).not.toContain('architectEvery');
+    expect(result.phaseState).toEqual(freshPhaseState);
   });
 
   it('cross-ref content change does not invalidate builder on first run', async () => {

--- a/packages/service/src/phaseState/invalidate.test.ts
+++ b/packages/service/src/phaseState/invalidate.test.ts
@@ -8,7 +8,7 @@
  * @module phaseState/invalidate.test
  */
 
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -24,7 +24,7 @@ import { computeInvalidation } from './invalidate.js';
 let mockArchive: MetaJson | null = null;
 
 vi.mock('../archive/index.js', () => ({
-  readLatestArchive: vi.fn(async () => mockArchive),
+  readLatestArchive: vi.fn(() => mockArchive),
 }));
 
 // ── Mock DEFAULT prompts to stable strings ──────────────────────────
@@ -40,7 +40,6 @@ const SCOPE_A = ['file-a.md', 'file-b.md'];
 const SCOPE_B = ['file-a.md', 'file-b.md', 'file-c.md'];
 
 const HASH_A = computeStructureHash(SCOPE_A);
-const HASH_B = computeStructureHash(SCOPE_B);
 
 function makeConfig(overrides?: Partial<MetaConfig>): MetaConfig {
   return {

--- a/packages/service/src/phaseState/invalidate.test.ts
+++ b/packages/service/src/phaseState/invalidate.test.ts
@@ -121,9 +121,9 @@ describe('computeInvalidation', () => {
 
     expect(result.phaseState).toEqual(freshPhaseState);
     expect(result.architectInvalidators).toEqual([]);
-    expect(result.stalenessInputs.steerChanged).toBe(false);
-    expect(result.stalenessInputs.crossRefsDeclChanged).toBe(false);
-    expect(result.stalenessInputs.crossRefContentChanged).toBe(false);
+    expect(result.inputStatus.steerChanged).toBe(false);
+    expect(result.inputStatus.crossRefsDeclChanged).toBe(false);
+    expect(result.inputStatus.crossRefContentChanged).toBe(false);
   });
 
   // ── 2. Structure hash mismatch (non-progressive) ───────────────
@@ -214,7 +214,7 @@ describe('computeInvalidation', () => {
     const result = await computeInvalidation(meta, SCOPE_A, makeConfig(), node);
 
     expect(result.architectInvalidators).toContain('_crossRefs');
-    expect(result.stalenessInputs.crossRefsDeclChanged).toBe(true);
+    expect(result.inputStatus.crossRefsDeclChanged).toBe(true);
     expect(result.phaseState.architect).toBe('pending');
   });
 
@@ -241,7 +241,7 @@ describe('computeInvalidation', () => {
 
   // ── 7. Prompt staleness — architect snapshot differs ───────────
 
-  it('bumps synthesisCount to architectEvery when architect prompt is stale', async () => {
+  it('does not invalidate architect when architect prompt is stale (#163)', async () => {
     const meta: MetaJson = {
       _phaseState: { ...freshPhaseState },
       _structureHash: HASH_A,
@@ -257,17 +257,16 @@ describe('computeInvalidation', () => {
       node,
     );
 
-    // Soft invalidation signals synthesisCountOverride without mutating meta,
-    // which triggers the architectEvery invalidator
-    expect(meta._synthesisCount).toBe(3); // original value unchanged
-    expect(result.synthesisCountOverride).toBe(10);
-    expect(result.architectInvalidators).toContain('architectEvery');
-    expect(result.stalenessInputs.architectChanged).toBe(true);
+    // Prompt staleness is informational only — no cascade, no storm
+    expect(meta._synthesisCount).toBe(3); // unchanged
+    expect(result.architectInvalidators).not.toContain('architectEvery');
+    expect(result.phaseState).toEqual(freshPhaseState);
+    expect(result.inputStatus.architectChanged).toBe(true);
   });
 
   // ── 8. Prompt staleness — critic snapshot differs ──────────────
 
-  it('bumps synthesisCount to architectEvery when critic prompt is stale', async () => {
+  it('does not invalidate architect when critic prompt is stale (#163)', async () => {
     const meta: MetaJson = {
       _phaseState: { ...freshPhaseState },
       _structureHash: HASH_A,
@@ -283,10 +282,11 @@ describe('computeInvalidation', () => {
       node,
     );
 
-    expect(meta._synthesisCount).toBe(2); // original value unchanged
-    expect(result.synthesisCountOverride).toBe(10);
-    expect(result.architectInvalidators).toContain('architectEvery');
-    expect(result.stalenessInputs.architectChanged).toBe(false);
+    // Prompt staleness is informational only — no cascade, no storm
+    expect(meta._synthesisCount).toBe(2); // unchanged
+    expect(result.architectInvalidators).not.toContain('architectEvery');
+    expect(result.phaseState).toEqual(freshPhaseState);
+    expect(result.inputStatus.architectChanged).toBe(false);
   });
 
   // ── 9. First run (no _builder) ─────────────────────────────────
@@ -337,7 +337,7 @@ describe('computeInvalidation', () => {
       archiveCrossRefContent,
     );
 
-    expect(result.stalenessInputs.crossRefContentChanged).toBe(true);
+    expect(result.inputStatus.crossRefContentChanged).toBe(true);
     expect(result.architectInvalidators).toEqual([]);
     expect(result.phaseState.architect).toBe('fresh');
     expect(result.phaseState.builder).toBe('pending');
@@ -377,7 +377,7 @@ describe('computeInvalidation', () => {
 
     // Architect is invalidated (steer change)
     expect(result.architectInvalidators).toContain('steer');
-    expect(result.stalenessInputs.crossRefContentChanged).toBe(true);
+    expect(result.inputStatus.crossRefContentChanged).toBe(true);
     // Builder invalidation is via architect cascade, not separately applied
     expect(result.phaseState.architect).toBe('pending');
     expect(result.phaseState.builder).toBe('stale');
@@ -446,7 +446,7 @@ describe('computeInvalidation', () => {
 
     const result = await computeInvalidation(meta, SCOPE_A, makeConfig(), node);
 
-    expect(result.stalenessInputs.crossRefsDeclChanged).toBe(true);
+    expect(result.inputStatus.crossRefsDeclChanged).toBe(true);
   });
 
   it('does not treat matching prompt snapshots as stale', async () => {
@@ -461,10 +461,9 @@ describe('computeInvalidation', () => {
 
     const result = await computeInvalidation(meta, SCOPE_A, makeConfig(), node);
 
-    // No bump — snapshots match
+    // No change — snapshots match
     expect(meta._synthesisCount).toBe(3);
-    expect(result.synthesisCountOverride).toBeNull();
-    expect(result.stalenessInputs.architectChanged).toBe(false);
+    expect(result.inputStatus.architectChanged).toBe(false);
     expect(result.architectInvalidators).not.toContain('architectEvery');
   });
 
@@ -481,8 +480,7 @@ describe('computeInvalidation', () => {
 
     // isPromptStale returns false when snapshot is undefined
     expect(meta._synthesisCount).toBe(3);
-    expect(result.synthesisCountOverride).toBeNull();
-    expect(result.stalenessInputs.architectChanged).toBe(false);
+    expect(result.inputStatus.architectChanged).toBe(false);
   });
 
   it('cross-ref content change does not invalidate builder on first run', async () => {
@@ -510,7 +508,7 @@ describe('computeInvalidation', () => {
     // First run triggers architect invalidation; builder cascade comes from
     // architect, not from cross-ref content change
     expect(result.phaseState.architect).toBe('pending');
-    expect(result.stalenessInputs.crossRefContentChanged).toBe(true);
+    expect(result.inputStatus.crossRefContentChanged).toBe(true);
   });
 
   it('returns correct structureHash in result', async () => {
@@ -542,6 +540,6 @@ describe('computeInvalidation', () => {
       // no crossRefMetas or archiveCrossRefContent
     );
 
-    expect(result.stalenessInputs.crossRefContentChanged).toBe(false);
+    expect(result.inputStatus.crossRefContentChanged).toBe(false);
   });
 });

--- a/packages/service/src/phaseState/invalidate.test.ts
+++ b/packages/service/src/phaseState/invalidate.test.ts
@@ -190,7 +190,7 @@ describe('computeInvalidation', () => {
     const result = await computeInvalidation(meta, SCOPE_A, makeConfig(), node);
 
     expect(result.architectInvalidators).toContain('steer');
-    expect(result.steerChanged).toBe(true);
+    expect(result.inputStatus.steerChanged).toBe(true);
     expect(result.phaseState.architect).toBe('pending');
   });
 

--- a/packages/service/src/phaseState/invalidate.test.ts
+++ b/packages/service/src/phaseState/invalidate.test.ts
@@ -302,6 +302,7 @@ describe('computeInvalidation', () => {
 
     const result = await computeInvalidation(meta, SCOPE_A, makeConfig(), node);
 
+    expect(result.architectInvalidators).toContain('firstRun');
     expect(result.phaseState.architect).toBe('pending');
     expect(result.phaseState.builder).toBe('stale');
     expect(result.phaseState.critic).toBe('stale');
@@ -446,6 +447,7 @@ describe('computeInvalidation', () => {
     const result = await computeInvalidation(meta, SCOPE_A, makeConfig(), node);
 
     expect(result.inputStatus.crossRefsDeclChanged).toBe(true);
+    expect(result.architectInvalidators).toContain('firstRun');
   });
 
   it('does not treat matching prompt snapshots as stale', async () => {
@@ -506,6 +508,7 @@ describe('computeInvalidation', () => {
 
     // First run triggers architect invalidation; builder cascade comes from
     // architect, not from cross-ref content change
+    expect(result.architectInvalidators).toContain('firstRun');
     expect(result.phaseState.architect).toBe('pending');
     expect(result.inputStatus.crossRefContentChanged).toBe(true);
   });
@@ -520,7 +523,7 @@ describe('computeInvalidation', () => {
 
     const result = await computeInvalidation(meta, SCOPE_A, makeConfig(), node);
 
-    expect(result.structureHash).toBe(HASH_A);
+    expect(result.inputStatus.structureHash).toBe(HASH_A);
   });
 
   it('no cross-ref content change when maps are not provided', async () => {

--- a/packages/service/src/phaseState/invalidate.ts
+++ b/packages/service/src/phaseState/invalidate.ts
@@ -35,16 +35,16 @@ export type ArchitectInvalidator =
   | 'structureHash'
   | 'steer'
   | '_crossRefs'
+  | 'firstRun'
   | 'architectEvery';
 
-/** Staleness inputs for a meta (exposed in /preview). */
+/** Informational input status for a meta (exposed in /preview). */
 export interface InputStatus {
   structureHash: string;
   steerChanged: boolean;
   architectChanged: boolean;
   criticChanged: boolean;
   crossRefsDeclChanged: boolean;
-  scopeMtimeMax: string | null;
   crossRefContentChanged: boolean;
 }
 
@@ -53,7 +53,6 @@ export interface InvalidationResult {
   phaseState: PhaseState;
   architectInvalidators: ArchitectInvalidator[];
   inputStatus: InputStatus;
-  structureHash: string;
 }
 
 /**
@@ -134,18 +133,13 @@ export async function computeInvalidation(
     architectInvalidators.push('architectEvery');
   }
 
-  // First-run check: no _builder means architect must run
-  const firstRun = !meta._builder;
+  if (!meta._builder) architectInvalidators.push('firstRun');
 
-  if (architectInvalidators.length > 0 || firstRun) {
+  if (architectInvalidators.length > 0) {
     phaseState = invalidateArchitect(phaseState);
   }
 
   // ── Builder-level inputs ──
-  // Scope file mtime check — if any file newer than _generatedAt
-  const scopeMtimeMax: string | null = null;
-  // Note: actual mtime check is done by the caller or via isStale;
-  // here we just detect cross-ref content changes for the cascade.
 
   // Cross-ref _content change (builder-invalidating)
   let crossRefContentChanged = false;
@@ -162,11 +156,7 @@ export async function computeInvalidation(
   // Builder invalidation: scope mtime advances OR cross-ref content changes
   // Scope mtime is already captured by the staleness detection in the caller;
   // here we apply cross-ref content change cascade.
-  if (
-    crossRefContentChanged &&
-    architectInvalidators.length === 0 &&
-    !firstRun
-  ) {
+  if (crossRefContentChanged && architectInvalidators.length === 0) {
     phaseState = invalidateBuilder(phaseState);
   }
 
@@ -179,9 +169,7 @@ export async function computeInvalidation(
       architectChanged,
       criticChanged,
       crossRefsDeclChanged,
-      scopeMtimeMax,
       crossRefContentChanged,
     },
-    structureHash,
   };
 }

--- a/packages/service/src/phaseState/invalidate.ts
+++ b/packages/service/src/phaseState/invalidate.ts
@@ -54,7 +54,6 @@ export interface InvalidationResult {
   architectInvalidators: ArchitectInvalidator[];
   inputStatus: InputStatus;
   structureHash: string;
-  steerChanged: boolean;
 }
 
 /**
@@ -184,6 +183,5 @@ export async function computeInvalidation(
       crossRefContentChanged,
     },
     structureHash,
-    steerChanged,
   };
 }

--- a/packages/service/src/phaseState/invalidate.ts
+++ b/packages/service/src/phaseState/invalidate.ts
@@ -20,7 +20,8 @@ import { invalidateArchitect, invalidateBuilder } from './phaseTransitions.js';
 
 /**
  * Check whether a persisted prompt snapshot mismatches the currently-resolved prompt.
- * Returns true when soft invalidation should bump _synthesisCount.
+ * Returns true when the snapshot exists and differs from the resolved prompt.
+ * This is informational only — it does NOT trigger invalidation.
  */
 function isPromptStale(
   snapshot: string | undefined,
@@ -37,10 +38,11 @@ export type ArchitectInvalidator =
   | 'architectEvery';
 
 /** Staleness inputs for a meta (exposed in /preview). */
-export interface StalenessInputs {
+export interface InputStatus {
   structureHash: string;
   steerChanged: boolean;
   architectChanged: boolean;
+  criticChanged: boolean;
   crossRefsDeclChanged: boolean;
   scopeMtimeMax: string | null;
   crossRefContentChanged: boolean;
@@ -50,11 +52,9 @@ export interface StalenessInputs {
 export interface InvalidationResult {
   phaseState: PhaseState;
   architectInvalidators: ArchitectInvalidator[];
-  stalenessInputs: StalenessInputs;
+  inputStatus: InputStatus;
   structureHash: string;
   steerChanged: boolean;
-  /** When non-null, callers that persist should set meta._synthesisCount to this value. */
-  synthesisCountOverride: number | null;
 }
 
 /**
@@ -93,10 +93,13 @@ export async function computeInvalidation(
     Boolean(latestArchive),
   );
 
-  // Soft invalidation: compare prompt snapshots against currently-resolved prompts.
-  // On mismatch, signal that _synthesisCount should be bumped to architectEvery so
-  // architect runs on the next natural cycle — but do NOT hard-cascade via
-  // invalidateArchitect and do NOT mutate the input meta.
+  // Prompt staleness detection: compare persisted prompt snapshots against
+  // currently-resolved prompts.  This is INFORMATIONAL ONLY — reported via
+  // inputStatus so /preview can surface it, but it must NEVER feed into
+  // the invalidation cascade.  When a meta naturally reaches architectEvery
+  // through real builder cycles, architect runs with the current prompt and
+  // the snapshot updates.  Coupling prompt changes to invalidation causes a
+  // corpus-wide synthesis storm (see #163).
   const architectChanged = isPromptStale(
     meta._architect,
     config.defaultArchitect ?? DEFAULT_ARCHITECT_PROMPT,
@@ -105,10 +108,7 @@ export async function computeInvalidation(
     meta._critic,
     config.defaultCritic ?? DEFAULT_CRITIC_PROMPT,
   );
-  const synthesisCountOverride =
-    architectChanged || criticChanged ? config.architectEvery : null;
-  const effectiveSynthesisCount =
-    synthesisCountOverride ?? meta._synthesisCount ?? 0;
+  const effectiveSynthesisCount = meta._synthesisCount ?? 0;
 
   // _crossRefs declaration change
   const currentRefs = (meta._crossRefs ?? []).slice().sort().join(',');
@@ -174,16 +174,16 @@ export async function computeInvalidation(
   return {
     phaseState,
     architectInvalidators,
-    stalenessInputs: {
+    inputStatus: {
       structureHash,
       steerChanged,
       architectChanged,
+      criticChanged,
       crossRefsDeclChanged,
       scopeMtimeMax,
       crossRefContentChanged,
     },
     structureHash,
     steerChanged,
-    synthesisCountOverride,
   };
 }

--- a/packages/service/src/phaseState/phaseTransitions.ts
+++ b/packages/service/src/phaseState/phaseTransitions.ts
@@ -60,7 +60,7 @@ export function enforceInvariant(state: PhaseState): PhaseState {
 
 /**
  * Architect invalidated: architect → pending; builder, critic → stale.
- * Triggers: _structureHash change, _steer change, _architect change,
+ * Triggers: first run, _structureHash change, _steer change,
  * _crossRefs declaration change, _synthesisCount \>= architectEvery.
  */
 export function invalidateArchitect(state: PhaseState): PhaseState {

--- a/packages/service/src/routes/preview.ts
+++ b/packages/service/src/routes/preview.ts
@@ -74,8 +74,7 @@ export function registerPreviewRoute(
       targetNode,
     );
     const { architectInvalidators, inputStatus, phaseState } = invalidation;
-    const architectTriggered =
-      architectInvalidators.length > 0 || !meta._builder;
+    const architectTriggered = architectInvalidators.length > 0;
 
     // Delta files
     const deltaFiles = getDeltaFiles(meta._generatedAt, scopeFiles);
@@ -110,7 +109,9 @@ export function registerPreviewRoute(
       architectWillRun: architectTriggered,
       architectReason:
         [
-          ...(!meta._builder ? ['no cached builder (first run)'] : []),
+          ...(architectInvalidators.includes('firstRun')
+            ? ['no cached builder (first run)']
+            : []),
           ...(architectInvalidators.includes('structureHash')
             ? ['structure changed']
             : []),

--- a/packages/service/src/routes/preview.ts
+++ b/packages/service/src/routes/preview.ts
@@ -12,7 +12,6 @@ import { normalizePath } from '../normalizePath.js';
 import {
   buildPhaseCandidates,
   computeInvalidation,
-  derivePhaseState,
   getOwedPhase,
   getPriorityBand,
   selectPhaseCandidate,
@@ -74,18 +73,9 @@ export function registerPreviewRoute(
       config,
       targetNode,
     );
-    const { architectInvalidators, inputStatus } = invalidation;
-    const { structureHash } = invalidation;
-    const structureChanged = structureHash !== meta._structureHash;
-    const { steerChanged } = invalidation;
-    const { crossRefsDeclChanged } = inputStatus;
-
-    const effectiveSynthesisCount = meta._synthesisCount ?? 0;
+    const { architectInvalidators, inputStatus, phaseState } = invalidation;
     const architectTriggered =
-      !meta._builder ||
-      structureChanged ||
-      steerChanged ||
-      effectiveSynthesisCount >= config.architectEvery;
+      architectInvalidators.length > 0 || !meta._builder;
 
     // Delta files
     const deltaFiles = getDeltaFiles(meta._generatedAt, scopeFiles);
@@ -108,13 +98,6 @@ export function registerPreviewRoute(
       config.depthWeight,
     );
 
-    // Phase state
-    const phaseState = derivePhaseState(meta, {
-      structureChanged,
-      steerChanged,
-      crossRefsChanged: crossRefsDeclChanged,
-      architectEvery: config.architectEvery,
-    });
     const owedPhase = getOwedPhase(phaseState);
     const priorityBand = getPriorityBand(phaseState);
 
@@ -128,9 +111,14 @@ export function registerPreviewRoute(
       architectReason:
         [
           ...(!meta._builder ? ['no cached builder (first run)'] : []),
-          ...(structureChanged ? ['structure changed'] : []),
-          ...(steerChanged ? ['steer changed'] : []),
-          ...(effectiveSynthesisCount >= config.architectEvery
+          ...(architectInvalidators.includes('structureHash')
+            ? ['structure changed']
+            : []),
+          ...(architectInvalidators.includes('steer') ? ['steer changed'] : []),
+          ...(architectInvalidators.includes('_crossRefs')
+            ? ['cross-refs changed']
+            : []),
+          ...(architectInvalidators.includes('architectEvery')
             ? ['periodic refresh']
             : []),
         ].join(', ') || 'not triggered',

--- a/packages/service/src/routes/preview.ts
+++ b/packages/service/src/routes/preview.ts
@@ -74,16 +74,13 @@ export function registerPreviewRoute(
       config,
       targetNode,
     );
-    const { architectInvalidators, stalenessInputs } = invalidation;
+    const { architectInvalidators, inputStatus } = invalidation;
     const { structureHash } = invalidation;
     const structureChanged = structureHash !== meta._structureHash;
     const { steerChanged } = invalidation;
-    const { crossRefsDeclChanged } = stalenessInputs;
+    const { crossRefsDeclChanged } = inputStatus;
 
-    // Use invalidation result for architectEvery check since computeInvalidation
-    // accounts for prompt staleness without mutating meta._synthesisCount.
-    const effectiveSynthesisCount =
-      invalidation.synthesisCountOverride ?? meta._synthesisCount ?? 0;
+    const effectiveSynthesisCount = meta._synthesisCount ?? 0;
     const architectTriggered =
       !meta._builder ||
       structureChanged ||
@@ -150,7 +147,7 @@ export function registerPreviewRoute(
       owedPhase,
       priorityBand,
       phaseState,
-      stalenessInputs,
+      inputStatus,
       architectInvalidators,
     };
   });

--- a/packages/service/src/routes/synthesize.ts
+++ b/packages/service/src/routes/synthesize.ts
@@ -72,9 +72,7 @@ export function registerSynthesizeRoute(
               structureHash: invalidation.structureHash,
             },
             invalidation.phaseState,
-            invalidation.synthesisCountOverride !== null
-              ? { _synthesisCount: invalidation.synthesisCountOverride }
-              : {},
+            {},
           );
           cache.invalidate();
         }

--- a/packages/service/src/routes/synthesize.ts
+++ b/packages/service/src/routes/synthesize.ts
@@ -69,7 +69,7 @@ export function registerSynthesizeRoute(
               metaPath: targetPath,
               current: meta,
               config,
-              structureHash: invalidation.structureHash,
+              structureHash: invalidation.inputStatus.structureHash,
             },
             invalidation.phaseState,
             {},

--- a/packages/service/src/scheduler/index.ts
+++ b/packages/service/src/scheduler/index.ts
@@ -289,7 +289,7 @@ export class Scheduler {
               metaPath: t2.node.metaPath,
               current: currentMeta,
               config: this.config,
-              structureHash: result.structureHash,
+              structureHash: result.inputStatus.structureHash,
             },
             result.phaseState,
             {},
@@ -309,7 +309,7 @@ export class Scheduler {
             metaPath: t2.node.metaPath,
             current: currentMeta,
             config: this.config,
-            structureHash: result.structureHash,
+            structureHash: result.inputStatus.structureHash,
           },
           result.phaseState,
           {

--- a/packages/service/src/scheduler/index.ts
+++ b/packages/service/src/scheduler/index.ts
@@ -292,9 +292,7 @@ export class Scheduler {
               structureHash: result.structureHash,
             },
             result.phaseState,
-            result.synthesisCountOverride !== null
-              ? { _synthesisCount: result.synthesisCountOverride }
-              : {},
+            {},
           );
           this.cache.invalidate();
 
@@ -316,9 +314,6 @@ export class Scheduler {
           result.phaseState,
           {
             _generatedAt: new Date().toISOString(),
-            ...(result.synthesisCountOverride !== null
-              ? { _synthesisCount: result.synthesisCountOverride }
-              : {}),
           },
         );
         dirty = true;


### PR DESCRIPTION
## Summary

Decouples prompt staleness from the invalidation cascade to prevent corpus-wide synthesis storms when architect/critic prompts change. Includes full DRY/SOLID refactoring of the invalidation result interface and preview route, plus comprehensive docs and test sync.

## Bug Fix (#163)

**Problem:** When defaultArchitect or defaultCritic config prompts differed from persisted _architect/_critic snapshots, computeInvalidation bumped _synthesisCount to rchitectEvery, triggering architect invalidation on *every* meta in the corpus — a synthesis storm.

**Fix:** Prompt staleness is now **informational only**. The rchitectChanged and criticChanged flags are reported in inputStatus (for /preview observability) but never feed into the invalidation cascade. Prompts update naturally when a meta reaches rchitectEvery through real builder cycles.

## Refactoring

- **Removed synthesisCountOverride** from InvalidationResult and all callers (synthesize route, scheduler)
- **Removed duplicate structureHash** from InvalidationResult top level — callers use inputStatus.structureHash
- **Removed duplicate steerChanged** from InvalidationResult top level — callers use inputStatus.steerChanged
- **Removed dead scopeMtimeMax** field from InputStatus (always null, never populated)
- **Added irstRun as an ArchitectInvalidator** — encapsulates all trigger reasons in a single array, eliminating special-case \|| !meta._builder\ checks
- **Added criticChanged** to \InputStatus\ (informational parity with \rchitectChanged\)
- **Renamed StalenessInputs → InputStatus** per review feedback (avoids 'stale' connotation for informational fields)
- **Simplified preview route** — uses \invalidation.phaseState\ directly instead of separate \derivePhaseState\ call; derives \rchitectTriggered\ and \rchitectReason\ from \rchitectInvalidators\ instead of re-computing trigger logic
- **Updated endpoint description** — \stalenessInputs\ → \inputStatus\

## Merged PRs

- **#127** (fix/docs-sync-and-lint) — lint fixes and docs sync. Closed as obsolete, changes merged into this branch.
- **#162** (fix/docs-sync-and-lint) — successor to #127. Merged into this branch, PR closed.

## Tests (541 pass)

- Strengthened trivial assertion (was \	oBeDefined()\, now \	oEqual(freshPhaseState)\)
- Added \criticChanged\ assertions to 4 tests (was never asserted)
- Added config prompt fallback test (\defaultArchitect: undefined\ → DEFAULT constant)
- Added \_synthesisCount: undefined\ fallback test (verifies \?? 0\ doesn't trigger architectEvery)
- Updated prompt staleness tests to verify no cascade (#163)
- Updated \irstRun\ tests to assert \rchitectInvalidators\ contains \'firstRun'\

## Docs

All 13 doc files reviewed and synced:
- Removed ghost module references (\synthesizeNode.ts\, \inalizeCycle.ts\) from orchestration guide
- Updated preview response to include \inputStatus\ and \rchitectInvalidators\
- Updated SKILL.md with \inputStatus\ field details and invalidator values
- Fixed stale JSDoc on \InputStatus\ and \invalidateArchitect\
- Updated endpoint catalog description