### PR TITLE
fix: batch resolve #204, #206, #207, #208

### DIFF
--- a/packages/core/src/metaConfig.ts
+++ b/packages/core/src/metaConfig.ts
@@ -28,22 +28,14 @@ export const metaConfigSchema = z.object({
   /** Thinking level for spawned synthesis sessions. */
   thinking: z.string().default('low'),
 
-  /** Resolved architect system prompt text. Falls back to built-in default. */
-  defaultArchitect: z.string().optional(),
-
-  /** Resolved critic system prompt text. Falls back to built-in default. */
-  defaultCritic: z.string().optional(),
-
   /** Skip unchanged candidates, bump _generatedAt. */
   skipUnchanged: z.boolean().default(true),
 
-  /** Watcher metadata properties applied to live .meta/meta.json files. */
-  metaProperty: z.record(z.string(), z.unknown()).default({ _meta: 'current' }),
+  /** Watcher metadata properties applied to live .meta/meta.json files. No default — set by installer. */
+  metaProperty: z.record(z.string(), z.unknown()),
 
-  /** Watcher metadata properties applied to archive snapshots. */
-  metaArchiveProperty: z
-    .record(z.string(), z.unknown())
-    .default({ _meta: 'archive' }),
+  /** Watcher metadata properties applied to archive snapshots. No default — set by installer. */
+  metaArchiveProperty: z.record(z.string(), z.unknown()),
 });
 
 /** Inferred type for core meta configuration. */

--- a/packages/openclaw/skills/jeeves-meta/SKILL.md
+++ b/packages/openclaw/skills/jeeves-meta/SKILL.md
@@ -202,8 +202,8 @@ Key settings:
 | `watcherUrl` | (required) | Watcher service URL (e.g. `http://localhost:1936`) |
 | `gatewayUrl` | `http://127.0.0.1:18789` | OpenClaw gateway URL for subprocess spawning |
 | `gatewayApiKey` | (optional) | API key for gateway authentication |
-| `metaProperty` | `{ _meta: "current" }` | Watcher metadata properties applied to live `.meta/meta.json` files. `Record<string, unknown>` — any shape accepted. |
-| `metaArchiveProperty` | `{ _meta: "archive" }` | Watcher metadata properties applied to `.meta/archive/**` snapshots. Same shape flexibility. |
+| `metaProperty` | (required) | Watcher metadata properties applied to live `.meta/meta.json` files. `Record<string, unknown>` — any shape accepted. Avoid underscore-prefixed keys (e.g. `_meta`) — they may conflict with watcher reserved fields and break rendering. |
+| `metaArchiveProperty` | (required) | Watcher metadata properties applied to `.meta/archive/**` snapshots. Same shape flexibility and underscore-prefix caveat as `metaProperty`. |
 | `architectEvery` | 10 | Re-run architect every N cycles even if structure unchanged |
 | `depthWeight` | 0.5 | Exponent for depth-based scheduling (0 = pure staleness) |
 | `maxArchive` | 20 | Max archived snapshots per meta |
@@ -214,6 +214,7 @@ Key settings:
 
 | `schedule` | `*/30 * * * *` | Cron expression for automatic synthesis scheduling |
 | `serverBaseUrl` | (optional) | Public base URL of the service (e.g. `http://myhost:1938`). When set, progress reports include clickable entity links. |
+| `serverDriveRoots` | (optional) | Drive label to absolute path mapping for Linux path resolution in progress links (e.g. `{ "content": "/opt/jeeves/content" }`). |
 | `reportChannel` | (optional) | Gateway channel name (e.g. `slack`). Legacy: also used as target if `reportTarget` is unset. |
 | `reportTarget` | (optional) | Channel/user ID to send progress messages to |
 | `tier2ScanLimit` | 50 | Max all-fresh candidates to scan per tick in Tier 2 invalidation |
@@ -275,24 +276,13 @@ properties.
 
 ### Prompt System
 
-The service ships with built-in default architect and critic prompts. Most
-installations need no prompt configuration at all.
-
-**Overriding defaults:** Set `defaultArchitect` and/or `defaultCritic` in the
-config to replace the built-in prompts. Supports `@file:` references resolved
-relative to the config file's directory:
-
-```json
-{
-  "defaultArchitect": "@file:jeeves-meta/prompts/architect.md",
-  "defaultCritic": "@file:jeeves-meta/prompts/critic.md"
-}
-```
+The service ships with built-in default architect and critic prompts. Prompts
+ship with the package and cannot be overridden via config.
 
 **Per-meta overrides:** Set `_architect` or `_critic` directly in a `meta.json`
 to override the defaults for that specific entity.
 
-**Template variables:** All prompts (default, config-overridden, and per-meta)
+**Template variables:** All prompts (built-in and per-meta)
 are compiled as Handlebars templates at synthesis time with access to:
 
 - `{{config.maxLines}}`, `{{config.architectEvery}}`, etc.
@@ -306,19 +296,20 @@ prompt is compiled.
 
 ### Minimal Config Example
 
-A minimum viable config file requires only `watcherUrl`:
+A minimum viable config file requires `watcherUrl`, `metaProperty`, and `metaArchiveProperty`:
 
 ```json
 {
   "watcherUrl": "http://localhost:1936",
   "gatewayUrl": "http://127.0.0.1:18789",
-  "gatewayApiKey": "your-api-key"
+  "gatewayApiKey": "your-api-key",
+  "metaProperty": { "_meta": "current" },
+  "metaArchiveProperty": { "_meta": "archive" }
 }
 ```
 
 All other fields use sensible defaults (port 1938, schedule every 30 min,
-depth weight 0.5, built-in prompts, etc). Add `reportChannel`, `metaProperty`,
-`logging`, etc. as needed.
+depth weight 0.5, built-in prompts, etc). Add `reportChannel`, `logging`, etc. as needed.
 
 ### Adding New Metas
 
@@ -414,8 +405,6 @@ restart-required fields:
 - `watcherUrl` — watcher service URL
 - `gatewayUrl` — OpenClaw gateway URL
 - `gatewayApiKey` — gateway authentication key
-- `defaultArchitect` — architect system prompt
-- `defaultCritic` — critic system prompt
 
 Edit the config file and save; the service detects changes via `fs.watchFile`.
 When a restart-required field changes, the service logs a warning but the
@@ -461,14 +450,11 @@ Before the synthesis engine can operate:
    - Verify: `curl http://localhost:6333/healthz`
 
 4. **Config file** must exist at the path specified by `JEEVES_META_CONFIG`
-   - Must contain valid `watcherUrl`
-   - `defaultArchitect` and `defaultCritic` are optional (built-in defaults
-     ship with the package). Set them only to override the defaults.
+   - Must contain valid `watcherUrl`, `metaProperty`, and `metaArchiveProperty`
+   - Built-in architect and critic prompts ship with the package; no prompt
+     configuration is required
 
-5. **Prompt files** must exist only if using `@file:` references in config
-   - Not needed if using the built-in defaults (most installations)
-
-6. **`.meta/` directories** must exist and be within paths the watcher indexes
+5. **`.meta/` directories** must exist and be within paths the watcher indexes
    - Seed new metas: `jeeves-meta seed <path>`
 
 ### Installation
@@ -700,12 +686,11 @@ not yet indexed new files
 - First-run quality is lower — the feedback loop needs 2-3 cycles to calibrate.
 - Changing `metaProperty` requires both a meta service restart AND a watcher reindex.
   The service restart re-registers virtual rules; the reindex retags existing points.
-- `defaultArchitect`/`defaultCritic` are optional — built-in defaults ship with
-  the package. The `@file:` prefix (when used) is resolved relative to the config
-  file's directory, not the working directory.
-- All prompts are compiled as Handlebars templates. Avoid using `{{` in prompt
-  overrides unless you intend template variable resolution. Escape with `\{{`
-  for literal double-braces.
+- Built-in architect and critic prompts ship with the package and cannot be
+  overridden via config.
+- All prompts (built-in and per-meta `_architect`/`_critic`) are compiled as
+  Handlebars templates. Avoid using `{{` in prompt text unless you intend
+  template variable resolution. Escape with `\{{` for literal double-braces.
 - The synthesis queue is single-threaded with three layers: `current` (the
   running phase), `overrides` (explicitly triggered entries, highest priority),
   and `automatic` (scheduler-computed candidates). Override entries are

--- a/packages/service/README.md
+++ b/packages/service/README.md
@@ -19,7 +19,7 @@ HTTP service for the Jeeves knowledge synthesis engine. Provides a Fastify API, 
 - **Virtual rule registration** — registers 3 watcher inference rules at startup with retry
 - **Progress reporting** — real-time synthesis events via gateway channel messages
 - **Graceful shutdown** — stop scheduler, release locks, close server
-- **Built-in prompts** — default architect and critic prompts ship with the package; optional config overrides via `@file:` or inline strings
+- **Built-in prompts** — default architect and critic prompts ship with the package
 - **Handlebars templates** — prompts compiled with `{ config, meta, scope }` context; architect can write template expressions into builder briefs
 - **Config hot-reload** — all synthesis parameters reload without restart; restart-required fields (port, URLs) warn on change
 - **Auto-seed policy** — config-driven declarative `.meta/` creation via `autoSeed` rules

--- a/packages/service/guides/configuration.md
+++ b/packages/service/guides/configuration.md
@@ -13,28 +13,25 @@ The service reads a JSON config file specified via `--config` flag or `JEEVES_ME
 | `watcherUrl` | string (URL) | — | Watcher service base URL (required) |
 | `gatewayUrl` | string (URL) | `http://127.0.0.1:18789` | OpenClaw gateway URL |
 | `gatewayApiKey` | string | — | Gateway authentication key |
-| `defaultArchitect` | string | (built-in) | Architect system prompt override. Supports `@file:` references. Omit to use built-in default. |
-| `defaultCritic` | string | (built-in) | Critic system prompt override. Supports `@file:` references. Omit to use built-in default. |
 | `architectEvery` | integer | `10` | Run architect every N cycles per meta (min 1) |
 | `depthWeight` | number | `0.5` | Exponent for depth weighting in staleness formula (min 0) |
 | `maxArchive` | integer | `20` | Maximum archive snapshots per meta (min 1) |
 | `maxLines` | integer | `500` | Max context lines in subprocess prompts (min 50) |
-
 | `thinking` | string | `"low"` | Thinking level for spawned sessions |
 | `skipUnchanged` | boolean | `true` | Skip candidates with no file changes |
-| `metaProperty` | object | `{ _meta: "current" }` | Watcher metadata for live meta.json files |
-| `metaArchiveProperty` | object | `{ _meta: "archive" }` | Watcher metadata for archive snapshots |
+| `metaProperty` | object | — (required) | Watcher metadata for live meta.json files. Avoid underscore-prefixed keys (e.g. `_meta`) — they may conflict with watcher reserved fields and break rendering. |
+| `metaArchiveProperty` | object | — (required) | Watcher metadata for archive snapshots. Same underscore-prefix caveat as `metaProperty`. |
 
 ## Service Fields (extends MetaConfig)
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `port` | integer | `1938` | HTTP listen port (min 1, max 65535) |
-
 | `schedule` | string | `*/30 * * * *` | Cron expression for synthesis scheduling |
 | `reportChannel` | string | — | Gateway channel name (e.g. `slack`). Legacy: also used as target if `reportTarget` is unset. |
 | `reportTarget` | string | — | Channel/user ID to send progress messages to |
 | `serverBaseUrl` | string | — | Base URL for entity links in progress reports (e.g. `http://myserver:1938`) |
+| `serverDriveRoots` | object | — | Drive label to absolute path mapping for Linux path resolution in progress links (e.g. `{ "content": "/opt/jeeves/content" }`) |
 | `watcherHealthIntervalMs` | integer | `60000` | Periodic watcher health check interval in ms (min 0). 0 = disabled. |
 | `tier2ScanLimit` | integer | `50` | Max all-fresh candidates to scan per tick in Tier 2 invalidation (min 1) |
 | `autoSeed` | array | `[]` | Auto-seed policy rules (see below). Rules evaluated in order; last match wins for steer/crossRefs. |
@@ -62,12 +59,9 @@ Each rule in the `autoSeed` array has the shape:
 All config fields hot-reload without a service restart **except** these restart-required fields:
 
 - `port` — HTTP listen port
-
 - `watcherUrl` — watcher service URL
 - `gatewayUrl` — OpenClaw gateway URL
 - `gatewayApiKey` — gateway authentication key
-- `defaultArchitect` — architect system prompt
-- `defaultCritic` — critic system prompt
 
 When a restart-required field changes, the service logs a warning but the change does not take effect until restart. All other fields (including `schedule`, `reportChannel`, `autoSeed`, timeouts, `metaProperty`, `logging.level`, etc.) are applied immediately on config file save.
 
@@ -81,13 +75,8 @@ Config values support `${VAR}` substitution from environment variables. Example:
 
 ## Prompt System
 
-The service ships with built-in default architect and critic prompts. `defaultArchitect` and `defaultCritic` are optional — set them only to override the built-in defaults.
+The service ships with built-in default architect and critic prompts. Prompts ship with the package and cannot be overridden via config.
 
-When set, they support `@file:` references resolved relative to the config file:
+All prompts (built-in and per-meta `_architect`/`_critic`) are compiled as Handlebars templates at synthesis time. Available variables include `{{config.*}}` (all config fields), `{{scope.*}}` (fileCount, deltaCount, childCount, crossRefCount), and `{{meta.*}}` (per-meta fields). Escape with `\{{` for literal double-braces.
 
-```json
-{ "defaultArchitect": "@file:prompts/architect.md" }
-```
-
-All prompts (built-in, config-overridden, and per-meta `_architect`/`_critic`) are compiled as Handlebars templates at synthesis time. Available variables include `{{config.*}}` (all config fields), `{{scope.*}}` (fileCount, deltaCount, childCount, crossRefCount), and `{{meta.*}}` (per-meta fields). Escape with `\{{` for literal double-braces.
-
+The architect prompt can write template expressions into its builder brief using escaped syntax (`\{{config.maxLines}}`). These pass through the architect compilation as literal `{{...}}` text and resolve when the builder prompt is compiled.

--- a/packages/service/src/cache.test.ts
+++ b/packages/service/src/cache.test.ts
@@ -30,8 +30,6 @@ function makeConfig(): ServiceConfig {
     maxArchive: 20,
     maxLines: 500,
     thinking: 'low',
-    defaultArchitect: 'a',
-    defaultCritic: 'c',
     skipUnchanged: true,
     metaProperty: {},
     metaArchiveProperty: {},

--- a/packages/service/src/configHotReload.test.ts
+++ b/packages/service/src/configHotReload.test.ts
@@ -23,6 +23,8 @@ import { serviceConfigSchema } from './schema/config.js';
 function makeConfig(overrides: Partial<ServiceConfig> = {}): ServiceConfig {
   return serviceConfigSchema.parse({
     watcherUrl: 'http://127.0.0.1:1936',
+    metaProperty: { _meta: 'current' },
+    metaArchiveProperty: { _meta: 'archive' },
     ...overrides,
   });
 }
@@ -235,8 +237,6 @@ describe('RESTART_REQUIRED_FIELDS', () => {
     expect(RESTART_REQUIRED_FIELDS).toContain('watcherUrl');
     expect(RESTART_REQUIRED_FIELDS).toContain('gatewayUrl');
     expect(RESTART_REQUIRED_FIELDS).toContain('gatewayApiKey');
-    expect(RESTART_REQUIRED_FIELDS).toContain('defaultArchitect');
-    expect(RESTART_REQUIRED_FIELDS).toContain('defaultCritic');
   });
 
   it('does not include hot-reloadable fields', () => {

--- a/packages/service/src/configHotReload.ts
+++ b/packages/service/src/configHotReload.ts
@@ -23,8 +23,6 @@ export const RESTART_REQUIRED_FIELDS = [
   'watcherUrl',
   'gatewayUrl',
   'gatewayApiKey',
-  'defaultArchitect',
-  'defaultCritic',
 ] as const;
 
 interface ConfigHotReloadRuntime {

--- a/packages/service/src/configLoader.ts
+++ b/packages/service/src/configLoader.ts
@@ -1,13 +1,13 @@
 /**
  * Load and resolve jeeves-meta service config.
  *
- * Supports \@file: indirection and environment-variable substitution (dollar-brace pattern).
+ * Supports environment-variable substitution (dollar-brace pattern).
  *
  * @module configLoader
  */
 
 import { copyFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 
 import { type ServiceConfig, serviceConfigSchema } from './schema/config.js';
 
@@ -41,19 +41,6 @@ function substituteEnvVars(value: unknown): unknown {
   }
 
   return value;
-}
-
-/**
- * Resolve \@file: references in a config value.
- *
- * @param value - String value that may start with "\@file:".
- * @param baseDir - Base directory for resolving relative paths.
- * @returns The resolved string (file contents or original value).
- */
-function resolveFileRef(value: string, baseDir: string): string {
-  if (!value.startsWith('@file:')) return value;
-  const filePath = join(baseDir, value.slice(6));
-  return readFileSync(filePath, 'utf8');
 }
 
 /**
@@ -111,8 +98,7 @@ export function resolveConfigPath(args: string[]): string {
 /**
  * Load service config from a JSON file.
  *
- * Resolves \@file: references for defaultArchitect and defaultCritic,
- * and substitutes environment-variable placeholders throughout.
+ * Substitutes environment-variable placeholders throughout.
  *
  * @param configPath - Path to config JSON file.
  * @returns Validated ServiceConfig.
@@ -120,14 +106,6 @@ export function resolveConfigPath(args: string[]): string {
 export function loadServiceConfig(configPath: string): ServiceConfig {
   const rawText = readFileSync(configPath, 'utf8');
   const raw = substituteEnvVars(JSON.parse(rawText)) as Record<string, unknown>;
-  const baseDir = dirname(configPath);
-
-  if (typeof raw['defaultArchitect'] === 'string') {
-    raw['defaultArchitect'] = resolveFileRef(raw['defaultArchitect'], baseDir);
-  }
-  if (typeof raw['defaultCritic'] === 'string') {
-    raw['defaultCritic'] = resolveFileRef(raw['defaultCritic'], baseDir);
-  }
 
   return serviceConfigSchema.parse(raw);
 }

--- a/packages/service/src/discovery/listMetas.test.ts
+++ b/packages/service/src/discovery/listMetas.test.ts
@@ -15,8 +15,6 @@ function makeConfig(overrides: Partial<MetaConfig> = {}): MetaConfig {
     watcherUrl: 'http://localhost:1936',
     gatewayUrl: 'http://localhost:3000',
     gatewayApiKey: 'test',
-    defaultArchitect: 'architect prompt',
-    defaultCritic: 'critic prompt',
     architectEvery: 5,
     thinking: 'low',
     maxLines: 500,

--- a/packages/service/src/orchestrator/buildTask.ts
+++ b/packages/service/src/orchestrator/buildTask.ts
@@ -197,7 +197,7 @@ export function buildArchitectTask(
   const sections = [
     `# jeeves-meta · ARCHITECT · ${ctx.path}`,
     '',
-    config.defaultArchitect ?? DEFAULT_ARCHITECT_PROMPT,
+    DEFAULT_ARCHITECT_PROMPT,
     '',
     '## SCOPE',
     `Path: ${ctx.path}`,
@@ -302,6 +302,9 @@ export function buildBuilderTask(
     '',
     'DIAGRAMS: When diagrams would aid understanding, use PlantUML in fenced code blocks (```plantuml).',
     'PlantUML is rendered natively by the serving infrastructure. NEVER use ASCII art diagrams.',
+    '',
+    'IMPORTANT: Do not call sessions_spawn or sessions_yield. Read all files directly using the tools',
+    'available in your session. Do not attempt to parallelize work by spawning sub-agents.',
   );
 
   return compileTemplate(
@@ -326,7 +329,7 @@ export function buildCriticTask(
   const sections = [
     `# jeeves-meta · CRITIC · ${ctx.path}`,
     '',
-    config.defaultCritic ?? DEFAULT_CRITIC_PROMPT,
+    DEFAULT_CRITIC_PROMPT,
     '',
     '## SYNTHESIS TO EVALUATE',
     meta._content ?? '(No content produced)',

--- a/packages/service/src/orchestrator/orchestrator.test.ts
+++ b/packages/service/src/orchestrator/orchestrator.test.ts
@@ -1,4 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock prompts so tests use stable, known template expressions.
+vi.mock('../prompts/index.js', () => ({
+  DEFAULT_ARCHITECT_PROMPT:
+    'You are an architect. Every {{config.architectEvery}} cycles, ' +
+    '{{scope.fileCount}} files, depth {{meta._depth}}. ' +
+    'Escaped: \\{{config.architectEvery}}.',
+  DEFAULT_CRITIC_PROMPT: 'You are a critic. Max lines: {{config.maxLines}}.',
+}));
 
 import type { MetaContext } from '../interfaces/index.js';
 import type { MetaConfig, MetaJson } from '../schema/index.js';
@@ -21,8 +30,6 @@ const sampleConfig: MetaConfig = {
   maxArchive: 20,
   maxLines: 500,
   thinking: 'low',
-  defaultArchitect: 'You are an architect. Analyze the data shape.',
-  defaultCritic: 'You are a critic. Evaluate the synthesis.',
   skipUnchanged: true,
   metaProperty: { domains: ['meta'] },
   metaArchiveProperty: { domains: ['meta-archive'] },
@@ -50,7 +57,7 @@ const sampleCtx: MetaContext = {
 };
 
 describe('buildArchitectTask', () => {
-  it('includes scope, steer, previous content, previous feedback, and child metas', () => {
+  it('includes built-in prompt, scope, steer, previous content, previous feedback, and child metas', () => {
     const task = buildArchitectTask(sampleCtx, sampleMeta, sampleConfig);
     expect(task).toContain('You are an architect');
     expect(task).toContain('/test/a.md');
@@ -60,7 +67,7 @@ describe('buildArchitectTask', () => {
     expect(task).toContain('Child synthesis content');
   });
 
-  it('ignores meta._architect snapshot and uses config default', () => {
+  it('ignores meta._architect snapshot and always uses DEFAULT_ARCHITECT_PROMPT', () => {
     const meta: MetaJson = {
       ...sampleMeta,
       _architect: 'Stale snapshot prompt',
@@ -68,6 +75,18 @@ describe('buildArchitectTask', () => {
     const task = buildArchitectTask(sampleCtx, meta, sampleConfig);
     expect(task).not.toContain('Stale snapshot prompt');
     expect(task).toContain('You are an architect');
+  });
+
+  it('includes IMPORTANT sub-agent prohibition in builder task output format', () => {
+    const task = buildBuilderTask(
+      sampleCtx,
+      { ...sampleMeta, _builder: 'brief' },
+      sampleConfig,
+    );
+    expect(task).toContain('Do not call sessions_spawn or sessions_yield');
+    expect(task).toContain(
+      'Do not attempt to parallelize work by spawning sub-agents',
+    );
   });
 });
 
@@ -115,7 +134,7 @@ describe('buildBuilderTask', () => {
 });
 
 describe('buildCriticTask', () => {
-  it('includes system prompt, content to evaluate, and scope', () => {
+  it('includes built-in critic prompt, content to evaluate, and steer', () => {
     const task = buildCriticTask(sampleCtx, sampleMeta, sampleConfig);
     expect(task).toContain('You are a critic');
     expect(task).toContain('Previous synthesis');
@@ -124,51 +143,36 @@ describe('buildCriticTask', () => {
 });
 
 describe('Handlebars template compilation in prompts', () => {
-  it('resolves config values in architect prompt via {{config.*}}', () => {
-    const configWithTemplate: MetaConfig = {
-      ...sampleConfig,
-      defaultArchitect:
-        'Every {{config.architectEvery}} cycles. Max {{config.maxLines}} lines.',
-    };
-    const task = buildArchitectTask(sampleCtx, sampleMeta, configWithTemplate);
+  // Prompts are mocked at module level (vi.mock above) with template expressions.
+  // These tests verify that Handlebars compilation resolves those expressions.
+
+  it('resolves {{config.*}} values in DEFAULT_ARCHITECT_PROMPT', () => {
+    // Mock prompt: '...Every {{config.architectEvery}} cycles...'
+    const task = buildArchitectTask(sampleCtx, sampleMeta, sampleConfig);
     expect(task).toContain('Every 10 cycles');
-    expect(task).toContain('Max 500 lines');
   });
 
-  it('resolves scope values via {{scope.*}}', () => {
-    const configWithTemplate: MetaConfig = {
-      ...sampleConfig,
-      defaultArchitect:
-        'Files: {{scope.fileCount}}, delta: {{scope.deltaCount}}',
-    };
-    const task = buildArchitectTask(sampleCtx, sampleMeta, configWithTemplate);
-    expect(task).toContain('Files: 3');
-    expect(task).toContain('delta: 1');
+  it('resolves {{scope.*}} values in DEFAULT_ARCHITECT_PROMPT', () => {
+    // Mock prompt: '...{{scope.fileCount}} files...'
+    const task = buildArchitectTask(sampleCtx, sampleMeta, sampleConfig);
+    expect(task).toContain('3 files');
   });
 
-  it('resolves meta values via {{meta.*}}', () => {
-    const meta: MetaJson = { ...sampleMeta, _depth: 3, _emphasis: 2 };
-    const configWithTemplate: MetaConfig = {
-      ...sampleConfig,
-      defaultArchitect: 'Depth: {{meta._depth}}, emphasis: {{meta._emphasis}}',
-    };
-    const task = buildArchitectTask(sampleCtx, meta, configWithTemplate);
-    expect(task).toContain('Depth: 3');
-    expect(task).toContain('emphasis: 2');
+  it('resolves {{meta.*}} values in DEFAULT_ARCHITECT_PROMPT', () => {
+    // Mock prompt: '...depth {{meta._depth}}...'
+    const meta: MetaJson = { ...sampleMeta, _depth: 3 };
+    const task = buildArchitectTask(sampleCtx, meta, sampleConfig);
+    expect(task).toContain('depth 3');
   });
 
-  it('escaped \\{{...}} passes through as literal {{...}} for architect output', () => {
-    const configWithTemplate: MetaConfig = {
-      ...sampleConfig,
-      defaultArchitect: 'Use \\{{config.architectEvery}} in your brief.',
-    };
-    const task = buildArchitectTask(sampleCtx, sampleMeta, configWithTemplate);
-    // Architect sees literal {{config.architectEvery}} in its instructions
-    expect(task).toContain('Use {{config.architectEvery}} in your brief.');
+  it('escaped \\{{...}} in DEFAULT_ARCHITECT_PROMPT passes through as literal {{...}}', () => {
+    // Mock prompt: '...Escaped: \\{{config.architectEvery}}...'
+    const task = buildArchitectTask(sampleCtx, sampleMeta, sampleConfig);
+    expect(task).toContain('Escaped: {{config.architectEvery}}');
   });
 
-  it('architect-written template expressions resolve in builder prompt', () => {
-    // Architect wrote {{config.architectEvery}} into _builder
+  it('architect-written template expressions in _builder resolve in builder prompt', () => {
+    // Architect wrote {{config.architectEvery}} into _builder brief
     const meta: MetaJson = {
       ...sampleMeta,
       _builder: 'You have {{config.architectEvery}} cycles to complete.',
@@ -179,26 +183,19 @@ describe('Handlebars template compilation in prompts', () => {
     expect(task).not.toContain('{{config.architectEvery}}');
   });
 
-  it('template compilation gracefully handles invalid expressions', () => {
-    const configWithBadTemplate: MetaConfig = {
-      ...sampleConfig,
-      defaultArchitect: 'Valid text with {{#if broken',
+  it('invalid Handlebars expression in _builder does not throw (graceful fallback)', () => {
+    const meta: MetaJson = {
+      ...sampleMeta,
+      _builder: 'Valid text with {{#if broken',
     };
-    // Should not throw — returns original text on compilation failure
-    const task = buildArchitectTask(
-      sampleCtx,
-      sampleMeta,
-      configWithBadTemplate,
-    );
-    expect(task).toContain('Valid text with');
+    // Should not throw — compileTemplate returns original text on failure
+    const task = buildBuilderTask(sampleCtx, meta, sampleConfig);
+    expect(task).toContain('Valid text with {{#if broken');
   });
 
-  it('critic prompt also resolves template variables', () => {
-    const configWithTemplate: MetaConfig = {
-      ...sampleConfig,
-      defaultCritic: 'Max lines: {{config.maxLines}}',
-    };
-    const task = buildCriticTask(sampleCtx, sampleMeta, configWithTemplate);
+  it('resolves {{config.*}} in DEFAULT_CRITIC_PROMPT', () => {
+    // Mock prompt: '...Max lines: {{config.maxLines}}...'
+    const task = buildCriticTask(sampleCtx, sampleMeta, sampleConfig);
     expect(task).toContain('Max lines: 500');
   });
 });
@@ -283,32 +280,33 @@ describe('parseBuilderOutput', () => {
         topics: ['a', 'b'],
       }),
     );
-    expect(out.content).toBe('# Synthesis');
-    expect(out.fields).toEqual({ topics: ['a', 'b'] });
+    expect(out).not.toBeNull();
+    expect(out!.content).toBe('# Synthesis');
+    expect(out!.fields).toEqual({ topics: ['a', 'b'] });
   });
 
   it('handles markdown-fenced JSON', () => {
     const out = parseBuilderOutput('```json\n{"_content": "hi"}\n```');
-    expect(out.content).toBe('hi');
+    expect(out).not.toBeNull();
+    expect(out!.content).toBe('hi');
   });
 
-  it('treats non-JSON output as plain content', () => {
+  it('returns null for non-JSON output (self-talk / plain text)', () => {
     const out = parseBuilderOutput('Just a narrative');
-    expect(out.content).toBe('Just a narrative');
-    expect(out.fields).toEqual({});
+    expect(out).toBeNull();
   });
 
-  it('strips trailing ANNOUNCE_SKIP from JSON output', () => {
+  it('strips trailing ANNOUNCE_SKIP from JSON output before parsing', () => {
     const out = parseBuilderOutput(
       JSON.stringify({ _content: '# Synthesis' }) + '\nANNOUNCE_SKIP',
     );
-    expect(out.content).toBe('# Synthesis');
+    expect(out).not.toBeNull();
+    expect(out!.content).toBe('# Synthesis');
   });
 
-  it('strips trailing ANNOUNCE_SKIP from plain text output', () => {
+  it('returns null for plain text with ANNOUNCE_SKIP (no JSON content)', () => {
     const out = parseBuilderOutput('Just narrative\nANNOUNCE_SKIP');
-    expect(out.content).toBe('Just narrative');
-    expect(out.fields).toEqual({});
+    expect(out).toBeNull();
   });
 
   it('extracts _state from JSON output', () => {
@@ -319,14 +317,16 @@ describe('parseBuilderOutput', () => {
         topics: ['a'],
       }),
     );
-    expect(out.content).toBe('# Progress');
-    expect(out.state).toEqual({ step: 2, pending: ['x'] });
-    expect(out.fields).toEqual({ topics: ['a'] });
+    expect(out).not.toBeNull();
+    expect(out!.content).toBe('# Progress');
+    expect(out!.state).toEqual({ step: 2, pending: ['x'] });
+    expect(out!.fields).toEqual({ topics: ['a'] });
   });
 
   it('does not set state when _state is absent', () => {
     const out = parseBuilderOutput(JSON.stringify({ _content: 'no state' }));
-    expect(out.state).toBeUndefined();
+    expect(out).not.toBeNull();
+    expect(out!.state).toBeUndefined();
   });
 });
 

--- a/packages/service/src/orchestrator/parseOutput.test.ts
+++ b/packages/service/src/orchestrator/parseOutput.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Unit tests for parseBuilderOutput.
+ *
+ * Verifies that:
+ * - Valid JSON with _content is parsed correctly.
+ * - JSON embedded in prose (self-talk) is extracted via brace strategy.
+ * - Plain text, self-talk without JSON, and sub-agent delegation text return null.
+ * - The ANNOUNCE_SKIP sentinel is stripped before parsing.
+ *
+ * @module orchestrator/parseOutput.test
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { parseBuilderOutput } from './parseOutput.js';
+
+describe('parseBuilderOutput', () => {
+  // ── Valid JSON ─────────────────────────────────────────────────────
+
+  it('parses a minimal valid JSON object with _content', () => {
+    const output = JSON.stringify({ _content: 'Hello world' });
+    const result = parseBuilderOutput(output);
+    expect(result).not.toBeNull();
+    expect(result!.content).toBe('Hello world');
+    expect(result!.fields).toEqual({});
+    expect(result!.state).toBeUndefined();
+  });
+
+  it('parses JSON with _content and structured fields', () => {
+    const output = JSON.stringify({
+      _content: 'Synthesis result',
+      status: 'active',
+      risk: 'low',
+    });
+    const result = parseBuilderOutput(output);
+    expect(result).not.toBeNull();
+    expect(result!.content).toBe('Synthesis result');
+    expect(result!.fields).toEqual({ status: 'active', risk: 'low' });
+  });
+
+  it('parses JSON with _state field', () => {
+    const output = JSON.stringify({
+      _content: 'Progress update',
+      _state: { cursor: 5, processed: ['a', 'b'] },
+    });
+    const result = parseBuilderOutput(output);
+    expect(result).not.toBeNull();
+    expect(result!.content).toBe('Progress update');
+    expect(result!.state).toEqual({ cursor: 5, processed: ['a', 'b'] });
+  });
+
+  it('accepts "content" as an alias for "_content"', () => {
+    const output = JSON.stringify({ content: 'Via alias' });
+    const result = parseBuilderOutput(output);
+    expect(result).not.toBeNull();
+    expect(result!.content).toBe('Via alias');
+  });
+
+  // ── JSON extraction strategies ─────────────────────────────────────
+
+  it('extracts JSON from a fenced code block', () => {
+    const json = JSON.stringify({ _content: 'Fenced content' });
+    const output = `Some preamble text.\n\`\`\`json\n${json}\n\`\`\``;
+    const result = parseBuilderOutput(output);
+    expect(result).not.toBeNull();
+    expect(result!.content).toBe('Fenced content');
+  });
+
+  it('prefers the last fenced code block when multiple exist', () => {
+    const json1 = JSON.stringify({ _content: 'First block' });
+    const json2 = JSON.stringify({ _content: 'Second block' });
+    const output = `\`\`\`json\n${json1}\n\`\`\`\nsome text\n\`\`\`json\n${json2}\n\`\`\``;
+    const result = parseBuilderOutput(output);
+    expect(result).not.toBeNull();
+    expect(result!.content).toBe('Second block');
+  });
+
+  it('extracts JSON using outermost brace strategy from self-talk prose', () => {
+    const json = JSON.stringify({ _content: 'Embedded result' });
+    const output = `I have analyzed the files. Here is my output: ${json}\nThat concludes my work.`;
+    const result = parseBuilderOutput(output);
+    expect(result).not.toBeNull();
+    expect(result!.content).toBe('Embedded result');
+  });
+
+  // ── Non-JSON input returns null ────────────────────────────────────
+
+  it('returns null for plain text (no JSON)', () => {
+    const result = parseBuilderOutput('This is just plain text with no JSON.');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for self-talk text without any JSON object', () => {
+    const result = parseBuilderOutput(
+      'I need to read more files before I can produce output. Let me start by examining the repository structure.',
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns null for sub-agent delegation text', () => {
+    const result = parseBuilderOutput(
+      'I will now spawn a sub-agent to handle this task in parallel.',
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    const result = parseBuilderOutput('');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for whitespace-only string', () => {
+    const result = parseBuilderOutput('   \n  \t  ');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for JSON missing _content', () => {
+    const result = parseBuilderOutput(JSON.stringify({ status: 'active' }));
+    expect(result).toBeNull();
+  });
+
+  it('returns null for a JSON array (not an object)', () => {
+    const result = parseBuilderOutput(JSON.stringify([1, 2, 3]));
+    expect(result).toBeNull();
+  });
+
+  it('returns null for JSON with null _content', () => {
+    const result = parseBuilderOutput(JSON.stringify({ _content: null }));
+    expect(result).toBeNull();
+  });
+
+  it('returns null for JSON with numeric _content', () => {
+    const result = parseBuilderOutput(JSON.stringify({ _content: 42 }));
+    expect(result).toBeNull();
+  });
+
+  // ── ANNOUNCE_SKIP sentinel stripping ──────────────────────────────
+
+  it('strips trailing ANNOUNCE_SKIP before parsing', () => {
+    const json = JSON.stringify({ _content: 'Skip test' });
+    const output = `${json}ANNOUNCE_SKIP`;
+    const result = parseBuilderOutput(output);
+    expect(result).not.toBeNull();
+    expect(result!.content).toBe('Skip test');
+  });
+});

--- a/packages/service/src/orchestrator/parseOutput.ts
+++ b/packages/service/src/orchestrator/parseOutput.ts
@@ -42,12 +42,13 @@ export function parseArchitectOutput(output: string): string {
 /**
  * Parse builder output. The builder returns JSON with _content and optional fields.
  *
- * Attempts JSON parse first. If that fails, treats the entire output as _content.
+ * Attempts JSON extraction via multiple strategies. Returns null if all strategies fail
+ * (e.g. the output is plain text, self-talk, or a sub-agent delegation response).
  *
  * @param output - Raw subprocess output.
- * @returns Parsed builder output with content and structured fields.
+ * @returns Parsed builder output, or null if output is not valid builder JSON.
  */
-export function parseBuilderOutput(output: string): BuilderOutput {
+export function parseBuilderOutput(output: string): BuilderOutput | null {
   const trimmed = stripSentinel(output);
 
   // Strategy 1: Try to parse the entire output as JSON directly
@@ -75,8 +76,8 @@ export function parseBuilderOutput(output: string): BuilderOutput {
     if (result) return result;
   }
 
-  // Fallback: treat entire output as content
-  return { content: trimmed, fields: {} };
+  // All JSON strategies failed — not valid builder output
+  return null;
 }
 
 /** Try to parse a string as JSON and extract builder output fields. */

--- a/packages/service/src/orchestrator/runPhase.ts
+++ b/packages/service/src/orchestrator/runPhase.ts
@@ -187,7 +187,7 @@ export async function runArchitect(
 
     const architectUpdates: Partial<MetaJson> = {
       _builder: builderBrief,
-      _architect: config.defaultArchitect ?? DEFAULT_ARCHITECT_PROMPT,
+      _architect: DEFAULT_ARCHITECT_PROMPT,
       _synthesisCount: 0,
       _architectTokens: architectTokens,
       _generatedAt: new Date().toISOString(),
@@ -279,6 +279,14 @@ export async function runBuilder(
     }
 
     const builderOutput = parseBuilderOutput(rawOutput);
+    if (!builderOutput) {
+      throw new Error(
+        'Builder output is not valid JSON — expected { _content|content: string, ... }. ' +
+          'Raw output (' +
+          rawOutput.length.toString() +
+          ' chars) did not match any JSON extraction strategy.',
+      );
+    }
     const builderTokens = result.tokens;
 
     // Builder success: builder → fresh, critic → pending
@@ -314,6 +322,7 @@ export async function runBuilder(
         const raw = await readFile(err.outputPath, 'utf8');
         const partial = parseBuilderOutput(raw);
         if (
+          partial !== null &&
           partial.state !== undefined &&
           JSON.stringify(partial.state) !== JSON.stringify(currentMeta._state)
         ) {
@@ -375,7 +384,7 @@ export async function runCritic(
 
     const updates: Partial<MetaJson> = {
       _feedback: feedback,
-      _critic: config.defaultCritic ?? DEFAULT_CRITIC_PROMPT,
+      _critic: DEFAULT_CRITIC_PROMPT,
       _criticTokens: criticTokens,
       _error: undefined,
     };

--- a/packages/service/src/phaseState/invalidate.test.ts
+++ b/packages/service/src/phaseState/invalidate.test.ts
@@ -50,8 +50,6 @@ function makeConfig(overrides?: Partial<MetaConfig>): MetaConfig {
     maxArchive: 20,
     maxLines: 500,
     thinking: 'low',
-    defaultArchitect: 'default-architect-prompt',
-    defaultCritic: 'default-critic-prompt',
     skipUnchanged: true,
     metaProperty: { _meta: 'current' },
     metaArchiveProperty: { _meta: 'archive' },
@@ -485,7 +483,7 @@ describe('computeInvalidation', () => {
     expect(result.inputStatus.criticChanged).toBe(false);
   });
 
-  it('uses DEFAULT prompts when config overrides are undefined', async () => {
+  it('always compares prompt snapshots against DEFAULT constants (no config override)', async () => {
     const meta: MetaJson = {
       _phaseState: { ...freshPhaseState },
       _structureHash: HASH_A,
@@ -495,15 +493,9 @@ describe('computeInvalidation', () => {
       _synthesisCount: 3,
     };
 
-    // Config with undefined prompts — should fall back to DEFAULT constants
-    const result = await computeInvalidation(
-      meta,
-      SCOPE_A,
-      makeConfig({ defaultArchitect: undefined, defaultCritic: undefined }),
-      node,
-    );
+    const result = await computeInvalidation(meta, SCOPE_A, makeConfig(), node);
 
-    // Snapshots match the DEFAULT prompts, so no staleness
+    // Snapshots match DEFAULT constants — no staleness
     expect(result.inputStatus.architectChanged).toBe(false);
     expect(result.inputStatus.criticChanged).toBe(false);
   });

--- a/packages/service/src/phaseState/invalidate.ts
+++ b/packages/service/src/phaseState/invalidate.ts
@@ -100,12 +100,9 @@ export async function computeInvalidation(
   // corpus-wide synthesis storm (see #163).
   const architectChanged = isPromptStale(
     meta._architect,
-    config.defaultArchitect ?? DEFAULT_ARCHITECT_PROMPT,
+    DEFAULT_ARCHITECT_PROMPT,
   );
-  const criticChanged = isPromptStale(
-    meta._critic,
-    config.defaultCritic ?? DEFAULT_CRITIC_PROMPT,
-  );
+  const criticChanged = isPromptStale(meta._critic, DEFAULT_CRITIC_PROMPT);
   const effectiveSynthesisCount = meta._synthesisCount ?? 0;
 
   // _crossRefs declaration change

--- a/packages/service/src/phaseState/phaseState.e2e.test.ts
+++ b/packages/service/src/phaseState/phaseState.e2e.test.ts
@@ -74,8 +74,6 @@ const baseConfig: MetaConfig = {
   maxArchive: 20,
   maxLines: 500,
   thinking: 'low',
-  defaultArchitect: '',
-  defaultCritic: '',
   skipUnchanged: true,
   metaProperty: { _meta: 'current' },
   metaArchiveProperty: { _meta: 'archive' },

--- a/packages/service/src/phaseState/phaseState.integration.test.ts
+++ b/packages/service/src/phaseState/phaseState.integration.test.ts
@@ -414,8 +414,6 @@ describe('I/O integration (Tasks #14-17)', () => {
     maxArchive: 20,
     maxLines: 500,
     thinking: 'low',
-    defaultArchitect: '',
-    defaultCritic: '',
     skipUnchanged: true,
     metaProperty: { _meta: 'current' },
     metaArchiveProperty: { _meta: 'archive' },

--- a/packages/service/src/progress/index.ts
+++ b/packages/service/src/progress/index.ts
@@ -39,6 +39,12 @@ export type ProgressReporterConfig = {
   reportTarget?: string;
   /** Optional base URL for the service, used to construct entity links. */
   serverBaseUrl?: string;
+  /**
+   * Optional mapping of server drive labels to absolute filesystem paths.
+   * Used on Linux to resolve absolute paths to jeeves-server browse paths.
+   * Example: `{ "content": "/opt/jeeves/content" }`
+   */
+  serverDriveRoots?: Record<string, string>;
 };
 
 function formatNumber(n: number): string {
@@ -71,21 +77,75 @@ function encodePathSegments(p: string): string {
     .join('/');
 }
 
-/** Build a link (or plain path) to the owner directory. */
-function buildDirectoryLink(path: string, serverBaseUrl?: string): string {
-  const normalized = normalizePath(path).replace(/^([A-Za-z]):/, '/$1');
-  const encoded = encodePathSegments(normalized);
+/**
+ * Resolve a filesystem path to a jeeves-server browse path segment.
+ *
+ * - Windows: `j:/domains/foo` → `/j/domains/foo` (drive-letter transform).
+ * - Linux with serverDriveRoots: `/opt/jeeves/content/slack` + roots
+ *   `{ content: "/opt/jeeves/content" }` → `/content/slack`.
+ * - Linux without serverDriveRoots: returns the normalized path unchanged
+ *   (browse link will be invalid, but this is the pre-existing behavior).
+ */
+function resolveServerPath(
+  path: string,
+  serverDriveRoots?: Record<string, string>,
+): string {
+  const normalized = normalizePath(path);
 
-  if (!serverBaseUrl) return normalized;
+  // Windows: drive letter present — use existing transform
+  if (/^[A-Za-z]:/.test(normalized)) {
+    return normalized.replace(/^([A-Za-z]):/, '/$1');
+  }
+
+  // Linux: attempt serverDriveRoots resolution (longest/most-specific root wins)
+  if (serverDriveRoots) {
+    const sorted = Object.entries(serverDriveRoots)
+      .map(
+        ([label, root]) =>
+          [label, normalizePath(root).replace(/\/+$/, '')] as const,
+      )
+      .sort((a, b) => b[1].length - a[1].length);
+
+    for (const [label, normalizedRoot] of sorted) {
+      if (
+        normalized === normalizedRoot ||
+        normalized.startsWith(normalizedRoot + '/')
+      ) {
+        const relative = normalized
+          .slice(normalizedRoot.length)
+          .replace(/^\//, '');
+        return `/${label}${relative ? '/' + relative : ''}`;
+      }
+    }
+  }
+
+  // Fallback: no drive roots configured or no match — return as-is
+  return normalized;
+}
+
+/** Build a link (or plain path) to the owner directory. */
+function buildDirectoryLink(
+  path: string,
+  serverBaseUrl?: string,
+  serverDriveRoots?: Record<string, string>,
+): string {
+  const resolved = resolveServerPath(path, serverDriveRoots);
+  const encoded = encodePathSegments(resolved);
+
+  if (!serverBaseUrl) return resolved;
 
   const base = serverBaseUrl.replace(/\/+$/, '');
   return `${base}/path${encoded}`;
 }
 
 /** Build a link (or plain path) to the entity's meta.json output file. */
-function buildMetaJsonLink(path: string, serverBaseUrl?: string): string {
-  const normalized = normalizePath(path).replace(/^([A-Za-z]):/, '/$1');
-  const metaJsonPath = `${normalized}/.meta/meta.json`;
+function buildMetaJsonLink(
+  path: string,
+  serverBaseUrl?: string,
+  serverDriveRoots?: Record<string, string>,
+): string {
+  const resolved = resolveServerPath(path, serverDriveRoots);
+  const metaJsonPath = `${resolved}/.meta/meta.json`;
   const encoded = encodePathSegments(metaJsonPath);
 
   if (!serverBaseUrl) return metaJsonPath;
@@ -97,10 +157,15 @@ function buildMetaJsonLink(path: string, serverBaseUrl?: string): string {
 export function formatProgressEvent(
   event: ProgressEvent,
   serverBaseUrl?: string,
+  serverDriveRoots?: Record<string, string>,
 ): string {
   switch (event.type) {
     case 'synthesis_start': {
-      const dirLink = buildDirectoryLink(event.path, serverBaseUrl);
+      const dirLink = buildDirectoryLink(
+        event.path,
+        serverBaseUrl,
+        serverDriveRoots,
+      );
       return `🔬 Started meta synthesis: ${dirLink}`;
     }
 
@@ -120,7 +185,11 @@ export function formatProgressEvent(
     }
 
     case 'synthesis_complete': {
-      const metaLink = buildMetaJsonLink(event.path, serverBaseUrl);
+      const metaLink = buildMetaJsonLink(
+        event.path,
+        serverBaseUrl,
+        serverDriveRoots,
+      );
       const tokenStr = formatTokens(event.tokens);
       const duration =
         event.durationMs !== undefined
@@ -130,7 +199,11 @@ export function formatProgressEvent(
     }
 
     case 'error': {
-      const dirLink = buildDirectoryLink(event.path, serverBaseUrl);
+      const dirLink = buildDirectoryLink(
+        event.path,
+        serverBaseUrl,
+        serverDriveRoots,
+      );
       const phase = event.phase ? `${titleCasePhase(event.phase)} ` : '';
       const error = event.error ?? 'Unknown error';
       return `❌ Synthesis failed at ${phase}phase: ${dirLink}\n   Error: ${error}`;
@@ -167,7 +240,11 @@ export class ProgressReporter {
     const target = this.config.reportTarget ?? this.config.reportChannel;
     if (!target) return;
 
-    const message = formatProgressEvent(event, this.config.serverBaseUrl);
+    const message = formatProgressEvent(
+      event,
+      this.config.serverBaseUrl,
+      this.config.serverDriveRoots,
+    );
     const url = new URL('/tools/invoke', this.config.gatewayUrl);
 
     const args: GatewayInvokeRequest['args'] = {

--- a/packages/service/src/progress/progress.test.ts
+++ b/packages/service/src/progress/progress.test.ts
@@ -140,6 +140,83 @@ describe('formatProgressEvent', () => {
       '✅ Completed: x/.meta/meta.json (unknown tokens / 2s)',
     );
   });
+
+  describe('serverDriveRoots (Linux path resolution)', () => {
+    const serverDriveRoots = { content: '/opt/jeeves/content' };
+    const base = 'http://localhost:1934';
+
+    it('resolves Linux path via serverDriveRoots for synthesis_start', () => {
+      const e: ProgressEvent = {
+        type: 'synthesis_start',
+        path: '/opt/jeeves/content/slack/general',
+      };
+      const result = formatProgressEvent(e, base, serverDriveRoots);
+      expect(result).toContain(
+        'http://localhost:1934/path/content/slack/general',
+      );
+    });
+
+    it('resolves Linux path via serverDriveRoots for synthesis_complete', () => {
+      const e: ProgressEvent = {
+        type: 'synthesis_complete',
+        path: '/opt/jeeves/content/slack/general',
+        tokens: 100,
+        durationMs: 3000,
+      };
+      const result = formatProgressEvent(e, base, serverDriveRoots);
+      expect(result).toContain(
+        'http://localhost:1934/path/content/slack/general/.meta/meta.json',
+      );
+    });
+
+    it('falls back to raw path when no roots match', () => {
+      const e: ProgressEvent = {
+        type: 'synthesis_start',
+        path: '/var/data/other/path',
+      };
+      const result = formatProgressEvent(e, base, serverDriveRoots);
+      // No matching root — falls back to normalized path
+      expect(result).toContain(
+        'http://localhost:1934/path/var/data/other/path',
+      );
+    });
+
+    it('resolves exact root match (no trailing relative path)', () => {
+      const e: ProgressEvent = {
+        type: 'synthesis_start',
+        path: '/opt/jeeves/content',
+      };
+      const result = formatProgressEvent(e, base, serverDriveRoots);
+      expect(result).toContain('http://localhost:1934/path/content');
+    });
+
+    it('prefers the longest matching root when roots overlap', () => {
+      const overlappingRoots = {
+        jeeves: '/opt/jeeves',
+        content: '/opt/jeeves/content',
+      };
+      const e: ProgressEvent = {
+        type: 'synthesis_start',
+        path: '/opt/jeeves/content/slack/general',
+      };
+      const result = formatProgressEvent(e, base, overlappingRoots);
+      // Must match "content" (longer root), not "jeeves"
+      expect(result).toContain(
+        'http://localhost:1934/path/content/slack/general',
+      );
+    });
+
+    it('does not affect Windows paths (drive letter takes priority)', () => {
+      const e: ProgressEvent = {
+        type: 'synthesis_start',
+        path: 'j:/domains/github/org',
+      };
+      const result = formatProgressEvent(e, base, serverDriveRoots);
+      expect(result).toContain(
+        'http://localhost:1934/path/j/domains/github/org',
+      );
+    });
+  });
 });
 
 describe('ProgressReporter', () => {

--- a/packages/service/src/prompts/index.ts
+++ b/packages/service/src/prompts/index.ts
@@ -4,9 +4,6 @@
  * Prompts ship as .md files bundled into dist/prompts/ via rollup-plugin-copy.
  * Loaded at runtime relative to the compiled module location.
  *
- * Users can override via `defaultArchitect` / `defaultCritic` in the service
- * config. Most installations should use the built-in defaults.
- *
  * @module prompts
  */
 

--- a/packages/service/src/routes/__testUtils.ts
+++ b/packages/service/src/routes/__testUtils.ts
@@ -27,8 +27,6 @@ const DEFAULT_TEST_CONFIG: RouteDeps['config'] = {
   maxArchive: 20,
   maxLines: 500,
   thinking: 'low',
-  defaultArchitect: 'arch',
-  defaultCritic: 'crit',
   skipUnchanged: true,
   metaProperty: {},
   metaArchiveProperty: {},

--- a/packages/service/src/routes/configApply.test.ts
+++ b/packages/service/src/routes/configApply.test.ts
@@ -35,6 +35,8 @@ describe('POST /config/apply', () => {
         watcherUrl: 'http://localhost:3456',
         schedule: '*/30 * * * *',
         port: 1938,
+        metaProperty: { domains: ['meta'] },
+        metaArchiveProperty: { domains: ['meta-archive'] },
       }),
     );
 

--- a/packages/service/src/scheduler/scheduler.test.ts
+++ b/packages/service/src/scheduler/scheduler.test.ts
@@ -28,8 +28,6 @@ function createTestConfig() {
     maxArchive: 20,
     maxLines: 500,
     thinking: 'low',
-    defaultArchitect: 'You are the architect...',
-    defaultCritic: 'You are the critic...',
     skipUnchanged: true,
     metaProperty: { _meta: 'current' },
     metaArchiveProperty: { _meta: 'archive' },

--- a/packages/service/src/schema/config.test.ts
+++ b/packages/service/src/schema/config.test.ts
@@ -4,8 +4,8 @@ import { metaConfigSchema, serviceConfigSchema } from './config.js';
 
 const validConfig = {
   watcherUrl: 'http://localhost:3456',
-  defaultArchitect: 'You are the architect...',
-  defaultCritic: 'You are the critic...',
+  metaProperty: { _meta: 'current' },
+  metaArchiveProperty: { _meta: 'archive' },
 };
 
 describe('metaConfigSchema', () => {
@@ -40,17 +40,23 @@ describe('metaConfigSchema', () => {
     expect(result.success).toBe(false);
   });
 
-  it('accepts missing defaultArchitect and defaultCritic (optional, built-in defaults)', () => {
-    const partial = {
+  it('requires metaProperty — rejects config missing it', () => {
+    const result = metaConfigSchema.safeParse({
       watcherUrl: validConfig.watcherUrl,
-    };
-    const result = metaConfigSchema.safeParse(partial);
-    expect(result.success).toBe(true);
-    expect(result.data?.defaultArchitect).toBeUndefined();
-    expect(result.data?.defaultCritic).toBeUndefined();
+      metaArchiveProperty: { _meta: 'archive' },
+    });
+    expect(result.success).toBe(false);
   });
 
-  it('applies default metaProperty and metaArchiveProperty', () => {
+  it('requires metaArchiveProperty — rejects config missing it', () => {
+    const result = metaConfigSchema.safeParse({
+      watcherUrl: validConfig.watcherUrl,
+      metaProperty: { _meta: 'current' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts explicit metaProperty and metaArchiveProperty', () => {
     const result = metaConfigSchema.safeParse(validConfig);
     expect(result.success).toBe(true);
     expect(result.data?.metaProperty).toEqual({ _meta: 'current' });

--- a/packages/service/src/schema/config.ts
+++ b/packages/service/src/schema/config.ts
@@ -55,6 +55,13 @@ export const serviceConfigSchema = metaConfigSchema.extend({
   /** Optional base URL for the service, used to construct entity links in progress reports. */
   serverBaseUrl: z.string().optional(),
 
+  /**
+   * Optional mapping of server drive labels to absolute filesystem paths.
+   * Used on Linux to resolve absolute paths to jeeves-server browse paths.
+   * Example: `{ "content": "/opt/jeeves/content" }`
+   */
+  serverDriveRoots: z.record(z.string(), z.string()).optional(),
+
   /** Interval in ms for periodic watcher health check. 0 = disabled. Default: 60000. */
   watcherHealthIntervalMs: z.number().int().min(0).default(60_000),
 


### PR DESCRIPTION
Resolves #204, #206, #207, #208 in a single PR.

## Changes

### #204 — Remove defaultArchitect/defaultCritic config overrides
- Removed both fields from core schema, config loader, hot reload, orchestrator, invalidation
- Prompts now always use built-in dist defaults (no config override path)
- Simplified prompt staleness detection in invalidate.ts

### #206 — Progress report links use absolute filesystem paths
- Added optional \serverDriveRoots\ config (\Record<string, string>\) for Linux path resolution
- \uildDirectoryLink\/\uildMetaJsonLink\ resolve absolute paths against drive root mappings
- Windows drive-letter paths unchanged (existing transform works correctly)

### #207 — GatewayExecutor false-completion race
- **parseBuilderOutput** returns \
ull\ instead of treating raw text as content (text fallback removed)
- **runPhase.ts** treats \
ull\ parse result as a builder error (preserves existing \_content\)
- **Builder prompt** explicitly prohibits \sessions_spawn\/\sessions_yield\

### #208 — Default metaProperty breaks meta.json rendering
- \metaProperty\ and \metaArchiveProperty\ now required with no default
- Installer sets the value — specific property conventions are a config-side decision
- All test utilities updated with explicit values

## Quality Gate
- build ✅
- typecheck ✅
- lint ✅ (0 errors, 0 warnings)
- knip ✅ (pre-existing unrelated issue only)
- test ✅ (586 passed)