### PR TITLE
fix: defer synthesis_start until phase actually executes

### DIFF
--- a/packages/service/src/bootstrap.ts
+++ b/packages/service/src/bootstrap.ts
@@ -112,18 +112,28 @@ export async function startService(
     const startMs = Date.now();
     // Strip .meta suffix for human-readable progress reporting
     const ownerPath = path.replace(/\/?\.meta\/?$/, '');
-    await progress.report({
-      type: 'synthesis_start',
-      path: ownerPath,
-    });
 
     try {
+      // Track whether synthesis_start has been emitted (deferred until
+      // a phase actually begins, avoiding orphan "Started" messages
+      // when the meta is skipped/locked/fresh). See #165.
+      let synthesisStartEmitted = false;
+
       const result = await orchestratePhase(
         config,
         executor,
         watcher,
         path,
         async (evt) => {
+          // Emit synthesis_start on first phase_start (deferred guard)
+          if (evt.type === 'phase_start' && !synthesisStartEmitted) {
+            synthesisStartEmitted = true;
+            await progress.report({
+              type: 'synthesis_start',
+              path: ownerPath,
+            });
+          }
+
           // Wire current-phase tracking for GET /queue and POST /synthesize/abort
           if (evt.type === 'phase_start' && evt.phase) {
             queue.setCurrentPhase(ownerPath, evt.phase);


### PR DESCRIPTION
Closes #165

## Problem

synthesis_start was emitted unconditionally in synthesizeFn before orchestratePhase checked whether there was actual work. When the phase was skipped (locked, fully fresh, race condition), the channel received orphan '🔬 Started' messages with no matching completion event.

Observed in production: stan-core emitted three identical 'Started' messages at 15-minute intervals with no phase events or completion reports.

## Fix

Defers synthesis_start emission into the onProgress callback, triggered on the first phase_start event using a closure flag. This ensures 'Started' only appears when a phase actually begins executing, maintaining the correct message sequence:

Started → Phase started → Phase complete → Completed

No orphan messages when the meta is skipped.

## Verification

- TypeScript: ✅ 	sc --noEmit clean
- ESLint: ✅ clean
- Tests: ✅ 541/541 passed (50 files)