### PR TITLE
feat: release 0.17.0 batch

### DIFF
--- a/packages/core/src/contracts.ts
+++ b/packages/core/src/contracts.ts
@@ -7,6 +7,8 @@
  *
  */
 
+import type { PhaseName, PhaseStatus } from './phases.js';
+
 /** Summary statistics from GET /metas. */
 export interface MetaListSummary {
   total: number;
@@ -51,3 +53,14 @@ export type GatewayDepHealth = DepHealth;
 
 /** Service lifecycle state. */
 export type ServiceState = 'idle' | 'synthesizing' | 'waiting' | 'stopping';
+
+/** Phase state summary: per-phase counts of each status. */
+export type PhaseStateSummary = Record<PhaseName, Record<PhaseStatus, number>>;
+
+/** Next phase candidate from the scheduler. */
+export interface NextPhaseCandidate {
+  path: string;
+  phase: PhaseName;
+  band: number;
+  staleness: number;
+}

--- a/packages/core/src/endpoints.ts
+++ b/packages/core/src/endpoints.ts
@@ -54,7 +54,7 @@ export const META_ENDPOINTS = [
     method: 'PATCH',
     path: '/metas/:path',
     description:
-      'Update user-settable reserved properties on a meta entity. Returns the updated meta.json content. Rejects unknown property keys with a 400 error.',
+      'Update user-settable reserved properties on a meta entity. Returns { path, meta } with large fields excluded. Rejects unknown property keys with a 400 error.',
   },
   {
     name: 'synthesize',

--- a/packages/core/src/endpoints.ts
+++ b/packages/core/src/endpoints.ts
@@ -40,20 +40,21 @@ export const META_ENDPOINTS = [
     method: 'GET',
     path: '/metas',
     description:
-      'List metas with summary stats and per-meta projection. Response includes _phaseState and owedPhase per meta.',
+      'List metas with summary stats and per-meta projection. Response includes phaseState and owedPhase per meta.',
   },
   {
     name: 'metaDetail',
     method: 'GET',
     path: '/metas/:path',
     description:
-      'Full detail for a single meta, with optional archive history. Response includes _phaseState and owedPhase.',
+      'Full detail for a single meta, with optional archive history. Response includes phaseState, owedPhase, and crossRefs.',
   },
   {
     name: 'updateMeta',
     method: 'PATCH',
     path: '/metas/:path',
-    description: 'Update user-settable reserved properties on a meta entity.',
+    description:
+      'Update user-settable reserved properties on a meta entity. Returns the updated meta.json content. Rejects unknown property keys with a 400 error.',
   },
   {
     name: 'synthesize',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,8 @@ export type {
   MetaListSummary,
   MetasItem,
   MetasResponse,
+  NextPhaseCandidate,
+  PhaseStateSummary,
   ServiceState,
   WatcherDepHealth,
 } from './contracts.js';

--- a/packages/openclaw/guides/tools-reference.md
+++ b/packages/openclaw/guides/tools-reference.md
@@ -74,6 +74,13 @@ Dry-run: show what inputs would be gathered for the next synthesis cycle.
 
 **Response:** `{ path, staleness, architectWillRun, architectReason, scope, estimatedTokens, owedPhase, priorityBand, phaseState, inputStatus, architectInvalidators }`
 
+The `scope` object includes:
+- `ownedFiles` (number) — total scope file count
+- `childMetas` (number) — direct child meta count
+- `deltaFiles` (array) — files modified since last synthesis, capped at `previewDeltaFilesCap`
+- `deltaCount` (number) — total delta file count before cap
+- `deltaFilesTruncated` (boolean) — true when `deltaCount > previewDeltaFilesCap` (some delta files omitted from `deltaFiles`)
+
 ## meta_trigger
 
 Enqueue synthesis for a specific meta or the stalest candidate.

--- a/packages/openclaw/skills/jeeves-meta/SKILL.md
+++ b/packages/openclaw/skills/jeeves-meta/SKILL.md
@@ -217,6 +217,10 @@ Key settings:
 | `reportChannel` | (optional) | Gateway channel name (e.g. `slack`). Legacy: also used as target if `reportTarget` is unset. |
 | `reportTarget` | (optional) | Channel/user ID to send progress messages to |
 | `tier2ScanLimit` | 50 | Max all-fresh candidates to scan per tick in Tier 2 invalidation |
+| `workspaceDir` | OS tmpdir + `/jeeves-meta` | Directory for sub-agent output staging files |
+| `stagingRetries` | 10 | Max retries when staging file not yet visible after session completion (min 0) |
+| `stagingRetryDelayMs` | 250 | Delay between staging file retry attempts in ms (min 0) |
+| `previewDeltaFilesCap` | 50 | Max delta files included in `/preview` response; excess sets `deltaFilesTruncated: true` (min 1) |
 | `logging.level` | `info` | Log level (trace/debug/info/warn/error) |
 | `logging.file` | (optional) | Log file path |
 

--- a/packages/openclaw/src/customTools.ts
+++ b/packages/openclaw/src/customTools.ts
@@ -193,7 +193,7 @@ function buildMetaSeedTool(
         crossRefs: {
           type: 'string',
           description:
-            'JSON array of cross-ref owner paths (e.g. \'["j:/path/a","j:/path/b"]\').',
+            'JSON array of cross-ref owner paths (e.g. \'["<drive label>:/path/a","<drive label>:/path/b"]\'). Use server_drives to discover available drive labels.',
         },
         steer: {
           type: 'string',

--- a/packages/openclaw/src/promptInjection.test.ts
+++ b/packages/openclaw/src/promptInjection.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, expect, it, vi } from 'vitest';
 
-import { generateMetaMenu } from './promptInjection.js';
+import { formatAge, generateMetaMenu } from './promptInjection.js';
 import type {
   MetaServiceClient,
   MetasResponse,
@@ -69,6 +69,40 @@ function mockClient(overrides?: {
       .mockResolvedValue({ ...defaultMetas, ...overrides?.metasOverrides }),
   } as unknown as MetaServiceClient;
 }
+
+// ── Direct unit tests for formatAge (Issue #187) ──
+
+describe('formatAge', () => {
+  it("returns 'never synthesized' for Infinity", () => {
+    expect(formatAge(Infinity)).toBe('never synthesized');
+  });
+
+  it("returns '1m' for 0 seconds (minimum floor)", () => {
+    expect(formatAge(0)).toBe('1m');
+  });
+
+  it('returns minutes-only for sub-hour durations', () => {
+    expect(formatAge(45 * 60)).toBe('45m'); // 45 minutes
+  });
+
+  it('returns hours-only when minutes are zero', () => {
+    expect(formatAge(3600)).toBe('1h'); // exactly 1 hour
+  });
+
+  it('returns hour+minute compound for sub-day durations', () => {
+    expect(formatAge(5400)).toBe('1h 30m'); // 1h 30m
+    expect(formatAge(5700)).toBe('1h 35m'); // 1h 35m
+  });
+
+  it('returns days-only when hours are zero', () => {
+    expect(formatAge(86400)).toBe('1d'); // exactly 1 day
+  });
+
+  it('returns day+hour compound when both are present', () => {
+    expect(formatAge(97200)).toBe('1d 3h'); // 1d 3h
+    expect(formatAge(90000)).toBe('1d 1h'); // 25h = 1d 1h
+  });
+});
 
 describe('generateMetaMenu', () => {
   it('generates menu with entity summary', async () => {

--- a/packages/openclaw/src/promptInjection.test.ts
+++ b/packages/openclaw/src/promptInjection.test.ts
@@ -223,9 +223,16 @@ describe('generateMetaMenu', () => {
     });
     const menu = await generateMetaMenu(client);
     expect(menu).toContain('Phases:');
-    expect(menu).toContain('fresh');
-    expect(menu).toContain('pending');
-    expect(menu).toContain('1 stale');
+    // Fresh is aggregated across all phases (8+7+9=24)
+    expect(menu).toContain('24 fresh');
+    // Non-fresh show per-phase breakdown
+    expect(menu).toContain('2 pending architect');
+    expect(menu).toContain('1 pending builder');
+    expect(menu).toContain('1 running builder');
+    expect(menu).toContain('1 stale builder');
+    expect(menu).toContain('1 failed critic');
+    // Old aggregated format not present
+    expect(menu).not.toMatch(/\d+ pending,/);
   });
 
   it('includes failed-phase alert when metas have failed phases', async () => {
@@ -302,6 +309,8 @@ describe('generateMetaMenu', () => {
     expect(menu).toContain('j:/domains/email/.meta');
     expect(menu).toContain('architect');
     expect(menu).toContain('band 3');
+    // 172800s = exactly 2 days
+    expect(menu).toContain('staleness 2d)');
   });
 
   it('omits phase sections when no phaseStateSummary in health', async () => {
@@ -310,5 +319,119 @@ describe('generateMetaMenu', () => {
     expect(menu).not.toContain('Phase State');
     expect(menu).not.toContain('Failed:');
     expect(menu).not.toContain('Next:');
+  });
+
+  // ── Issue #187: compound interval format ──
+
+  it('formats staleness with compound day+hour intervals', async () => {
+    const allFreshHealth = {
+      phaseStateSummary: {
+        architect: { fresh: 1, stale: 0, pending: 0, running: 0, failed: 0 },
+        builder: { fresh: 1, stale: 0, pending: 0, running: 0, failed: 0 },
+        critic: { fresh: 1, stale: 0, pending: 0, running: 0, failed: 0 },
+      },
+      nextPhase: {
+        path: 'j:/domains/test/.meta',
+        phase: 'architect' as const,
+        band: 1,
+        staleness: 97200, // 1 day + 3 hours
+      },
+      dependencies: {
+        watcher: { ...defaultWatcher },
+        gateway: { ...defaultGateway },
+      },
+    };
+    const client = mockClient({
+      statusOverrides: { health: allFreshHealth },
+      metasOverrides: {
+        metas: [{ stalenessSeconds: 5400 }], // 1h 30m
+      },
+    });
+    const menu = await generateMetaMenu(client);
+    // Next phase staleness: 97200s = 1d 3h
+    expect(menu).toContain('staleness 1d 3h)');
+    // Stalest display: 5400s = 1h 30m
+    expect(menu).toContain('1h 30m');
+  });
+
+  it('formats hour+minute intervals correctly', async () => {
+    const client = mockClient({
+      statusOverrides: {
+        health: {
+          phaseStateSummary: {
+            architect: {
+              fresh: 1,
+              stale: 0,
+              pending: 0,
+              running: 0,
+              failed: 0,
+            },
+            builder: { fresh: 1, stale: 0, pending: 0, running: 0, failed: 0 },
+            critic: { fresh: 1, stale: 0, pending: 0, running: 0, failed: 0 },
+          },
+          nextPhase: {
+            path: 'j:/domains/test/.meta',
+            phase: 'builder' as const,
+            band: 2,
+            staleness: 5700, // 1h 35m
+          },
+          dependencies: {
+            watcher: { ...defaultWatcher },
+            gateway: { ...defaultGateway },
+          },
+        },
+      },
+    });
+    const menu = await generateMetaMenu(client);
+    expect(menu).toContain('staleness 1h 35m)');
+  });
+
+  // ── Issue #185: failed-entity overflow (>10) test coverage ──
+
+  it('truncates failed-phase list with (+N more) when more than 10 entries', async () => {
+    // Build 12 failed metas to trigger the overflow branch
+    const failedMetas = Array.from({ length: 12 }, (_, i) => ({
+      stalenessSeconds: 100,
+      path: `j:/domains/test-${(i + 1).toString()}/.meta`,
+      phaseState: {
+        architect: 'failed' as const,
+        builder: 'fresh' as const,
+        critic: 'fresh' as const,
+      },
+    }));
+
+    const client = mockClient({
+      statusOverrides: {
+        health: {
+          phaseStateSummary: {
+            architect: {
+              fresh: 0,
+              stale: 0,
+              pending: 0,
+              running: 0,
+              failed: 12,
+            },
+            builder: { fresh: 12, stale: 0, pending: 0, running: 0, failed: 0 },
+            critic: { fresh: 12, stale: 0, pending: 0, running: 0, failed: 0 },
+          },
+          nextPhase: null,
+          dependencies: {
+            watcher: { ...defaultWatcher },
+            gateway: { ...defaultGateway },
+          },
+        },
+      },
+      metasOverrides: { metas: failedMetas },
+    });
+    const menu = await generateMetaMenu(client);
+    expect(menu).toContain('⚠ Failed:');
+    // First 10 entries shown, +2 overflow
+    expect(menu).toContain('(+2 more)');
+    // Verify some of the first 10 entries are shown
+    expect(menu).toContain('j:/domains/test-1/.meta (architect)');
+    expect(menu).toContain('j:/domains/test-10/.meta (architect)');
+    // Entry 11 and 12 should NOT appear directly
+    expect(menu).not.toContain('j:/domains/test-11/.meta');
+    expect(menu).not.toContain('j:/domains/test-12/.meta');
   });
 });

--- a/packages/openclaw/src/promptInjection.ts
+++ b/packages/openclaw/src/promptInjection.ts
@@ -15,6 +15,30 @@ import type {
   StatusResponse,
 } from './serviceClient.js';
 
+/** Phase statuses that require per-phase breakdown (everything except fresh). */
+const nonFreshStatuses = phaseStatuses.filter((s) => s !== 'fresh');
+
+/**
+ * Format a duration in seconds as a compound human-readable interval.
+ *
+ * Produces at most two units: `2d 3h`, `1h 35m`, `45m`, etc.
+ * Returns `'never synthesized'` for non-finite input.
+ *
+ * @param seconds - Duration in seconds.
+ * @returns Formatted interval string.
+ */
+export function formatAge(seconds: number): string {
+  if (!isFinite(seconds)) return 'never synthesized';
+  const d = Math.floor(seconds / 86400);
+  const h = Math.floor((seconds % 86400) / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (d > 0 && h > 0) return `${d.toString()}d ${h.toString()}h`;
+  if (d > 0) return `${d.toString()}d`;
+  if (h > 0 && m > 0) return `${h.toString()}h ${m.toString()}m`;
+  if (h > 0) return `${h.toString()}h`;
+  return `${Math.max(m, 1).toString()}m`;
+}
+
 /**
  * Generate the Meta menu Markdown for TOOLS.md.
  *
@@ -40,18 +64,6 @@ export async function generateMetaMenu(
   }
 
   const { summary } = metas;
-
-  const formatAge = (seconds: number): string => {
-    if (!isFinite(seconds)) return 'never synthesized';
-    const d = Math.floor(seconds / 86400);
-    const h = Math.floor((seconds % 86400) / 3600);
-    const m = Math.floor((seconds % 3600) / 60);
-    if (d > 0 && h > 0) return `${d.toString()}d ${h.toString()}h`;
-    if (d > 0) return `${d.toString()}d`;
-    if (h > 0 && m > 0) return `${h.toString()}h ${m.toString()}m`;
-    if (h > 0) return `${h.toString()}h`;
-    return `${Math.max(m, 1).toString()}m`;
-  };
 
   // Find stalest age
   let stalestAge = 0;
@@ -107,7 +119,6 @@ export async function generateMetaMenu(
     }
     const parts: string[] = [];
     if (freshTotal > 0) parts.push(freshTotal.toString() + ' fresh');
-    const nonFreshStatuses = phaseStatuses.filter((s) => s !== 'fresh');
     for (const phase of phaseNames) {
       for (const state of nonFreshStatuses) {
         const count = phaseSummary[phase][state];

--- a/packages/openclaw/src/promptInjection.ts
+++ b/packages/openclaw/src/promptInjection.ts
@@ -7,7 +7,7 @@
  * @module promptInjection
  */
 
-import { phaseNames } from '@karmaniverous/jeeves-meta-core';
+import { phaseNames, phaseStatuses } from '@karmaniverous/jeeves-meta-core';
 
 import type {
   MetaServiceClient,
@@ -43,9 +43,14 @@ export async function generateMetaMenu(
 
   const formatAge = (seconds: number): string => {
     if (!isFinite(seconds)) return 'never synthesized';
-    if (seconds < 3600) return Math.round(seconds / 60).toString() + 'm';
-    if (seconds < 86400) return Math.round(seconds / 3600).toString() + 'h';
-    return Math.round(seconds / 86400).toString() + 'd';
+    const d = Math.floor(seconds / 86400);
+    const h = Math.floor((seconds % 86400) / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    if (d > 0 && h > 0) return `${d.toString()}d ${h.toString()}h`;
+    if (d > 0) return `${d.toString()}d`;
+    if (h > 0 && m > 0) return `${h.toString()}h ${m.toString()}m`;
+    if (h > 0) return `${h.toString()}h`;
+    return `${Math.max(m, 1).toString()}m`;
   };
 
   // Find stalest age
@@ -93,24 +98,20 @@ export async function generateMetaMenu(
 
   // Phase-state summary from /status health
   const phaseLines: string[] = [];
-  const phaseSummary = status.health.phaseStateSummary as
-    | Record<string, Record<string, number>>
-    | undefined;
+  const phaseSummary = status.health.phaseStateSummary;
   if (phaseSummary) {
-    // Aggregate counts across all phases
-    const totals: Record<string, number> = {};
+    // Fresh counts are aggregated; non-fresh show <count> <state> <phase>
+    let freshTotal = 0;
     for (const phase of phaseNames) {
-      const counts = phaseSummary[phase];
-      for (const [state, count] of Object.entries(counts)) {
-        if (count > 0) {
-          totals[state] = (totals[state] ?? 0) + count;
-        }
-      }
+      freshTotal += phaseSummary[phase].fresh;
     }
     const parts: string[] = [];
-    for (const state of ['fresh', 'pending', 'running', 'stale', 'failed']) {
-      if (totals[state]) {
-        parts.push(totals[state].toString() + ' ' + state);
+    if (freshTotal > 0) parts.push(freshTotal.toString() + ' fresh');
+    const nonFreshStatuses = phaseStatuses.filter((s) => s !== 'fresh');
+    for (const phase of phaseNames) {
+      for (const state of nonFreshStatuses) {
+        const count = phaseSummary[phase][state];
+        if (count > 0) parts.push(`${count.toString()} ${state} ${phase}`);
       }
     }
     if (parts.length > 0) {
@@ -141,9 +142,7 @@ export async function generateMetaMenu(
   }
 
   // Next-phase indicator from /status health
-  const nextPhase = status.health.nextPhase as
-    | { path: string; phase: string; band: number; staleness: number }
-    | undefined;
+  const nextPhase = status.health.nextPhase;
   if (nextPhase) {
     phaseLines.push(
       'Next: ' +

--- a/packages/openclaw/src/serviceClient.ts
+++ b/packages/openclaw/src/serviceClient.ts
@@ -16,6 +16,8 @@ import {
   type MetaListSummary,
   type MetasItem,
   type MetasResponse,
+  type NextPhaseCandidate,
+  type PhaseStateSummary,
   type ServiceState,
   type WatcherDepHealth,
 } from '@karmaniverous/jeeves-meta-core';
@@ -27,6 +29,8 @@ export type {
   MetaListSummary,
   MetasItem,
   MetasResponse,
+  NextPhaseCandidate,
+  PhaseStateSummary,
   ServiceState,
   WatcherDepHealth,
 };
@@ -54,6 +58,10 @@ export interface StatusResponse {
       watcher: WatcherDepHealth;
       gateway: GatewayDepHealth;
     };
+    /** Per-phase counts of each status, from the scheduler. */
+    phaseStateSummary?: PhaseStateSummary;
+    /** Next phase candidate from the scheduler. */
+    nextPhase?: NextPhaseCandidate | null;
     [key: string]: unknown;
   };
 }

--- a/packages/service/README.md
+++ b/packages/service/README.md
@@ -14,6 +14,8 @@ HTTP service for the Jeeves knowledge synthesis engine. Provides a Fastify API, 
 - **Cross-meta references** — `_crossRefs` declares relationships to other metas; referenced `_content` included as architect/builder context
 - **Archive management** — timestamped snapshots with configurable pruning
 - **Lock staging** — write to `.lock` → copy to `meta.json` → archive (crash-safe)
+- **Staging file retry** — configurable retries (`stagingRetries`, `stagingRetryDelayMs`) when sub-agent output file is not yet visible after session completion (network/NFS latency)
+- **Preview delta cap** — `/preview` response includes `deltaFilesTruncated` flag and `deltaCount` total when delta files exceed `previewDeltaFilesCap`
 - **Virtual rule registration** — registers 3 watcher inference rules at startup with retry
 - **Progress reporting** — real-time synthesis events via gateway channel messages
 - **Graceful shutdown** — stop scheduler, release locks, close server

--- a/packages/service/guides/configuration.md
+++ b/packages/service/guides/configuration.md
@@ -38,6 +38,10 @@ The service reads a JSON config file specified via `--config` flag or `JEEVES_ME
 | `watcherHealthIntervalMs` | integer | `60000` | Periodic watcher health check interval in ms (min 0). 0 = disabled. |
 | `tier2ScanLimit` | integer | `50` | Max all-fresh candidates to scan per tick in Tier 2 invalidation (min 1) |
 | `autoSeed` | array | `[]` | Auto-seed policy rules (see below). Rules evaluated in order; last match wins for steer/crossRefs. |
+| `workspaceDir` | string | OS tmpdir + `/jeeves-meta` | Directory for synthesis staging files written by sub-agent sessions |
+| `stagingRetries` | integer | `10` | Max retries when staging file is not yet visible after session completion (min 0) |
+| `stagingRetryDelayMs` | integer | `250` | Delay between staging file retry attempts in ms (min 0) |
+| `previewDeltaFilesCap` | integer | `50` | Maximum number of delta files included in `/preview` response (min 1) |
 | `logging.level` | string | `"info"` | Log level (trace/debug/info/warn/error) |
 | `logging.file` | string | — | Log file path |
 

--- a/packages/service/src/bootstrap.ts
+++ b/packages/service/src/bootstrap.ts
@@ -74,6 +74,9 @@ export async function startService(
   const executor = new GatewayExecutor({
     gatewayUrl: config.gatewayUrl,
     apiKey: config.gatewayApiKey,
+    workspaceDir: config.workspaceDir,
+    stagingRetries: config.stagingRetries,
+    stagingRetryDelayMs: config.stagingRetryDelayMs,
   });
 
   // Runtime stats (mutable, shared with routes)

--- a/packages/service/src/cache.test.ts
+++ b/packages/service/src/cache.test.ts
@@ -41,6 +41,9 @@ function makeConfig(): ServiceConfig {
     tier2ScanLimit: 50,
     logging: { level: 'info' },
     autoSeed: [],
+    stagingRetries: 10,
+    stagingRetryDelayMs: 250,
+    previewDeltaFilesCap: 50,
   };
 }
 

--- a/packages/service/src/executor/GatewayExecutor.test.ts
+++ b/packages/service/src/executor/GatewayExecutor.test.ts
@@ -12,6 +12,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { sleepAsync } from '@karmaniverous/jeeves';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock sleepAsync to resolve with a minimal macrotask yield (the real 3s
@@ -555,6 +556,80 @@ describe('GatewayExecutor.spawn', () => {
     const outputPath = findOutputPath();
     expect(outputPath).toBeDefined();
     expect(existsSync(outputPath!)).toBe(false);
+  });
+
+  // ── Issue #202: staging file retry loop ──
+
+  it('retries staging file read when file not immediately visible after completion', async () => {
+    const executor = new GatewayExecutor({
+      gatewayUrl: 'http://localhost:18789',
+      pollIntervalMs: 10,
+      workspaceDir: testDir,
+      stagingRetries: 5,
+      stagingRetryDelayMs: 99, // unique value — distinguishable from pollIntervalMs
+    });
+
+    let stagingFileWritten = false;
+    let retrySleepCount = 0;
+
+    // Override sleepAsync: write the file when the 2nd staging retry sleep fires
+    const sleepMock = vi.mocked(sleepAsync);
+    sleepMock.mockImplementation(async (ms?: number) => {
+      if (ms === 99) {
+        retrySleepCount++;
+        if (retrySleepCount >= 2 && !stagingFileWritten) {
+          const op = findOutputPath();
+          if (op) {
+            writeFileSync(op, JSON.stringify({ _content: 'Retry output' }));
+            stagingFileWritten = true;
+          }
+        }
+      }
+      await new Promise<void>((r) => setTimeout(r, 0));
+    });
+
+    installMock({
+      sessionKey: 'sess-staging-retry',
+      sessions: [
+        { key: 'sess-staging-retry', totalTokens: 300, status: 'done' },
+      ],
+      // No onHistory — staging file not written during poll
+    });
+
+    const result = await executor.spawn('Task');
+    expect(result.output).toContain('Retry output');
+    expect(retrySleepCount).toBeGreaterThanOrEqual(2);
+
+    // Restore default mock
+    sleepMock.mockImplementation(
+      () => new Promise<void>((r) => setTimeout(r, 0)),
+    );
+  });
+
+  it('falls back to message text after exhausting all staging retries', async () => {
+    const executor = new GatewayExecutor({
+      gatewayUrl: 'http://localhost:18789',
+      pollIntervalMs: 10,
+      workspaceDir: testDir,
+      stagingRetries: 3,
+      stagingRetryDelayMs: 0,
+    });
+
+    installMock({
+      sessionKey: 'sess-retry-exhaust',
+      historyMessages: [
+        {
+          role: 'assistant',
+          content: 'Exhausted retry fallback',
+          stopReason: 'endTurn',
+        },
+      ],
+      sessions: [{ key: 'sess-retry-exhaust', status: 'done' }],
+      // No onHistory — staging file never written
+    });
+
+    const result = await executor.spawn('Task');
+    expect(result.output).toBe('Exhausted retry fallback');
   });
 
   it('continues polling when sessions_list throws transiently', async () => {

--- a/packages/service/src/executor/GatewayExecutor.test.ts
+++ b/packages/service/src/executor/GatewayExecutor.test.ts
@@ -632,6 +632,51 @@ describe('GatewayExecutor.spawn', () => {
     expect(result.output).toBe('Exhausted retry fallback');
   });
 
+  it('falls back immediately when stagingRetries is 0 (no retry iterations)', async () => {
+    // With stagingRetries: 0, the executor performs the initial unconditional read,
+    // finds no file, executes the loop 0 times, then falls back to message content.
+    // This explicitly tests the SOLID/DRY refactor where the initial read now
+    // precedes the loop and the loop only fires when that first read misses.
+    const executor = new GatewayExecutor({
+      gatewayUrl: 'http://localhost:18789',
+      pollIntervalMs: 10,
+      workspaceDir: testDir,
+      stagingRetries: 0,
+      stagingRetryDelayMs: 9999, // would be observable if the loop ran
+    });
+
+    const sleepMock = vi.mocked(sleepAsync);
+    const retrySleepcalls: (number | undefined)[] = [];
+    sleepMock.mockImplementation(async (ms?: number) => {
+      if (ms === 9999) retrySleepcalls.push(ms);
+      await new Promise<void>((r) => setTimeout(r, 0));
+    });
+
+    installMock({
+      sessionKey: 'sess-zero-retries',
+      historyMessages: [
+        {
+          role: 'assistant',
+          content: 'Zero-retry fallback',
+          stopReason: 'endTurn',
+        },
+      ],
+      sessions: [{ key: 'sess-zero-retries', status: 'done' }],
+      // No onHistory — staging file never written
+    });
+
+    const result = await executor.spawn('Task');
+    // Must fall back to message content
+    expect(result.output).toBe('Zero-retry fallback');
+    // Retry delay must never have been called (loop ran 0 times)
+    expect(retrySleepcalls).toHaveLength(0);
+
+    // Restore default mock
+    sleepMock.mockImplementation(
+      () => new Promise<void>((r) => setTimeout(r, 0)),
+    );
+  });
+
   it('continues polling when sessions_list throws transiently', async () => {
     const executor = new GatewayExecutor({
       gatewayUrl: 'http://localhost:18789',

--- a/packages/service/src/executor/GatewayExecutor.ts
+++ b/packages/service/src/executor/GatewayExecutor.ts
@@ -395,6 +395,12 @@ export class GatewayExecutor implements MetaExecutor {
           // Staging file not yet visible — retry with bounded grace window
           for (let i = 0; i < this.stagingRetries; i++) {
             await sleepAsync(this.stagingRetryDelayMs);
+            // Check abort after yield point — signal may have been
+            // set externally (e.g. operator abort) during the sleep.
+            if (this.aborted) {
+              this.cleanupOutputFile(outputPath);
+              throw new SpawnAbortedError();
+            }
             const retryOutput = this.readStagingFile(outputPath);
             if (retryOutput !== undefined)
               return { output: retryOutput, tokens };

--- a/packages/service/src/executor/GatewayExecutor.ts
+++ b/packages/service/src/executor/GatewayExecutor.ts
@@ -36,6 +36,10 @@ export interface GatewayExecutorOptions {
   pollIntervalMs?: number;
   /** Workspace directory for output staging. Default: OS temp dir + /jeeves-meta. */
   workspaceDir?: string;
+  /** Max retries when staging file not yet visible after session completion. Default: 10. */
+  stagingRetries?: number;
+  /** Delay between retries in ms. Default: 250. */
+  stagingRetryDelayMs?: number;
 }
 
 /** Response shape from /tools/invoke. */
@@ -72,6 +76,8 @@ export class GatewayExecutor implements MetaExecutor {
   private readonly apiKey: string | undefined;
   private readonly pollIntervalMs: number;
   private readonly workspaceDir: string;
+  private readonly stagingRetries: number;
+  private readonly stagingRetryDelayMs: number;
   private controller: AbortController = new AbortController();
 
   constructor(options: GatewayExecutorOptions = {}) {
@@ -82,6 +88,8 @@ export class GatewayExecutor implements MetaExecutor {
     this.apiKey = options.apiKey;
     this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
     this.workspaceDir = options.workspaceDir ?? join(tmpdir(), 'jeeves-meta');
+    this.stagingRetries = options.stagingRetries ?? 10;
+    this.stagingRetryDelayMs = options.stagingRetryDelayMs ?? 250;
   }
 
   /** Remove a temp output file if it exists. */
@@ -380,9 +388,12 @@ export class GatewayExecutor implements MetaExecutor {
             );
           }
 
-          // Normal completion — read output from file
-          const output = this.readStagingFile(outputPath);
-          if (output !== undefined) return { output, tokens };
+          // Normal completion — retry loop for staging file visibility before fallback
+          for (let i = 0; i < this.stagingRetries; i++) {
+            const output = this.readStagingFile(outputPath);
+            if (output !== undefined) return { output, tokens };
+            await sleepAsync(this.stagingRetryDelayMs);
+          }
 
           // Fallback: extract from message content if file wasn't written.
           // Skip ANNOUNCE_SKIP sentinel messages — the real output is in

--- a/packages/service/src/executor/GatewayExecutor.ts
+++ b/packages/service/src/executor/GatewayExecutor.ts
@@ -388,11 +388,16 @@ export class GatewayExecutor implements MetaExecutor {
             );
           }
 
-          // Normal completion — retry loop for staging file visibility before fallback
+          // Normal completion — read staging file with retry for delayed visibility
+          const output = this.readStagingFile(outputPath);
+          if (output !== undefined) return { output, tokens };
+
+          // Staging file not yet visible — retry with bounded grace window
           for (let i = 0; i < this.stagingRetries; i++) {
-            const output = this.readStagingFile(outputPath);
-            if (output !== undefined) return { output, tokens };
             await sleepAsync(this.stagingRetryDelayMs);
+            const retryOutput = this.readStagingFile(outputPath);
+            if (retryOutput !== undefined)
+              return { output: retryOutput, tokens };
           }
 
           // Fallback: extract from message content if file wasn't written.

--- a/packages/service/src/routes/__testUtils.ts
+++ b/packages/service/src/routes/__testUtils.ts
@@ -38,6 +38,9 @@ const DEFAULT_TEST_CONFIG: RouteDeps['config'] = {
   tier2ScanLimit: 50,
   logging: { level: 'info' },
   autoSeed: [],
+  stagingRetries: 10,
+  stagingRetryDelayMs: 250,
+  previewDeltaFilesCap: 50,
 };
 
 /** Default service stats for tests. */

--- a/packages/service/src/routes/preview.test.ts
+++ b/packages/service/src/routes/preview.test.ts
@@ -4,12 +4,12 @@
  * @module routes/preview.test
  */
 
-import { rmSync } from 'node:fs';
+import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import Fastify, { type FastifyInstance } from 'fastify';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   createTestMeta,
@@ -161,15 +161,38 @@ describe('GET /preview', () => {
 
   it('deltaFilesTruncated is true when delta files exceed previewDeltaFilesCap', async () => {
     const owner = join(previewRoot, 'delta-cap');
-    // Create 3 scope files all older than _generatedAt so they count as delta files
-    const generatedAt = new Date(Date.now() + 10_000).toISOString(); // future time
+    // _generatedAt in the past so newly-created scope files count as delta files
+    const generatedAt = new Date(Date.now() - 60_000).toISOString(); // 1 min ago
     const metaJsonPath = createTestMeta(owner, {
       _id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
       _generatedAt: generatedAt,
     });
-    const watcher = makeTestWatcher([metaJsonPath]);
+
+    // Create 3 scope files in the owner directory (not under .meta/).
+    // Their on-disk mtimes are current, which is newer than generatedAt.
+    const scopeFiles = ['scope-a.ts', 'scope-b.ts', 'scope-c.ts'].map(
+      (name) => {
+        const fp = join(owner, name);
+        writeFileSync(fp, 'content');
+        return fp;
+      },
+    );
+
+    // Use a mock that routes the two walk() calls separately:
+    //   1st call (discoverMetas): '**/.meta/meta.json'  → return only the meta
+    //   2nd call (getScopeFiles): '<ownerPath>/**'       → return meta + scope files
+    const customWatcher = {
+      walk: vi
+        .fn()
+        .mockResolvedValueOnce([metaJsonPath]) // discoverMetas
+        .mockResolvedValue([metaJsonPath, ...scopeFiles]), // getScopeFiles
+      registerRules: vi.fn().mockResolvedValue(undefined),
+      scan: vi.fn().mockResolvedValue({ points: [], cursor: null }),
+    };
+
+    // Cap at 2, but we have 3 delta scope files — so deltaFilesTruncated must be true
     const deps = makeTestDeps({
-      watcher,
+      watcher: customWatcher,
       config: { previewDeltaFilesCap: 2 },
     });
     app = Fastify();
@@ -185,8 +208,9 @@ describe('GET /preview', () => {
     const body = res.json<{
       scope: { deltaFilesTruncated: boolean; deltaCount: number };
     }>();
-    // deltaFilesTruncated is always present in the response
-    expect(body.scope).toHaveProperty('deltaFilesTruncated');
+    expect(body.scope.deltaFilesTruncated).toBe(true);
+    // deltaCount is the total before truncation
+    expect(body.scope.deltaCount).toBe(3);
   });
 
   it('deltaFilesTruncated is false when delta files are within cap', async () => {

--- a/packages/service/src/routes/preview.test.ts
+++ b/packages/service/src/routes/preview.test.ts
@@ -159,6 +159,63 @@ describe('GET /preview', () => {
     expect(body.error).toBe('NOT_FOUND');
   });
 
+  it('deltaFilesTruncated is true when delta files exceed previewDeltaFilesCap', async () => {
+    const owner = join(previewRoot, 'delta-cap');
+    // Create 3 scope files all older than _generatedAt so they count as delta files
+    const generatedAt = new Date(Date.now() + 10_000).toISOString(); // future time
+    const metaJsonPath = createTestMeta(owner, {
+      _id: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+      _generatedAt: generatedAt,
+    });
+    const watcher = makeTestWatcher([metaJsonPath]);
+    const deps = makeTestDeps({
+      watcher,
+      config: { previewDeltaFilesCap: 2 },
+    });
+    app = Fastify();
+    registerPreviewRoute(app, deps);
+    await app.ready();
+
+    const metaDir = join(owner, '.meta');
+    const res = await app.inject({
+      method: 'GET',
+      url: `/preview?path=${encodeURIComponent(metaDir)}`,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      scope: { deltaFilesTruncated: boolean; deltaCount: number };
+    }>();
+    // deltaFilesTruncated is always present in the response
+    expect(body.scope).toHaveProperty('deltaFilesTruncated');
+  });
+
+  it('deltaFilesTruncated is false when delta files are within cap', async () => {
+    const owner = join(previewRoot, 'delta-within-cap');
+    const metaJsonPath = createTestMeta(owner, {
+      _id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+      _generatedAt: new Date(Date.now() - 3600_000).toISOString(),
+    });
+    const watcher = makeTestWatcher([metaJsonPath]);
+    const deps = makeTestDeps({
+      watcher,
+      config: { previewDeltaFilesCap: 100 },
+    });
+    app = Fastify();
+    registerPreviewRoute(app, deps);
+    await app.ready();
+
+    const metaDir = join(owner, '.meta');
+    const res = await app.inject({
+      method: 'GET',
+      url: `/preview?path=${encodeURIComponent(metaDir)}`,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      scope: { deltaFilesTruncated: boolean };
+    }>();
+    expect(body.scope.deltaFilesTruncated).toBe(false);
+  });
+
   it('architect is triggered for fresh meta (no _builder)', async () => {
     const owner = join(previewRoot, 'fresh');
     const metaJsonPath = createTestMeta(owner, {

--- a/packages/service/src/routes/preview.ts
+++ b/packages/service/src/routes/preview.ts
@@ -127,9 +127,10 @@ export function registerPreviewRoute(
         ownedFiles: scopeFiles.length,
         childMetas: targetNode.children.length,
         deltaFiles: deltaFiles
-          .slice(0, 50)
+          .slice(0, config.previewDeltaFilesCap)
           .map((f) => ({ path: f, action: 'modified' as const })),
         deltaCount: deltaFiles.length,
+        deltaFilesTruncated: deltaFiles.length > config.previewDeltaFilesCap,
       },
       estimatedTokens,
       // New phase-state fields (additive)

--- a/packages/service/src/routes/status.ts
+++ b/packages/service/src/routes/status.ts
@@ -11,7 +11,8 @@ import { createStatusHandler } from '@karmaniverous/jeeves';
 import {
   type DepHealth,
   getEndpoint,
-  type PhaseName,
+  type NextPhaseCandidate,
+  type PhaseStateSummary,
   type PhaseStatus,
   type ServiceState,
 } from '@karmaniverous/jeeves-meta-core';
@@ -75,10 +76,7 @@ function deriveServiceState(deps: RouteDeps): ServiceState {
   return 'idle';
 }
 
-/** Phase state count record. */
-type PhaseStateCounts = Record<PhaseStatus, number>;
-
-function emptyPhaseCounts(): PhaseStateCounts {
+function emptyPhaseCounts(): Record<PhaseStatus, number> {
   return { fresh: 0, stale: 0, pending: 0, running: 0, failed: 0 };
 }
 
@@ -99,18 +97,13 @@ export function registerStatusRoute(
       ]);
 
       // Phase state summary
-      const phaseStateSummary: Record<PhaseName, PhaseStateCounts> = {
+      const phaseStateSummary: PhaseStateSummary = {
         architect: emptyPhaseCounts(),
         builder: emptyPhaseCounts(),
         critic: emptyPhaseCounts(),
       };
 
-      let nextPhase: {
-        path: string;
-        phase: PhaseName;
-        band: number;
-        staleness: number;
-      } | null = null;
+      let nextPhase: NextPhaseCandidate | null = null;
 
       try {
         const metaResult = await cache.get(config, watcher);

--- a/packages/service/src/scheduler/scheduler.test.ts
+++ b/packages/service/src/scheduler/scheduler.test.ts
@@ -39,6 +39,9 @@ function createTestConfig() {
     tier2ScanLimit: 50,
     logging: { level: 'info' },
     autoSeed: [],
+    stagingRetries: 10,
+    stagingRetryDelayMs: 250,
+    previewDeltaFilesCap: 50,
   };
 }
 

--- a/packages/service/src/schema/config.ts
+++ b/packages/service/src/schema/config.ts
@@ -69,6 +69,18 @@ export const serviceConfigSchema = metaConfigSchema.extend({
    * Rules are evaluated in order; last match wins for steer/crossRefs.
    */
   autoSeed: z.array(autoSeedRuleSchema).optional().default([]),
+
+  /** Optional workspace directory for synthesis staging files. Defaults to `os.tmpdir() + '/jeeves-meta'`. */
+  workspaceDir: z.string().optional(),
+
+  /** Max retries when staging file not yet visible after session completion. Default: 10. */
+  stagingRetries: z.number().int().min(0).default(10),
+
+  /** Delay between staging file retries in ms. Default: 250. */
+  stagingRetryDelayMs: z.number().int().min(0).default(250),
+
+  /** Maximum number of delta files returned in /preview response. Default: 50. */
+  previewDeltaFilesCap: z.number().int().min(1).default(50),
 });
 
 /** Inferred type for service configuration. */


### PR DESCRIPTION
## Release 0.17.0 Batch — 10 issues

### Core (#202)
- **Configurable workspaceDir** — staging file directory wired from service config; defaults to os.tmpdir() + '/jeeves-meta' (status quo), operators can override
- **Staging-file completion retry** — configurable retry loop (stagingRetries, stagingRetryDelayMs) before falling back to message text extraction, fixing the race where the staging file isn't yet visible after session completion

### Bug fixes
- **#190** — _phaseState → phaseState in endpoint catalog descriptions (listMetas, metaDetail)
- **#203** — Replaced hardcoded j: in meta_seed crossRefs example with generic <drive label>: placeholder

### Tool descriptions / typing (#191, #192, #193)
- **#191** — Added PhaseStateSummary and NextPhaseCandidate types to core contracts; replaced s casts in plugin and local types in status route
- **#192** — meta_detail description now mentions crossRefs in response
- **#193** — meta_update description now documents response shape and 400 rejection

### TOOLS.md polish (#178, #187)
- **#178** — Phase-state summary now shows per-phase breakdown for non-fresh states (e.g. \3 pending architect, 1 running builder\); fresh remains aggregated
- **#187** — Staleness display uses compound intervals (\2d 3h\, \1h 35m\) instead of single-unit (\2d\)

### Preview enhancement (#188)
- **#188** — \/preview\ deltaFiles cap configurable via \previewDeltaFilesCap\ config field; response includes \deltaFilesTruncated\ indicator

### Test coverage (#185)
- **#185** — Added test with 12 failed metas exercising the overflow \(+N more)\ branch

### Documentation
- Updated \packages/service/guides/configuration.md\ with new config fields

### Quality
- Build ✅ | 561 tests ✅ | Typecheck ✅ | Lint ✅ | Knip ✅ (pre-existing rollup false positive only)

Closes #178, #185, #187, #188, #190, #191, #192, #193, #202, #203