### PR TITLE
fix: batch fixes #179, #184, #194, #199, #200

### DIFF
--- a/packages/openclaw/src/helpers.test.ts
+++ b/packages/openclaw/src/helpers.test.ts
@@ -92,10 +92,31 @@ describe('resolvePluginSetting', () => {
 });
 
 describe('getConfigRoot', () => {
-  it('delegates with correct default', () => {
+  const originalEnv = process.env['JEEVES_CONFIG_ROOT'];
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env['JEEVES_CONFIG_ROOT'];
+    } else {
+      process.env['JEEVES_CONFIG_ROOT'] = originalEnv;
+    }
+  });
+
+  it('returns plugin config value when set', () => {
+    const api = makeApi({ configRoot: '/custom/config' });
+    expect(getConfigRoot(api)).toBe('/custom/config');
+  });
+
+  it('returns env var when plugin config absent', () => {
+    const api = makeApi({});
+    process.env['JEEVES_CONFIG_ROOT'] = '/env/config';
+    expect(getConfigRoot(api)).toBe('/env/config');
+  });
+
+  it('throws when neither plugin config nor env var is set', () => {
     const api = makeApi({});
     delete process.env['JEEVES_CONFIG_ROOT'];
-    expect(getConfigRoot(api)).toBe('j:/config');
+    expect(() => getConfigRoot(api)).toThrow('configRoot not configured');
   });
 });
 

--- a/packages/openclaw/src/helpers.ts
+++ b/packages/openclaw/src/helpers.ts
@@ -4,7 +4,11 @@
  * @module helpers
  */
 
-import { type PluginApi, resolvePluginSetting } from '@karmaniverous/jeeves';
+import {
+  type PluginApi,
+  resolveOptionalPluginSetting,
+  resolvePluginSetting,
+} from '@karmaniverous/jeeves';
 
 import { PLUGIN_ID } from './constants.js';
 
@@ -21,11 +25,16 @@ export function getServiceUrl(api: PluginApi): string {
 
 /** Resolve the platform config root. */
 export function getConfigRoot(api: PluginApi): string {
-  return resolvePluginSetting(
+  const value = resolveOptionalPluginSetting(
     api,
     PLUGIN_ID,
     'configRoot',
     'JEEVES_CONFIG_ROOT',
-    'j:/config',
   );
+  if (!value) {
+    throw new Error(
+      'configRoot not configured — set it in plugin config or via JEEVES_CONFIG_ROOT env var',
+    );
+  }
+  return value;
 }

--- a/packages/openclaw/src/promptInjection.test.ts
+++ b/packages/openclaw/src/promptInjection.test.ts
@@ -225,6 +225,7 @@ describe('generateMetaMenu', () => {
     expect(menu).toContain('Phases:');
     expect(menu).toContain('fresh');
     expect(menu).toContain('pending');
+    expect(menu).toContain('1 stale');
   });
 
   it('includes failed-phase alert when metas have failed phases', async () => {
@@ -264,7 +265,7 @@ describe('generateMetaMenu', () => {
       },
     });
     const menu = await generateMetaMenu(client);
-    expect(menu).toContain('Failed:');
+    expect(menu).toContain('⚠ Failed:');
     expect(menu).toContain('j:/domains/test/.meta (builder)');
   });
 

--- a/packages/openclaw/src/promptInjection.ts
+++ b/packages/openclaw/src/promptInjection.ts
@@ -108,7 +108,7 @@ export async function generateMetaMenu(
       }
     }
     const parts: string[] = [];
-    for (const state of ['fresh', 'pending', 'running', 'failed']) {
+    for (const state of ['fresh', 'pending', 'running', 'stale', 'failed']) {
       if (totals[state]) {
         parts.push(totals[state].toString() + ' ' + state);
       }
@@ -131,7 +131,7 @@ export async function generateMetaMenu(
     }
     if (failedParts.length > 0) {
       phaseLines.push(
-        '> Failed: ' +
+        '⚠ Failed: ' +
           failedParts.slice(0, 10).join(', ') +
           (failedParts.length > 10
             ? ' (+' + (failedParts.length - 10).toString() + ' more)'

--- a/packages/service/src/executor/GatewayExecutor.test.ts
+++ b/packages/service/src/executor/GatewayExecutor.test.ts
@@ -162,7 +162,7 @@ describe('GatewayExecutor.spawn', () => {
           );
         }
       },
-      sessions: [{ key: 'test-session-1', totalTokens: 5000 }],
+      sessions: [{ key: 'test-session-1', totalTokens: 5000, status: 'done' }],
     });
 
     const result = await executor.spawn('Test task');

--- a/packages/service/src/executor/GatewayExecutor.ts
+++ b/packages/service/src/executor/GatewayExecutor.ts
@@ -120,17 +120,21 @@ export class GatewayExecutor implements MetaExecutor {
     return text && text.trim() !== 'ANNOUNCE_SKIP' ? text : undefined;
   }
 
-  /** Check history messages for terminal completion. */
+  /**
+   * Check history messages for timeout detection.
+   *
+   * Does NOT determine completion — session completion is authoritative
+   * (via sessions_list). History stop reasons can false-positive on
+   * sessions_yield artifacts (#200).
+   */
   private static checkHistoryCompletion(
     messages: Array<{ role: string; stopReason?: string }>,
-  ): { done: boolean; timedOut: boolean } {
-    if (messages.length === 0) return { done: false, timedOut: false };
+  ): { timedOut: boolean } {
+    if (messages.length === 0) return { timedOut: false };
     const last = messages[messages.length - 1];
     if (last.role !== 'assistant' || !last.stopReason)
-      return { done: false, timedOut: false };
-    if (last.stopReason === 'toolUse' || last.stopReason === 'error')
-      return { done: false, timedOut: false };
-    return { done: true, timedOut: last.stopReason === 'timeout' };
+      return { timedOut: false };
+    return { timedOut: last.stopReason === 'timeout' };
   }
 
   /** Invoke a gateway tool via the /tools/invoke HTTP endpoint. */
@@ -352,15 +356,17 @@ export class GatewayExecutor implements MetaExecutor {
           usage?: { totalTokens?: number };
         }>;
 
-        // Check 1: terminal stop reason in history
-        const { done: historyDone, timedOut: historyTimedOut } =
+        // Check 1: history-based timeout detection (stop reason)
+        const { timedOut: historyTimedOut } =
           GatewayExecutor.checkHistoryCompletion(msgArray);
 
         // Check 2: session completion status via sessions_list
+        // Gate on session completion only — history stop reasons can
+        // false-positive on sessions_yield artifacts (#200).
         const sessionInfo = await this.getSessionInfo(sessionKey);
         const timedOut = sessionInfo.timedOut || historyTimedOut;
 
-        if (historyDone || sessionInfo.completed) {
+        if (sessionInfo.completed) {
           const tokens = sessionInfo.tokens;
 
           // Gateway-side timeout detected — check staging file for recovery

--- a/packages/service/src/index.ts
+++ b/packages/service/src/index.ts
@@ -142,8 +142,9 @@ export { Scheduler } from './scheduler/index.js';
 
 // ── Queue ──
 export {
+  type CurrentItem,
   type EnqueueResult,
-  type QueueItem,
+  type QueueEntry,
   type QueueState,
   SynthesisQueue,
 } from './queue/index.js';

--- a/packages/service/src/queue/index.ts
+++ b/packages/service/src/queue/index.ts
@@ -41,6 +41,11 @@ export interface QueueState {
 
 const DEPTH_WARNING_THRESHOLD = 3;
 
+/** Strip trailing .meta suffix for consistent path comparison. */
+function normQueuePath(p: string): string {
+  return p.endsWith('.meta') ? p.slice(0, -5).replace(/[/\\]$/, '') : p;
+}
+
 /**
  * Synthesis queue.
  *
@@ -70,13 +75,20 @@ export class SynthesisQueue {
    * Deduped by path. Returns position and whether already queued.
    */
   enqueue(path: string): EnqueueResult {
+    const norm = normQueuePath(path);
+
     // Check if currently executing
-    if (this.currentPhaseItem?.path === path) {
+    if (
+      this.currentPhaseItem &&
+      normQueuePath(this.currentPhaseItem.path) === norm
+    ) {
       return { position: 0, alreadyQueued: true };
     }
 
     // Check if already in queue
-    const existing = this.entries.findIndex((e) => e.path === path);
+    const existing = this.entries.findIndex(
+      (e) => normQueuePath(e.path) === norm,
+    );
     if (existing !== -1) {
       return { position: existing, alreadyQueued: true };
     }
@@ -128,8 +140,14 @@ export class SynthesisQueue {
 
   /** Check whether a path is in the queue or currently being synthesized. */
   has(path: string): boolean {
-    if (this.currentPhaseItem?.path === path) return true;
-    return this.entries.some((e) => e.path === path);
+    const norm = normQueuePath(path);
+    if (
+      this.currentPhaseItem &&
+      normQueuePath(this.currentPhaseItem.path) === norm
+    ) {
+      return true;
+    }
+    return this.entries.some((e) => normQueuePath(e.path) === norm);
   }
 
   // ── Current-item tracking ──────────────────────────────────────────

--- a/packages/service/src/queue/index.ts
+++ b/packages/service/src/queue/index.ts
@@ -1,13 +1,11 @@
 /**
- * Hybrid 3-layer synthesis queue.
+ * Synthesis queue.
  *
  * Layer 1: Current — the single item currently executing (at most one).
- * Layer 2: Overrides — items manually enqueued via POST /synthesize with path.
- *          FIFO among overrides, ahead of automatic candidates.
- * Layer 3: Automatic — computed on read, not persisted. All metas with a
- *          pending phase, ranked by scheduler priority.
- *
- * Legacy: `pending` array is the union of overrides + automatic.
+ * Layer 2: Pending — items enqueued via POST /synthesize (targeted) or
+ *          scheduler tick (automatic). FIFO, ahead of automatic candidates.
+ * Layer 3: Automatic — computed on read (GET /queue), not persisted. All
+ *          metas with a pending phase, ranked by scheduler priority.
  *
  * @module queue
  */
@@ -16,15 +14,8 @@ import type { Logger } from 'pino';
 
 import type { PhaseName } from '../schema/meta.js';
 
-/** A queued synthesis work item. */
-export interface QueueItem {
-  path: string;
-  priority: boolean;
-  enqueuedAt: string;
-}
-
-/** An override entry in the explicit queue layer. */
-export interface OverrideEntry {
+/** An entry in the synthesis queue. */
+export interface QueueEntry {
   path: string;
   enqueuedAt: string;
 }
@@ -45,29 +36,23 @@ export interface EnqueueResult {
 /** Snapshot of queue state for the /status endpoint. */
 export interface QueueState {
   depth: number;
-  items: Array<{ path: string; priority: boolean; enqueuedAt: string }>;
+  items: Array<{ path: string; enqueuedAt: string }>;
 }
 
 const DEPTH_WARNING_THRESHOLD = 3;
 
 /**
- * Hybrid 3-layer synthesis queue.
+ * Synthesis queue.
  *
- * Only one synthesis runs at a time. Override items (explicit triggers)
- * take priority over automatic candidates.
+ * Only one synthesis runs at a time. Explicitly enqueued items
+ * take priority over automatic (computed-on-read) candidates.
  */
 export class SynthesisQueue {
-  /** Legacy queue (used by processQueue for backward compat). */
-  private queue: QueueItem[] = [];
-  private currentItem: QueueItem | null = null;
+  private entries: QueueEntry[] = [];
+  private currentPhaseItem: CurrentItem | null = null;
   private processing = false;
   private logger: Logger;
   private onEnqueueCallback: (() => void) | null = null;
-
-  /** Explicit override entries (3-layer model). */
-  private overrideEntries: OverrideEntry[] = [];
-  /** Currently executing item with phase info (3-layer model). */
-  private currentPhaseItem: CurrentItem | null = null;
 
   constructor(logger: Logger) {
     this.logger = logger;
@@ -78,38 +63,35 @@ export class SynthesisQueue {
     this.onEnqueueCallback = callback;
   }
 
-  // ── Override layer (3-layer model) ─────────────────────────────────
+  // ── Enqueue / dequeue ──────────────────────────────────────────────
 
   /**
-   * Add an explicit override entry (from POST /synthesize with path).
+   * Add an entry to the queue.
    * Deduped by path. Returns position and whether already queued.
    */
-  enqueueOverride(path: string): EnqueueResult {
+  enqueue(path: string): EnqueueResult {
     // Check if currently executing
-    if (
-      this.currentPhaseItem?.path === path ||
-      this.currentItem?.path === path
-    ) {
+    if (this.currentPhaseItem?.path === path) {
       return { position: 0, alreadyQueued: true };
     }
 
-    // Check if already in overrides
-    const existing = this.overrideEntries.findIndex((e) => e.path === path);
+    // Check if already in queue
+    const existing = this.entries.findIndex((e) => e.path === path);
     if (existing !== -1) {
       return { position: existing, alreadyQueued: true };
     }
 
-    this.overrideEntries.push({
+    this.entries.push({
       path,
       enqueuedAt: new Date().toISOString(),
     });
 
-    const position = this.overrideEntries.length - 1;
+    const position = this.entries.length - 1;
 
-    if (this.overrideEntries.length > DEPTH_WARNING_THRESHOLD) {
+    if (this.entries.length > DEPTH_WARNING_THRESHOLD) {
       this.logger.warn(
-        { depth: this.overrideEntries.length },
-        'Override queue depth exceeds threshold',
+        { depth: this.entries.length },
+        'Queue depth exceeds threshold',
       );
     }
 
@@ -117,29 +99,40 @@ export class SynthesisQueue {
     return { position, alreadyQueued: false };
   }
 
-  /** Dequeue the next override entry, or undefined if empty. */
-  dequeueOverride(): OverrideEntry | undefined {
-    return this.overrideEntries.shift();
+  /** Dequeue the next entry, or undefined if empty. */
+  dequeue(): QueueEntry | undefined {
+    return this.entries.shift();
   }
 
-  /** Get all override entries (shallow copy). */
-  get overrides(): OverrideEntry[] {
-    return [...this.overrideEntries];
+  /** Get all queued entries (shallow copy). */
+  get items(): QueueEntry[] {
+    return [...this.entries];
   }
 
-  /** Clear all override entries. Returns count removed. */
-  clearOverrides(): number {
-    const count = this.overrideEntries.length;
-    this.overrideEntries = [];
+  /** Number of items waiting in the queue (excludes current). */
+  get depth(): number {
+    return this.entries.length;
+  }
+
+  /**
+   * Remove all pending items from the queue.
+   * Does not affect the currently-running item.
+   *
+   * @returns The number of items removed.
+   */
+  clear(): number {
+    const count = this.entries.length;
+    this.entries = [];
     return count;
   }
 
-  /** Check if a path is in the override layer. */
-  hasOverride(path: string): boolean {
-    return this.overrideEntries.some((e) => e.path === path);
+  /** Check whether a path is in the queue or currently being synthesized. */
+  has(path: string): boolean {
+    if (this.currentPhaseItem?.path === path) return true;
+    return this.entries.some((e) => e.path === path);
   }
 
-  // ── Current-item tracking (3-layer model) ──────────────────────────
+  // ── Current-item tracking ──────────────────────────────────────────
 
   /** Set the currently executing phase item. */
   setCurrentPhase(path: string, phase: PhaseName): void {
@@ -160,149 +153,24 @@ export class SynthesisQueue {
     return this.currentPhaseItem;
   }
 
-  // ── Legacy queue interface (preserved for backward compat) ─────────
-
-  /**
-   * Add a path to the synthesis queue.
-   *
-   * @param path - Meta path to synthesize.
-   * @param priority - If true, insert at front of queue.
-   * @returns Position and whether the path was already queued.
-   */
-  enqueue(path: string, priority = false): EnqueueResult {
-    if (this.currentItem?.path === path) {
-      return { position: 0, alreadyQueued: true };
-    }
-
-    const existingIndex = this.queue.findIndex((item) => item.path === path);
-    if (existingIndex !== -1) {
-      return { position: existingIndex, alreadyQueued: true };
-    }
-
-    const item: QueueItem = {
-      path,
-      priority,
-      enqueuedAt: new Date().toISOString(),
-    };
-
-    if (priority) {
-      this.queue.unshift(item);
-    } else {
-      this.queue.push(item);
-    }
-
-    if (this.queue.length > DEPTH_WARNING_THRESHOLD) {
-      this.logger.warn(
-        { depth: this.queue.length },
-        'Queue depth exceeds threshold',
-      );
-    }
-
-    const position = this.queue.findIndex((i) => i.path === path);
-    this.onEnqueueCallback?.();
-    return { position, alreadyQueued: false };
-  }
-
-  /** Remove and return the next item from the queue. */
-  dequeue(): QueueItem | undefined {
-    const item = this.queue.shift();
-    if (item) {
-      this.currentItem = item;
-    }
-    return item;
-  }
-
-  /** Mark the currently-running synthesis as complete. */
-  complete(): void {
-    this.currentItem = null;
-  }
-
-  /** Number of items waiting in the queue (excludes current). */
-  get depth(): number {
-    return this.queue.length;
-  }
-
-  /** The item currently being synthesized, or null. */
-  get current(): QueueItem | null {
-    return this.currentItem;
-  }
-
-  /** A shallow copy of the queued items. */
-  get items(): QueueItem[] {
-    return [...this.queue];
-  }
-
-  /** A shallow copy of the pending items (alias for items). */
-  get pending(): QueueItem[] {
-    return [...this.queue];
-  }
-
-  /**
-   * Remove all pending items from the queue.
-   * Does not affect the currently-running item.
-   *
-   * @returns The number of items removed.
-   */
-  clear(): number {
-    const count = this.queue.length;
-    this.queue = [];
-    return count;
-  }
-
-  /** Check whether a path is in the queue or currently being synthesized. */
-  has(path: string): boolean {
-    if (this.currentItem?.path === path) return true;
-    if (this.currentPhaseItem?.path === path) return true;
-    return (
-      this.queue.some((item) => item.path === path) ||
-      this.overrideEntries.some((e) => e.path === path)
-    );
-  }
-
-  /** Get the 0-indexed position of a path in the queue. */
-  getPosition(path: string): number | null {
-    // Check overrides first
-    const overrideIdx = this.overrideEntries.findIndex((e) => e.path === path);
-    if (overrideIdx !== -1) return overrideIdx;
-
-    const index = this.queue.findIndex((item) => item.path === path);
-    return index === -1 ? null : index;
-  }
-
-  /** Dequeue the next item: overrides first, then legacy queue. */
-  private nextItem():
-    | { path: string; source: 'override' | 'legacy' }
-    | undefined {
-    const override = this.dequeueOverride();
-    if (override) return { path: override.path, source: 'override' };
-    const item = this.dequeue();
-    if (item) return { path: item.path, source: 'legacy' };
-    return undefined;
-  }
+  // ── Queue state ────────────────────────────────────────────────────
 
   /** Return a snapshot of queue state for the /status endpoint. */
   getState(): QueueState {
     return {
-      depth: this.queue.length + this.overrideEntries.length,
-      items: [
-        ...this.overrideEntries.map((e) => ({
-          path: e.path,
-          priority: true,
-          enqueuedAt: e.enqueuedAt,
-        })),
-        ...this.queue.map((item) => ({
-          path: item.path,
-          priority: item.priority,
-          enqueuedAt: item.enqueuedAt,
-        })),
-      ],
+      depth: this.entries.length,
+      items: this.entries.map((e) => ({
+        path: e.path,
+        enqueuedAt: e.enqueuedAt,
+      })),
     };
   }
 
+  // ── Processing ─────────────────────────────────────────────────────
+
   /**
-   * Process queued items one at a time until all queues are empty.
+   * Process queued items one at a time until the queue is empty.
    *
-   * Override entries are processed first (FIFO), then legacy queue items.
    * Re-entry is prevented: if already processing, the call returns
    * immediately. Errors are logged and do not block subsequent items.
    *
@@ -316,7 +184,7 @@ export class SynthesisQueue {
     this.processing = true;
 
     try {
-      let next = this.nextItem();
+      let next = this.dequeue();
       while (next) {
         try {
           await synthesizeFn(next.path);
@@ -324,8 +192,7 @@ export class SynthesisQueue {
           this.logger.error({ path: next.path, err }, 'Synthesis failed');
         }
         this.clearCurrentPhase();
-        if (next.source === 'legacy') this.complete();
-        next = this.nextItem();
+        next = this.dequeue();
       }
     } finally {
       this.clearCurrentPhase();

--- a/packages/service/src/queue/queue.test.ts
+++ b/packages/service/src/queue/queue.test.ts
@@ -36,16 +36,6 @@ describe('SynthesisQueue', () => {
     expect(queue.depth).toBe(2);
   });
 
-  it('priority items go to front', () => {
-    queue.enqueue('/meta/a');
-    queue.enqueue('/meta/b');
-    const result = queue.enqueue('/meta/c', true);
-
-    expect(result.position).toBe(0);
-    expect(queue.items[0]?.path).toBe('/meta/c');
-    expect(queue.items[0]?.priority).toBe(true);
-  });
-
   it('deduplication returns existing position', () => {
     queue.enqueue('/meta/a');
     queue.enqueue('/meta/b');
@@ -57,28 +47,22 @@ describe('SynthesisQueue', () => {
     expect(queue.depth).toBe(3);
   });
 
-  it('dequeue returns items in order (priority first)', () => {
-    queue.enqueue('/meta/a');
-    queue.enqueue('/meta/b');
-    queue.enqueue('/meta/priority', true);
-
-    const first = queue.dequeue();
-    expect(first?.path).toBe('/meta/priority');
-
-    const second = queue.dequeue();
-    expect(second?.path).toBe('/meta/a');
-
-    const third = queue.dequeue();
-    expect(third?.path).toBe('/meta/b');
+  it('deduplication detects current phase item', () => {
+    queue.setCurrentPhase('/meta/x', 'builder');
+    const result = queue.enqueue('/meta/x');
+    expect(result.alreadyQueued).toBe(true);
+    expect(result.position).toBe(0);
   });
 
-  it('complete clears current', () => {
+  it('dequeue returns entries in FIFO order', () => {
     queue.enqueue('/meta/a');
-    queue.dequeue();
-    expect(queue.current?.path).toBe('/meta/a');
+    queue.enqueue('/meta/b');
+    queue.enqueue('/meta/c');
 
-    queue.complete();
-    expect(queue.current).toBeNull();
+    expect(queue.dequeue()?.path).toBe('/meta/a');
+    expect(queue.dequeue()?.path).toBe('/meta/b');
+    expect(queue.dequeue()?.path).toBe('/meta/c');
+    expect(queue.dequeue()).toBeUndefined();
   });
 
   it('depth reflects queue size', () => {
@@ -87,20 +71,30 @@ describe('SynthesisQueue', () => {
     queue.enqueue('/meta/b');
     expect(queue.depth).toBe(2);
 
-    queue.dequeue(); // moves to current, not counted
+    queue.dequeue();
     expect(queue.depth).toBe(1);
   });
 
-  it('has checks both queue and current', () => {
+  it('has checks both queue and currentPhase', () => {
     queue.enqueue('/meta/a');
     queue.enqueue('/meta/b');
     expect(queue.has('/meta/a')).toBe(true);
     expect(queue.has('/meta/b')).toBe(true);
     expect(queue.has('/meta/c')).toBe(false);
 
-    queue.dequeue(); // /meta/a becomes current
-    expect(queue.has('/meta/a')).toBe(true); // still found as current
-    expect(queue.has('/meta/b')).toBe(true); // still in queue
+    queue.setCurrentPhase('/meta/x', 'critic');
+    expect(queue.has('/meta/x')).toBe(true);
+    expect(queue.has('/meta/y')).toBe(false);
+  });
+
+  it('items returns shallow copy', () => {
+    queue.enqueue('/meta/a');
+    queue.enqueue('/meta/b');
+
+    const items = queue.items;
+    expect(items).toHaveLength(2);
+    expect(items[0]?.path).toBe('/meta/a');
+    expect(items[1]?.path).toBe('/meta/b');
   });
 
   it('processQueue processes all items', async () => {
@@ -118,7 +112,7 @@ describe('SynthesisQueue', () => {
 
     expect(processed).toEqual(['/meta/a', '/meta/b', '/meta/c']);
     expect(queue.depth).toBe(0);
-    expect(queue.current).toBeNull();
+    expect(queue.currentPhase).toBeNull();
   });
 
   it('processQueue continues after errors', async () => {
@@ -164,142 +158,6 @@ describe('SynthesisQueue', () => {
     expect(maxConcurrency).toBe(1);
   });
 
-  it('deduplication detects current item', () => {
-    queue.enqueue('/meta/a');
-    queue.dequeue(); // /meta/a is now current
-
-    const result = queue.enqueue('/meta/a');
-    expect(result.alreadyQueued).toBe(true);
-    expect(result.position).toBe(0);
-  });
-
-  it('warns when queue depth exceeds threshold', () => {
-    queue.enqueue('/meta/a');
-    queue.enqueue('/meta/b');
-    queue.enqueue('/meta/c');
-    expect(logger.warn).not.toHaveBeenCalled();
-
-    queue.enqueue('/meta/d');
-    expect(logger.warn).toHaveBeenCalledWith(
-      { depth: 4 },
-      'Queue depth exceeds threshold',
-    );
-  });
-
-  it('getState returns queue snapshot', () => {
-    queue.enqueue('/meta/a');
-    queue.enqueue('/meta/b', true);
-
-    const state = queue.getState();
-    expect(state.depth).toBe(2);
-    expect(state.items).toHaveLength(2);
-    expect(state.items[0]?.path).toBe('/meta/b');
-    expect(state.items[1]?.path).toBe('/meta/a');
-  });
-
-  it('getPosition returns index or null', () => {
-    queue.enqueue('/meta/a');
-    queue.enqueue('/meta/b');
-
-    expect(queue.getPosition('/meta/a')).toBe(0);
-    expect(queue.getPosition('/meta/b')).toBe(1);
-    expect(queue.getPosition('/meta/c')).toBeNull();
-  });
-
-  // ── 3-Layer Model (Override + CurrentPhase) ─────────────────────────
-
-  describe('override layer', () => {
-    it('enqueueOverride adds an entry', () => {
-      const result = queue.enqueueOverride('/meta/x');
-      expect(result.alreadyQueued).toBe(false);
-      expect(result.position).toBe(0);
-      expect(queue.overrides).toHaveLength(1);
-      expect(queue.overrides[0]?.path).toBe('/meta/x');
-    });
-
-    it('enqueueOverride deduplicates by path', () => {
-      queue.enqueueOverride('/meta/x');
-      const result = queue.enqueueOverride('/meta/x');
-      expect(result.alreadyQueued).toBe(true);
-      expect(result.position).toBe(0);
-      expect(queue.overrides).toHaveLength(1);
-    });
-
-    it('enqueueOverride detects current phase item', () => {
-      queue.setCurrentPhase('/meta/x', 'builder');
-      const result = queue.enqueueOverride('/meta/x');
-      expect(result.alreadyQueued).toBe(true);
-      expect(result.position).toBe(0);
-    });
-
-    it('enqueueOverride detects legacy current item', () => {
-      queue.enqueue('/meta/x');
-      queue.dequeue();
-      const result = queue.enqueueOverride('/meta/x');
-      expect(result.alreadyQueued).toBe(true);
-    });
-
-    it('dequeueOverride returns entries in FIFO order', () => {
-      queue.enqueueOverride('/meta/a');
-      queue.enqueueOverride('/meta/b');
-      queue.enqueueOverride('/meta/c');
-
-      expect(queue.dequeueOverride()?.path).toBe('/meta/a');
-      expect(queue.dequeueOverride()?.path).toBe('/meta/b');
-      expect(queue.dequeueOverride()?.path).toBe('/meta/c');
-      expect(queue.dequeueOverride()).toBeUndefined();
-    });
-
-    it('clearOverrides removes all override entries', () => {
-      queue.enqueueOverride('/meta/a');
-      queue.enqueueOverride('/meta/b');
-      const count = queue.clearOverrides();
-      expect(count).toBe(2);
-      expect(queue.overrides).toHaveLength(0);
-    });
-
-    it('hasOverride checks override layer', () => {
-      queue.enqueueOverride('/meta/a');
-      expect(queue.hasOverride('/meta/a')).toBe(true);
-      expect(queue.hasOverride('/meta/b')).toBe(false);
-    });
-
-    it('has checks override layer', () => {
-      queue.enqueueOverride('/meta/a');
-      expect(queue.has('/meta/a')).toBe(true);
-    });
-
-    it('getPosition checks overrides first', () => {
-      queue.enqueueOverride('/meta/a');
-      queue.enqueue('/meta/b');
-      expect(queue.getPosition('/meta/a')).toBe(0);
-      expect(queue.getPosition('/meta/b')).toBe(0);
-    });
-
-    it('getState includes overrides in depth and items', () => {
-      queue.enqueueOverride('/meta/a');
-      queue.enqueue('/meta/b');
-      const state = queue.getState();
-      expect(state.depth).toBe(2);
-      expect(state.items).toHaveLength(2);
-      expect(state.items[0]?.path).toBe('/meta/a');
-      expect(state.items[0]?.priority).toBe(true);
-    });
-
-    it('warns when override depth exceeds threshold', () => {
-      queue.enqueueOverride('/meta/a');
-      queue.enqueueOverride('/meta/b');
-      queue.enqueueOverride('/meta/c');
-      expect(logger.warn).not.toHaveBeenCalled();
-
-      queue.enqueueOverride('/meta/d');
-      expect(logger.warn).toHaveBeenCalledWith(
-        { depth: 4 },
-        'Override queue depth exceeds threshold',
-      );
-    });
-  });
-
   describe('currentPhase tracking', () => {
     it('setCurrentPhase / clearCurrentPhase', () => {
       expect(queue.currentPhase).toBeNull();
@@ -314,16 +172,10 @@ describe('SynthesisQueue', () => {
       queue.clearCurrentPhase();
       expect(queue.currentPhase).toBeNull();
     });
-
-    it('has detects currentPhase item', () => {
-      queue.setCurrentPhase('/meta/x', 'critic');
-      expect(queue.has('/meta/x')).toBe(true);
-      expect(queue.has('/meta/y')).toBe(false);
-    });
   });
 
   describe('clear', () => {
-    it('removes all legacy queue items and returns count', () => {
+    it('removes all queue items and returns count', () => {
       queue.enqueue('/meta/a');
       queue.enqueue('/meta/b');
       queue.enqueue('/meta/c');
@@ -333,48 +185,52 @@ describe('SynthesisQueue', () => {
       expect(queue.items).toEqual([]);
     });
 
-    it('does not affect currently-running item', () => {
-      queue.enqueue('/meta/a');
-      queue.enqueue('/meta/b');
-      queue.dequeue(); // /meta/a becomes current
-      queue.clear();
-      expect(queue.current?.path).toBe('/meta/a');
-      expect(queue.depth).toBe(0);
-    });
-
     it('returns 0 when queue is already empty', () => {
       expect(queue.clear()).toBe(0);
     });
   });
 
+  describe('getState', () => {
+    it('returns queue snapshot', () => {
+      queue.enqueue('/meta/a');
+      queue.enqueue('/meta/b');
+
+      const state = queue.getState();
+      expect(state.depth).toBe(2);
+      expect(state.items).toHaveLength(2);
+      expect(state.items[0]?.path).toBe('/meta/a');
+      expect(state.items[1]?.path).toBe('/meta/b');
+    });
+  });
+
+  describe('warns when queue depth exceeds threshold', () => {
+    it('warns at depth 4', () => {
+      queue.enqueue('/meta/a');
+      queue.enqueue('/meta/b');
+      queue.enqueue('/meta/c');
+      expect(logger.warn).not.toHaveBeenCalled();
+
+      queue.enqueue('/meta/d');
+      expect(logger.warn).toHaveBeenCalledWith(
+        { depth: 4 },
+        'Queue depth exceeds threshold',
+      );
+    });
+  });
+
   describe('onEnqueue callback', () => {
-    it('fires on new legacy enqueue', () => {
+    it('fires on new enqueue', () => {
       const cb = vi.fn();
       queue.onEnqueue(cb);
       queue.enqueue('/meta/a');
       expect(cb).toHaveBeenCalledTimes(1);
     });
 
-    it('fires on new override enqueue', () => {
-      const cb = vi.fn();
-      queue.onEnqueue(cb);
-      queue.enqueueOverride('/meta/a');
-      expect(cb).toHaveBeenCalledTimes(1);
-    });
-
-    it('fires on duplicate legacy enqueue (callback still called)', () => {
+    it('does not fire on duplicate enqueue', () => {
       const cb = vi.fn();
       queue.onEnqueue(cb);
       queue.enqueue('/meta/a');
-      queue.enqueue('/meta/a'); // duplicate — callback not called
-      expect(cb).toHaveBeenCalledTimes(1);
-    });
-
-    it('fires on duplicate override enqueue (callback not called)', () => {
-      const cb = vi.fn();
-      queue.onEnqueue(cb);
-      queue.enqueueOverride('/meta/a');
-      queue.enqueueOverride('/meta/a'); // duplicate — callback not called
+      queue.enqueue('/meta/a');
       expect(cb).toHaveBeenCalledTimes(1);
     });
   });

--- a/packages/service/src/queue/queue.test.ts
+++ b/packages/service/src/queue/queue.test.ts
@@ -54,6 +54,28 @@ describe('SynthesisQueue', () => {
     expect(result.position).toBe(0);
   });
 
+  it('deduplication normalizes .meta suffix (currentPhase vs enqueue)', () => {
+    // currentPhase is set with owner path, enqueue with .meta path
+    queue.setCurrentPhase('/owner/path', 'architect');
+    const result = queue.enqueue('/owner/path/.meta');
+    expect(result.alreadyQueued).toBe(true);
+  });
+
+  it('deduplication normalizes .meta suffix (enqueue vs enqueue)', () => {
+    queue.enqueue('/owner/path/.meta');
+    const result = queue.enqueue('/owner/path');
+    expect(result.alreadyQueued).toBe(true);
+  });
+
+  it('has normalizes .meta suffix', () => {
+    queue.setCurrentPhase('/owner/path', 'builder');
+    expect(queue.has('/owner/path/.meta')).toBe(true);
+    expect(queue.has('/owner/path')).toBe(true);
+    queue.clearCurrentPhase();
+    queue.enqueue('/some/meta/.meta');
+    expect(queue.has('/some/meta')).toBe(true);
+  });
+
   it('dequeue returns entries in FIFO order', () => {
     queue.enqueue('/meta/a');
     queue.enqueue('/meta/b');

--- a/packages/service/src/routes/phaseState.routes.test.ts
+++ b/packages/service/src/routes/phaseState.routes.test.ts
@@ -86,17 +86,13 @@ describe('phase-state operator surfaces (Task #18)', () => {
       const res = await app.inject({ method: 'GET', url: '/queue' });
       const body = res.json<{
         current: unknown;
-        overrides: unknown[];
-        automatic: unknown[];
         pending: unknown[];
-        state: { depth: number; items: unknown[] };
+        automatic: unknown[];
       }>();
 
       expect(body).toHaveProperty('current');
-      expect(body).toHaveProperty('overrides');
-      expect(body).toHaveProperty('automatic');
       expect(body).toHaveProperty('pending');
-      expect(body).toHaveProperty('state');
+      expect(body).toHaveProperty('automatic');
     });
 
     it('current includes phase when phase-aware item is set', async () => {
@@ -120,11 +116,11 @@ describe('phase-state operator surfaces (Task #18)', () => {
       expect(body.current.startedAt).toBeDefined();
     });
 
-    it('overrides reflect enqueued override entries', async () => {
+    it('pending reflects enqueued entries', async () => {
       const logger = makeTestLogger();
       const queue = new SynthesisQueue(logger);
-      queue.enqueueOverride('/meta/override-a');
-      queue.enqueueOverride('/meta/override-b');
+      queue.enqueue('/meta/pending-a');
+      queue.enqueue('/meta/pending-b');
 
       const deps = makeTestDeps({ queue });
       app = Fastify();
@@ -133,23 +129,23 @@ describe('phase-state operator surfaces (Task #18)', () => {
 
       const res = await app.inject({ method: 'GET', url: '/queue' });
       const body = res.json<{
-        overrides: Array<{
+        pending: Array<{
           path: string;
           owedPhase: string | null;
           enqueuedAt: string;
         }>;
       }>();
 
-      expect(body.overrides).toHaveLength(2);
-      expect(body.overrides[0].path).toBe('/meta/override-a');
-      expect(body.overrides[1].path).toBe('/meta/override-b');
+      expect(body.pending).toHaveLength(2);
+      expect(body.pending[0].path).toBe('/meta/pending-a');
+      expect(body.pending[1].path).toBe('/meta/pending-b');
     });
 
-    it('POST /queue/clear removes only overrides', async () => {
+    it('POST /queue/clear removes pending entries', async () => {
       const logger = makeTestLogger();
       const queue = new SynthesisQueue(logger);
-      queue.enqueueOverride('/meta/override-a');
-      queue.enqueue('/meta/legacy-item');
+      queue.enqueue('/meta/pending-a');
+      queue.enqueue('/meta/pending-b');
 
       const deps = makeTestDeps({ queue });
       app = Fastify();
@@ -158,11 +154,10 @@ describe('phase-state operator surfaces (Task #18)', () => {
 
       const res = await app.inject({ method: 'POST', url: '/queue/clear' });
       expect(res.statusCode).toBe(200);
-      expect(res.json()).toEqual({ cleared: 1 });
+      expect(res.json()).toEqual({ cleared: 2 });
 
-      // Legacy queue should be unaffected
-      expect(queue.depth).toBe(1);
-      expect(queue.overrides).toHaveLength(0);
+      expect(queue.depth).toBe(0);
+      expect(queue.items).toHaveLength(0);
     });
   });
 

--- a/packages/service/src/routes/queue.test.ts
+++ b/packages/service/src/routes/queue.test.ts
@@ -20,7 +20,7 @@ describe('queue routes', () => {
     await app.close();
   });
 
-  it('GET /queue returns current, pending, and state', async () => {
+  it('GET /queue returns current, pending, and automatic', async () => {
     const queue = new SynthesisQueue(makeTestLogger());
     queue.enqueue('/meta/a');
     queue.enqueue('/meta/b');
@@ -35,20 +35,16 @@ describe('queue routes', () => {
     const body = res.json<{
       current: unknown;
       pending: unknown[];
-      state: { depth: number; items: unknown[] };
+      automatic: unknown[];
     }>();
     expect(body.current).toBeNull();
     expect(body.pending).toHaveLength(2);
-    expect(body.state.depth).toBe(2);
-    expect(body.state.items).toHaveLength(2);
   });
 
-  it('POST /queue/clear removes override entries only', async () => {
+  it('POST /queue/clear removes pending entries', async () => {
     const queue = new SynthesisQueue(makeTestLogger());
-    queue.enqueue('/meta/current');
-    queue.dequeue();
-    queue.enqueueOverride('/meta/override-a');
-    queue.enqueueOverride('/meta/override-b');
+    queue.enqueue('/meta/a');
+    queue.enqueue('/meta/b');
 
     app = Fastify();
     registerQueueRoutes(app, makeTestDeps({ queue }));
@@ -57,8 +53,7 @@ describe('queue routes', () => {
     const res = await app.inject({ method: 'POST', url: '/queue/clear' });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toEqual({ cleared: 2 });
-    expect(queue.current?.path).toBe('/meta/current');
-    expect(queue.overrides).toHaveLength(0);
+    expect(queue.items).toHaveLength(0);
   });
 
   it('POST /synthesize/abort returns idle when nothing running', async () => {
@@ -77,13 +72,22 @@ describe('queue routes', () => {
     const metaDir = join(ownerDir, '.meta');
     mkdirSync(metaDir, { recursive: true });
     writeFileSync(
+      join(metaDir, 'meta.json'),
+      JSON.stringify({
+        _phaseState: {
+          architect: 'fresh',
+          builder: 'running',
+          critic: 'stale',
+        },
+      }),
+    );
+    writeFileSync(
       join(metaDir, '.lock'),
       JSON.stringify({ _lockPid: process.pid, _lockStartedAt: new Date() }),
     );
 
     const queue = new SynthesisQueue(makeTestLogger());
-    queue.enqueue(ownerDir);
-    queue.dequeue();
+    queue.setCurrentPhase(ownerDir, 'builder');
     const abort = vi.fn();
 
     app = Fastify();
@@ -92,7 +96,10 @@ describe('queue routes', () => {
 
     const res = await app.inject({ method: 'POST', url: '/synthesize/abort' });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ status: 'aborted', path: ownerDir });
+    const body = res.json<{ status: string; path: string; phase: string }>();
+    expect(body.status).toBe('aborted');
+    expect(body.path).toBe(ownerDir);
+    expect(body.phase).toBe('builder');
     expect(abort).toHaveBeenCalledTimes(1);
     expect(existsSync(join(metaDir, '.lock'))).toBe(false);
 

--- a/packages/service/src/routes/queue.ts
+++ b/packages/service/src/routes/queue.ts
@@ -1,8 +1,8 @@
 /**
  * Queue management and abort routes.
  *
- * - GET /queue — 3-layer queue model (current, overrides, automatic, pending)
- * - POST /queue/clear — remove override entries only
+ * - GET /queue — 3-layer queue model (current, pending, automatic)
+ * - POST /queue/clear — remove pending entries
  * - POST /synthesize/abort — abort the current synthesis
  *
  * @module routes/queue
@@ -34,25 +34,25 @@ export function registerQueueRoutes(
 
   app.get(getEndpoint('queue').path, async () => {
     const currentPhase = queue.currentPhase;
-    const overrides = queue.overrides;
+    const pending = queue.items;
 
-    // Compute owedPhase for each override entry by reading meta state
-    const enrichedOverrides = await Promise.all(
-      overrides.map(async (o) => {
+    // Compute owedPhase for each pending entry by reading meta state
+    const enrichedPending = await Promise.all(
+      pending.map(async (entry) => {
         try {
-          const metaDir = resolveMetaDir(o.path);
+          const metaDir = resolveMetaDir(entry.path);
           const meta = await readMetaJson(metaDir);
           const ps = derivePhaseState(meta);
           return {
-            path: o.path,
+            path: entry.path,
             owedPhase: getOwedPhase(ps),
-            enqueuedAt: o.enqueuedAt,
+            enqueuedAt: entry.enqueuedAt,
           };
         } catch {
           return {
-            path: o.path,
+            path: entry.path,
             owedPhase: null as string | null,
-            enqueuedAt: o.enqueuedAt,
+            enqueuedAt: entry.enqueuedAt,
           };
         }
       }),
@@ -83,22 +83,6 @@ export function registerQueueRoutes(
       // If listing fails, automatic stays empty
     }
 
-    // Legacy: pending is the union of overrides + automatic + legacy queue items
-    const pendingItems = [
-      ...enrichedOverrides.map((o) => ({
-        path: o.path,
-        owedPhase: o.owedPhase,
-      })),
-      ...automatic.map((a) => ({
-        path: a.path,
-        owedPhase: a.owedPhase,
-      })),
-      ...queue.pending.map((item) => ({
-        path: item.path,
-        owedPhase: null as string | null,
-      })),
-    ];
-
     return {
       current: currentPhase
         ? {
@@ -106,65 +90,52 @@ export function registerQueueRoutes(
             phase: currentPhase.phase,
             startedAt: currentPhase.startedAt,
           }
-        : queue.current
-          ? {
-              path: queue.current.path,
-              phase: null,
-              startedAt: queue.current.enqueuedAt,
-            }
-          : null,
-      overrides: enrichedOverrides,
+        : null,
+      pending: enrichedPending,
       automatic,
-      pending: pendingItems,
-      // Legacy state
-      state: queue.getState(),
     };
   });
 
   app.post(getEndpoint('queueClear').path, () => {
-    const removed = queue.clearOverrides();
+    const removed = queue.clear();
     return { cleared: removed };
   });
 
   app.post(getEndpoint('abort').path, async (_request, reply) => {
-    // Check 3-layer current first
     const currentPhase = queue.currentPhase;
-    const current = currentPhase ?? queue.current;
 
-    if (!current) {
+    if (!currentPhase) {
       return reply.status(200).send({ status: 'idle' });
     }
 
     // Abort the executor
     deps.executor?.abort();
 
-    const metaDir = resolveMetaDir(current.path);
-    const phase = currentPhase?.phase ?? null;
+    const metaDir = resolveMetaDir(currentPhase.path);
+    const { phase } = currentPhase;
 
     // Transition running phase to failed and write _error to meta.json
-    if (phase) {
-      try {
-        const meta = await readMetaJson(metaDir);
-        let ps = derivePhaseState(meta);
-        ps = phaseFailed(ps, phase);
+    try {
+      const meta = await readMetaJson(metaDir);
+      let ps = derivePhaseState(meta);
+      ps = phaseFailed(ps, phase);
 
-        const updated = {
-          ...meta,
-          _phaseState: ps,
-          _error: {
-            step: phase,
-            code: 'ABORT',
-            message: 'Aborted by operator',
-          },
-        };
+      const updated = {
+        ...meta,
+        _phaseState: ps,
+        _error: {
+          step: phase,
+          code: 'ABORT',
+          message: 'Aborted by operator',
+        },
+      };
 
-        const lockPath = join(metaDir, '.lock');
-        const metaJsonPath = join(metaDir, 'meta.json');
-        await writeFile(lockPath, JSON.stringify(updated, null, 2) + '\n');
-        await copyFile(lockPath, metaJsonPath);
-      } catch {
-        // Best-effort — meta may be unreadable
-      }
+      const lockPath = join(metaDir, '.lock');
+      const metaJsonPath = join(metaDir, 'meta.json');
+      await writeFile(lockPath, JSON.stringify(updated, null, 2) + '\n');
+      await copyFile(lockPath, metaJsonPath);
+    } catch {
+      // Best-effort — meta may be unreadable
     }
 
     // Release the lock for the current meta path
@@ -174,12 +145,12 @@ export function registerQueueRoutes(
       // Lock may already be released
     }
 
-    deps.logger.info({ path: current.path }, 'Synthesis aborted');
+    deps.logger.info({ path: currentPhase.path }, 'Synthesis aborted');
 
     return {
       status: 'aborted',
-      path: current.path,
-      ...(phase ? { phase } : {}),
+      path: currentPhase.path,
+      phase,
     };
   });
 }

--- a/packages/service/src/routes/status.test.ts
+++ b/packages/service/src/routes/status.test.ts
@@ -92,7 +92,7 @@ describe('GET /status', () => {
     const logger = makeTestLogger();
     const queue = new SynthesisQueue(logger);
     queue.enqueue('/meta/a');
-    queue.enqueue('/meta/b', true);
+    queue.enqueue('/meta/b');
 
     const deps = makeTestDeps({ queue, stats: TEST_STATS });
     app = Fastify();
@@ -145,8 +145,7 @@ describe('GET /status', () => {
   it('shows currentTarget in nested health when synthesis is active', async () => {
     const logger = makeTestLogger();
     const queue = new SynthesisQueue(logger);
-    queue.enqueue('/meta/active');
-    queue.dequeue();
+    queue.setCurrentPhase('/meta/active', 'builder');
 
     const deps = makeTestDeps({ queue, stats: TEST_STATS });
     app = Fastify();
@@ -177,8 +176,7 @@ describe('GET /status', () => {
   it('returns serviceState "synthesizing" when a synthesis is in progress', async () => {
     const logger = makeTestLogger();
     const queue = new SynthesisQueue(logger);
-    queue.enqueue('/meta/active');
-    queue.dequeue();
+    queue.setCurrentPhase('/meta/active', 'builder');
 
     const deps = makeTestDeps({ queue, stats: TEST_STATS });
     app = Fastify();

--- a/packages/service/src/routes/status.ts
+++ b/packages/service/src/routes/status.ts
@@ -70,8 +70,8 @@ export type { ServiceState };
 /** Derive service-specific state from current activity and lifecycle. */
 function deriveServiceState(deps: RouteDeps): ServiceState {
   if (deps.shuttingDown) return 'stopping';
-  if (deps.queue.current || deps.queue.currentPhase) return 'synthesizing';
-  if (deps.queue.depth > 0 || deps.queue.overrides.length > 0) return 'waiting';
+  if (deps.queue.currentPhase) return 'synthesizing';
+  if (deps.queue.depth > 0) return 'waiting';
   return 'idle';
 }
 
@@ -145,7 +145,7 @@ export function registerStatusRoute(
 
       return {
         serviceState: deriveServiceState(deps),
-        currentTarget: queue.current?.path ?? queue.currentPhase?.path ?? null,
+        currentTarget: queue.currentPhase?.path ?? null,
         queue: queue.getState(),
         stats: {
           totalSyntheses: stats.totalSyntheses,

--- a/packages/service/src/routes/synthesize.test.ts
+++ b/packages/service/src/routes/synthesize.test.ts
@@ -60,7 +60,7 @@ describe('POST /synthesize', () => {
     expect(body.path).toBe('/meta/target/.meta');
     expect(body.queuePosition).toBe(0);
     expect(body.alreadyQueued).toBe(false);
-    expect(queue.overrides).toHaveLength(1);
+    expect(queue.items).toHaveLength(1);
   });
 
   it('normalizes owner path to .meta path', async () => {
@@ -81,7 +81,7 @@ describe('POST /synthesize', () => {
     const body = res.json<{ status: string; path: string }>();
     expect(body.status).toBe('queued');
     expect(body.path).toMatch(/[/\\]some[/\\]owner[/\\]dir[/\\]\.meta$/);
-    expect(queue.overrides).toHaveLength(1);
+    expect(queue.items).toHaveLength(1);
   });
 
   it('preserves path already ending in .meta', async () => {
@@ -102,7 +102,7 @@ describe('POST /synthesize', () => {
     const body = res.json<{ status: string; path: string }>();
     expect(body.status).toBe('queued');
     expect(body.path).toBe('/some/owner/dir/.meta');
-    expect(queue.overrides).toHaveLength(1);
+    expect(queue.items).toHaveLength(1);
   });
 
   it('returns queue position', async () => {
@@ -123,9 +123,8 @@ describe('POST /synthesize', () => {
     });
 
     const body = res.json<{ queuePosition: number }>();
-    // /meta/third is 3rd item — position 0 is front of queue
-    // With priority=true (path provided), it goes to front
-    expect(body.queuePosition).toBe(0);
+    // /meta/third is 3rd item — FIFO, position 2
+    expect(body.queuePosition).toBe(2);
   });
 
   it('returns already-queued status for duplicate path', async () => {
@@ -186,7 +185,7 @@ describe('POST /synthesize', () => {
 
     expect(res.statusCode).toBe(202);
     const body = res.json<{ status: string; path: string }>();
-    expect(body.status).toBe('accepted');
+    expect(body.status).toBe('queued');
     expect(body.path).toContain('stale');
   });
 
@@ -230,7 +229,7 @@ describe('POST /synthesize', () => {
     const bodyExplicit = resExplicit.json<{ status: string; path: string }>();
     expect(bodyExplicit.status).toBe('queued');
     expect(bodyExplicit.path).toContain('disabled-stale');
-    expect(queue.overrides).toHaveLength(1);
+    expect(queue.items).toHaveLength(1);
   });
 
   it('recomputes invalidation instead of trusting cached _phaseState (#160)', async () => {
@@ -278,7 +277,7 @@ describe('POST /synthesize', () => {
     const body = res.json<{ status: string; owedPhase: string | null }>();
     expect(body.status).toBe('queued');
     expect(body.owedPhase).toBe('architect');
-    expect(queue.overrides).toHaveLength(1);
+    expect(queue.items).toHaveLength(1);
   });
 
   it('returns 503 when watcher unreachable and no path provided', async () => {

--- a/packages/service/src/routes/synthesize.ts
+++ b/packages/service/src/routes/synthesize.ts
@@ -92,7 +92,7 @@ export function registerSynthesizeRoute(
         });
       }
 
-      const result = queue.enqueueOverride(targetPath);
+      const result = queue.enqueue(targetPath);
       return reply.code(202).send({
         status: 'queued',
         path: targetPath,
@@ -128,8 +128,9 @@ export function registerSynthesizeRoute(
     const enqueueResult = queue.enqueue(stalest);
 
     return reply.code(202).send({
-      status: 'accepted',
+      status: 'queued',
       path: stalest,
+      owedPhase: winner.owedPhase,
       queuePosition: enqueueResult.position,
       alreadyQueued: enqueueResult.alreadyQueued,
     });

--- a/packages/service/src/scheduler/index.ts
+++ b/packages/service/src/scheduler/index.ts
@@ -187,7 +187,6 @@ export class Scheduler {
       return;
     }
 
-    // Enqueue using the legacy queue path (backward compat with processQueue)
     this.queue.enqueue(candidate.path);
     this.logger.info(
       { path: candidate.path, phase: candidate.phase, band: candidate.band },

--- a/packages/service/src/shutdown/index.ts
+++ b/packages/service/src/shutdown/index.ts
@@ -56,36 +56,18 @@ export function registerShutdownHandlers(deps: ShutdownDeps): void {
     }
 
     // 2. Release lock for in-progress synthesis
-    const current = deps.queue.current;
-    if (current) {
-      try {
-        releaseLock(current.path);
-        deps.logger.info(
-          { path: current.path },
-          'Released lock for in-progress synthesis',
-        );
-      } catch {
-        deps.logger.warn(
-          { path: current.path },
-          'Failed to release lock during shutdown',
-        );
-      }
-    }
-
-    // Release lock for in-progress override synthesis (only when it
-    // differs from the legacy current item to avoid double-release)
     const currentPhase = deps.queue.currentPhase;
-    if (currentPhase && currentPhase.path !== current?.path) {
+    if (currentPhase) {
       try {
         releaseLock(resolveMetaDir(currentPhase.path));
         deps.logger.info(
           { path: currentPhase.path },
-          'Released lock for in-progress override synthesis',
+          'Released lock for in-progress synthesis',
         );
       } catch {
         deps.logger.warn(
           { path: currentPhase.path },
-          'Failed to release override lock during shutdown',
+          'Failed to release lock during shutdown',
         );
       }
     }


### PR DESCRIPTION
## Summary

Batch of bug fixes and enhancements across 5 open tickets, plus closure of 4 tickets already fixed in v0.16.0.

### Active fixes

| # | Title | Type |
|---|-------|------|
| #200 | GatewayExecutor.checkHistoryCompletion false-positive on sessions_yield | bug |
| #194 | Eliminate legacy queue path (queue.current.phase can be null) | enhancement |
| #199 | Remove hardcoded j:/config fallback for configRoot | bug |
| #184 | stale phase state silently omitted from TOOLS.md phase summary | enhancement |
| #179 | Failed-phase alert missing ⚠ prefix | bug |

### Already fixed (closing)

These were implemented in commit a3b8b17 (v0.16.0) but issues were never closed:

| # | Title |
|---|-------|
| #177 | Empty-scope handling not implemented (spec §3.9) |
| #181 | _id not auto-generated during synthesis for manual stubs |
| #183 | Tier 1 invalidation triggers on architect-fresh only, not all-fresh |
| #189 | /preview returns HTTP 200 with error body instead of 404 |

### Changes

**#200 — Completion gate fix:**
- Changed completion gate from \historyDone \|\| sessionInfo.completed\ to \sessionInfo.completed\ only
- \checkHistoryCompletion\ retained solely for timeout detection via \historyTimedOut\
- History stop reasons can false-positive on \sessions_yield\ artifacts; session completion status is authoritative

**#194 — Legacy queue elimination:**
- Removed legacy \QueueItem\, priority insertion, \current\/\complete()\/\getPosition()\ tracking
- Renamed \enqueueOverride\ → \enqueue\ (single unified entry point)
- Queue is now FIFO with phase-aware \currentPhase\ tracking only
- \GET /queue\ response simplified: \current\, \pending\, \utomatic\ (no more \overrides\/\state\)
- Updated scheduler, synthesize route, status route, shutdown handler, and all tests

**#199 — configRoot fallback removal:**
- Replaced \esolvePluginSetting\ (with \'j:/config'\ fallback) with \esolveOptionalPluginSetting\ + throw
- Error message: \configRoot not configured — set it in plugin config or via JEEVES_CONFIG_ROOT env var\
- Companion issue: karmaniverous/jeeves-tools#80 (add configRoot to default template)

**#184 — stale phase state visibility:**
- Added \'stale'\ to the iterated states array in \promptInjection.ts\

**#179 — Failed-phase alert prefix:**
- Changed \'> Failed:'\ to \'⚠ Failed:'\ per spec §3.17.2

### Quality

- Typecheck: ✅ (all 3 packages)
- Tests: ✅ 554 passed (27 openclaw + 527 service)
- Lint: ✅ zero errors, zero warnings
- Build: ✅
- Knip: pre-existing \@rollup/plugin-typescript\ warning only

### Dependency note

\
cu --peer\ shows \@commander-js/extra-typings\ major bump (14→15). Not included in this PR.

Closes #177, #179, #181, #183, #184, #189, #194, #199, #200