### PR TITLE
feat: plugin schema gen, core fetchWithTimeout, templated progress, resolve-path API (#93, #94, #129, #210)

### DIFF
--- a/packages/openclaw/openclaw.plugin.json
+++ b/packages/openclaw/openclaw.plugin.json
@@ -10,15 +10,16 @@
     "type": "object",
     "properties": {
       "apiUrl": {
-        "type": "string",
+        "default": "http://127.0.0.1:1938",
         "description": "URL of the jeeves-meta HTTP service. Falls back to JEEVES_META_URL env var.",
-        "default": "http://127.0.0.1:1938"
+        "type": "string"
       },
       "configRoot": {
-        "type": "string",
-        "description": "Absolute path to the platform config root (e.g. j:/config). Used by @karmaniverous/jeeves core for config directory resolution."
+        "description": "Absolute path to the platform config root (e.g. j:/config). Used by @karmaniverous/jeeves core for config directory resolution.",
+        "type": "string"
       }
-    }
+    },
+    "additionalProperties": false
   },
   "contracts": {
     "tools": [

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -96,10 +96,11 @@
     "url": "git+https://github.com/karmaniverous/jeeves-meta.git"
   },
   "scripts": {
-    "build": "npm run build:plugin && npm run build:skills && npm run build:content",
+    "build": "npm run generate-schema && npm run build:plugin && npm run build:skills && npm run build:content",
     "build:content": "node scripts/copy-content.mjs",
     "build:plugin": "rimraf dist && cross-env NO_COLOR=1 rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript",
     "build:skills": "node scripts/build-skills.mjs",
+    "generate-schema": "node scripts/generate-plugin-schema.mjs",
     "changelog": "git-cliff -o CHANGELOG.md",
     "diagrams": "cd diagrams && plantuml -tpng -o ../assets -r .",
     "knip": "knip",

--- a/packages/openclaw/package.json
+++ b/packages/openclaw/package.json
@@ -96,7 +96,7 @@
     "url": "git+https://github.com/karmaniverous/jeeves-meta.git"
   },
   "scripts": {
-    "build": "npm run generate-schema && npm run build:plugin && npm run build:skills && npm run build:content",
+    "build": "npm run build:plugin && npm run generate-schema && npm run build:skills && npm run build:content",
     "build:content": "node scripts/copy-content.mjs",
     "build:plugin": "rimraf dist && cross-env NO_COLOR=1 rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript",
     "build:skills": "node scripts/build-skills.mjs",

--- a/packages/openclaw/scripts/generate-plugin-schema.mjs
+++ b/packages/openclaw/scripts/generate-plugin-schema.mjs
@@ -2,10 +2,7 @@
  * Generates the configSchema in openclaw.plugin.json from the Zod schema.
  *
  * Run via: node scripts/generate-plugin-schema.mjs
- * Wired into build via the generate-schema npm script (called before build:plugin).
- *
- * The Zod schema is defined inline here to avoid requiring TypeScript compilation
- * before this script runs. Keep in sync with src/pluginConfigSchema.ts.
+ * Wired into build via the generate-schema npm script (called after build:plugin).
  */
 
 /* global console */
@@ -14,29 +11,16 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { toJSONSchema, z } from 'zod';
+import { toJSONSchema } from 'zod';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const PLUGIN_JSON = path.join(ROOT, 'openclaw.plugin.json');
 
-// Mirror of src/pluginConfigSchema.ts — keep in sync.
-const schema = z.object({
-  apiUrl: z
-    .string()
-    .default('http://127.0.0.1:1938')
-    .describe(
-      'URL of the jeeves-meta HTTP service. Falls back to JEEVES_META_URL env var.',
-    ),
-  configRoot: z
-    .string()
-    .optional()
-    .describe(
-      'Absolute path to the platform config root (e.g. j:/config). Used by @karmaniverous/jeeves core for config directory resolution.',
-    ),
-});
+// Import the schema from the built dist output
+import { pluginConfigSchema } from '../dist/index.js';
 
 // Generate JSON Schema from Zod
-const jsonSchema = toJSONSchema(schema);
+const jsonSchema = toJSONSchema(pluginConfigSchema);
 
 // Remove $schema — not needed in plugin.json
 delete jsonSchema.$schema;
@@ -50,4 +34,4 @@ const plugin = JSON.parse(readFileSync(PLUGIN_JSON, 'utf8'));
 plugin.configSchema = jsonSchema;
 writeFileSync(PLUGIN_JSON, JSON.stringify(plugin, null, 2) + '\n');
 
-console.log('Generated configSchema in openclaw.plugin.json');
+console.log('Generated configSchema in openclaw.plugin.json from src/pluginConfigSchema.ts');

--- a/packages/openclaw/scripts/generate-plugin-schema.mjs
+++ b/packages/openclaw/scripts/generate-plugin-schema.mjs
@@ -1,0 +1,53 @@
+/**
+ * Generates the configSchema in openclaw.plugin.json from the Zod schema.
+ *
+ * Run via: node scripts/generate-plugin-schema.mjs
+ * Wired into build via the generate-schema npm script (called before build:plugin).
+ *
+ * The Zod schema is defined inline here to avoid requiring TypeScript compilation
+ * before this script runs. Keep in sync with src/pluginConfigSchema.ts.
+ */
+
+/* global console */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { toJSONSchema, z } from 'zod';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const PLUGIN_JSON = path.join(ROOT, 'openclaw.plugin.json');
+
+// Mirror of src/pluginConfigSchema.ts — keep in sync.
+const schema = z.object({
+  apiUrl: z
+    .string()
+    .default('http://127.0.0.1:1938')
+    .describe(
+      'URL of the jeeves-meta HTTP service. Falls back to JEEVES_META_URL env var.',
+    ),
+  configRoot: z
+    .string()
+    .optional()
+    .describe(
+      'Absolute path to the platform config root (e.g. j:/config). Used by @karmaniverous/jeeves core for config directory resolution.',
+    ),
+});
+
+// Generate JSON Schema from Zod
+const jsonSchema = toJSONSchema(schema);
+
+// Remove $schema — not needed in plugin.json
+delete jsonSchema.$schema;
+
+// Remove required array — the plugin config UI does not use required,
+// and the hand-written schema had no required field.
+delete jsonSchema.required;
+
+// Patch plugin.json in place
+const plugin = JSON.parse(readFileSync(PLUGIN_JSON, 'utf8'));
+plugin.configSchema = jsonSchema;
+writeFileSync(PLUGIN_JSON, JSON.stringify(plugin, null, 2) + '\n');
+
+console.log('Generated configSchema in openclaw.plugin.json');

--- a/packages/openclaw/skills/jeeves-meta/SKILL.md
+++ b/packages/openclaw/skills/jeeves-meta/SKILL.md
@@ -213,8 +213,8 @@ Key settings:
 | `port` | 1938 | HTTP API listen port |
 
 | `schedule` | `*/30 * * * *` | Cron expression for automatic synthesis scheduling |
-| `serverBaseUrl` | (optional) | Public base URL of the service (e.g. `http://myhost:1938`). When set, progress reports include clickable entity links. |
-| `serverDriveRoots` | (optional) | Drive label to absolute path mapping for Linux path resolution in progress links (e.g. `{ "content": "/opt/jeeves/content" }`). |
+| `serverUrl` | `http://127.0.0.1:1934` | jeeves-server base URL for progress report links |
+| `templates` | (see docs) | Templates for phase start, end, and error progress reports |
 | `reportChannel` | (optional) | Gateway channel name (e.g. `slack`). Legacy: also used as target if `reportTarget` is unset. |
 | `reportTarget` | (optional) | Channel/user ID to send progress messages to |
 | `tier2ScanLimit` | 50 | Max all-fresh candidates to scan per tick in Tier 2 invalidation |
@@ -583,6 +583,8 @@ Recommended periodic checks:
 - **Phase health:** `/status` includes `phaseStateSummary` with aggregate
   counts per phase (`fresh`, `stale`, `pending`, `running`, `failed`) and
   `nextPhase` showing the next candidate.
+- **Meta counts:** `/status` includes `health.metaCounts` with totals broken
+  down by current/archive and meta/steer/crossRefs.
 - **Service health:** `/status` endpoint (via `meta_list` summary or direct
   HTTP) includes dependency status for watcher and gateway
 

--- a/packages/openclaw/skills/jeeves-meta/SKILL.md
+++ b/packages/openclaw/skills/jeeves-meta/SKILL.md
@@ -583,8 +583,8 @@ Recommended periodic checks:
 - **Phase health:** `/status` includes `phaseStateSummary` with aggregate
   counts per phase (`fresh`, `stale`, `pending`, `running`, `failed`) and
   `nextPhase` showing the next candidate.
-- **Meta counts:** `/status` includes `health.metaCounts` with totals broken
-  down by current/archive and meta/steer/crossRefs.
+- **Meta counts:** `/status` includes `health.metaCounts` with totals:
+  `total`, `enabled`, `disabled`, `neverSynthesized`, `stale`, `errors`, and `locked`.
 - **Service health:** `/status` endpoint (via `meta_list` summary or direct
   HTTP) includes dependency status for watcher and gateway
 

--- a/packages/openclaw/src/index.ts
+++ b/packages/openclaw/src/index.ts
@@ -26,6 +26,8 @@ import { generateMetaMenu } from './promptInjection.js';
 import { MetaServiceClient } from './serviceClient.js';
 import { registerMetaTools } from './tools.js';
 
+export { type PluginConfig, pluginConfigSchema } from './pluginConfigSchema.js';
+
 /** Register all jeeves-meta tools with the OpenClaw plugin API. */
 export default function register(api: PluginApi): void {
   const client = new MetaServiceClient({ apiUrl: getServiceUrl(api) });

--- a/packages/openclaw/src/pluginConfigSchema.ts
+++ b/packages/openclaw/src/pluginConfigSchema.ts
@@ -1,0 +1,30 @@
+/**
+ * Zod schema for the jeeves-meta OpenClaw plugin configuration.
+ *
+ * This is the source of truth for the plugin configSchema.
+ * The build-time script `scripts/generate-plugin-schema.mjs` derives
+ * the JSON Schema in `openclaw.plugin.json` from this definition.
+ *
+ * @module pluginConfigSchema
+ */
+
+import { z } from 'zod';
+
+/** Zod schema for the jeeves-meta OpenClaw plugin configuration. */
+export const pluginConfigSchema = z.object({
+  apiUrl: z
+    .string()
+    .default('http://127.0.0.1:1938')
+    .describe(
+      'URL of the jeeves-meta HTTP service. Falls back to JEEVES_META_URL env var.',
+    ),
+  configRoot: z
+    .string()
+    .optional()
+    .describe(
+      'Absolute path to the platform config root (e.g. j:/config). Used by @karmaniverous/jeeves core for config directory resolution.',
+    ),
+});
+
+/** Inferred type for the plugin configuration. */
+export type PluginConfig = z.infer<typeof pluginConfigSchema>;

--- a/packages/service/guides/architecture.md
+++ b/packages/service/guides/architecture.md
@@ -13,7 +13,7 @@ title: Architecture
 | `GatewayExecutor` | Spawns LLM sessions via gateway `/tools/invoke`, polls for completion |
 | `ProgressReporter` | Sends synthesis events to a channel via gateway `/tools/invoke` → `message` tool |
 | `RuleRegistrar` | Registers 2 virtual inference rules with watcher at startup |
-| `HttpWatcherClient` | Watcher HTTP client with 3-retry exponential backoff |
+| `HttpWatcherClient` | Watcher HTTP client with 3-retry exponential backoff and connection timeout protection |
 | Fastify server | 13 HTTP endpoints across 10 route modules |
 | Config hot-reload | `fs.watchFile` monitors config; hot-reloadable fields applied immediately, restart-required fields warn on change |
 | Shutdown handlers | SIGTERM/SIGINT → stop scheduler → release lock → close server |

--- a/packages/service/guides/configuration.md
+++ b/packages/service/guides/configuration.md
@@ -30,8 +30,10 @@ The service reads a JSON config file specified via `--config` flag or `JEEVES_ME
 | `schedule` | string | `*/30 * * * *` | Cron expression for synthesis scheduling |
 | `reportChannel` | string | — | Gateway channel name (e.g. `slack`). Legacy: also used as target if `reportTarget` is unset. |
 | `reportTarget` | string | — | Channel/user ID to send progress messages to |
-| `serverBaseUrl` | string | — | Base URL for entity links in progress reports (e.g. `http://myserver:1938`) |
-| `serverDriveRoots` | object | — | Drive label to absolute path mapping for Linux path resolution in progress links (e.g. `{ "content": "/opt/jeeves/content" }`) |
+| `serverUrl` | string (URL) | `http://127.0.0.1:1934` | jeeves-server base URL for progress report links |
+| `templates.phaseStart` | string | `:gear: ...` | Template for phase start progress reports |
+| `templates.phaseEnd` | string | `:white_check_mark: ...` | Template for phase success progress reports |
+| `templates.phaseError` | string | `:x: ...` | Template for phase failure progress reports |
 | `watcherHealthIntervalMs` | integer | `60000` | Periodic watcher health check interval in ms (min 0). 0 = disabled. |
 | `tier2ScanLimit` | integer | `50` | Max all-fresh candidates to scan per tick in Tier 2 invalidation (min 1) |
 | `autoSeed` | array | `[]` | Auto-seed policy rules (see below). Rules evaluated in order; last match wins for steer/crossRefs. |

--- a/packages/service/src/bootstrap.ts
+++ b/packages/service/src/bootstrap.ts
@@ -141,23 +141,12 @@ export async function startService(
       // Track whether synthesis_start has been emitted (deferred until
       // a phase actually begins, avoiding orphan "Started" messages
       // when the meta is skipped/locked/fresh). See #165.
-      let synthesisStartEmitted = false;
-
       const result = await orchestratePhase(
         config,
         executor,
         watcher,
         path,
         async (evt) => {
-          // Emit synthesis_start on first phase_start (deferred guard)
-          if (evt.type === 'phase_start' && !synthesisStartEmitted) {
-            synthesisStartEmitted = true;
-            await progress.report({
-              type: 'synthesis_start',
-              path: ownerPath,
-            });
-          }
-
           // Wire current-phase tracking for GET /queue and POST /synthesize/abort
           if (evt.type === 'phase_start' && evt.phase) {
             queue.setCurrentPhase(ownerPath, evt.phase);
@@ -210,19 +199,8 @@ export async function startService(
         scheduler.resetBackoff();
       }
 
-      // Emit synthesis_complete only on full-cycle completion
-      if (result.cycleComplete) {
-        const updatedMeta = result.phaseResult?.updatedMeta;
-        const tokens = updatedMeta
-          ? computeCycleTokens(updatedMeta)
-          : undefined;
-        await progress.report({
-          type: 'synthesis_complete',
-          path: ownerPath,
-          durationMs,
-          tokens,
-        });
-      }
+      // Note: synthesis_complete is no longer emitted; the phaseEnd template
+      // for the final critic phase serves as the completion signal (#129).
     } catch (err) {
       stats.totalErrors++;
       const message = err instanceof Error ? err.message : String(err);

--- a/packages/service/src/cache.test.ts
+++ b/packages/service/src/cache.test.ts
@@ -42,6 +42,15 @@ function makeConfig(): ServiceConfig {
     stagingRetries: 10,
     stagingRetryDelayMs: 250,
     previewDeltaFilesCap: 50,
+    serverUrl: 'http://127.0.0.1:1934',
+    templates: {
+      phaseStart:
+        ':gear: Started meta synthesis {{phase}} phase of <{{dirLink}}>',
+      phaseEnd:
+        ':white_check_mark: Completed meta synthesis {{phase}} phase ({{tokens}} tokens / {{seconds}}s) at <{{metaLink}}>',
+      phaseError:
+        ':x: Meta synthesis {{phase}} phase failed at <{{dirLink}}>\n   Error: {{error}}',
+    },
   };
 }
 

--- a/packages/service/src/cache.test.ts
+++ b/packages/service/src/cache.test.ts
@@ -9,6 +9,8 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { DEFAULT_TEMPLATE_STRINGS } from './schema/config.js';
+
 // Mock the discovery module so listMetas is controllable
 vi.mock('./discovery/index.js', () => ({
   listMetas: vi.fn(),
@@ -43,14 +45,7 @@ function makeConfig(): ServiceConfig {
     stagingRetryDelayMs: 250,
     previewDeltaFilesCap: 50,
     serverUrl: 'http://127.0.0.1:1934',
-    templates: {
-      phaseStart:
-        ':gear: Started meta synthesis {{phase}} phase of <{{dirLink}}>',
-      phaseEnd:
-        ':white_check_mark: Completed meta synthesis {{phase}} phase ({{tokens}} tokens / {{seconds}}s) at <{{metaLink}}>',
-      phaseError:
-        ':x: Meta synthesis {{phase}} phase failed at <{{dirLink}}>\n   Error: {{error}}',
-    },
+    templates: { ...DEFAULT_TEMPLATE_STRINGS },
   };
 }
 

--- a/packages/service/src/index.ts
+++ b/packages/service/src/index.ts
@@ -107,11 +107,12 @@ export {
 
 // ── Progress ──
 export {
-  formatProgressEvent,
   type ProgressEvent,
   type ProgressPhase,
   ProgressReporter,
   type ProgressReporterConfig,
+  renderProgressEvent,
+  type TemplateStrings,
 } from './progress/index.js';
 
 // ── Scheduling ──

--- a/packages/service/src/progress/index.ts
+++ b/packages/service/src/progress/index.ts
@@ -1,28 +1,40 @@
 /**
  * Progress reporting via OpenClaw gateway `/tools/invoke` → `message` tool.
  *
+ * Progress events are rendered using Handlebars templates. Owner-path links
+ * are resolved via the jeeves-server resolve-path API, with graceful
+ * fallback to raw filesystem paths when the server is unreachable.
+ *
  * @module progress
  */
 
+import Handlebars from 'handlebars';
 import type { Logger } from 'pino';
-
-import { normalizePath } from '../normalizePath.js';
 
 export type ProgressPhase = 'architect' | 'builder' | 'critic';
 
 export type ProgressEvent = {
-  type:
-    | 'synthesis_start'
-    | 'phase_start'
-    | 'phase_complete'
-    | 'synthesis_complete'
-    | 'error';
+  type: 'phase_start' | 'phase_complete' | 'error';
   /** Owner path (not .meta path) of the entity being synthesized. */
   path: string;
   phase?: ProgressPhase;
   tokens?: number;
   durationMs?: number;
   error?: string;
+};
+
+/** Compiled Handlebars templates for the three progress event types. */
+type CompiledTemplates = {
+  phaseStart: HandlebarsTemplateDelegate;
+  phaseEnd: HandlebarsTemplateDelegate;
+  phaseError: HandlebarsTemplateDelegate;
+};
+
+/** Raw (string) template config — mirrors the schema definition. */
+export type TemplateStrings = {
+  phaseStart: string;
+  phaseEnd: string;
+  phaseError: string;
 };
 
 export type ProgressReporterConfig = {
@@ -37,181 +49,149 @@ export type ProgressReporterConfig = {
   reportChannel?: string;
   /** Channel/user ID to send messages to. Takes priority over reportChannel as target. */
   reportTarget?: string;
-  /** Optional base URL for the service, used to construct entity links. */
-  serverBaseUrl?: string;
   /**
-   * Optional mapping of server drive labels to absolute filesystem paths.
-   * Used on Linux to resolve absolute paths to jeeves-server browse paths.
-   * Example: `{ "content": "/opt/jeeves/content" }`
+   * URL of the local jeeves-server instance, used to resolve filesystem paths
+   * to browse links via the resolve-path API.
+   * Default: http://127.0.0.1:1934
    */
-  serverDriveRoots?: Record<string, string>;
+  serverUrl?: string;
+  /** Handlebars template strings for each progress event type. */
+  templates?: Partial<TemplateStrings>;
 };
+
+const DEFAULT_TEMPLATES: TemplateStrings = {
+  phaseStart: ':gear: Started meta synthesis {{phase}} phase of <{{dirLink}}>',
+  phaseEnd:
+    ':white_check_mark: Completed meta synthesis {{phase}} phase ({{tokens}} tokens / {{seconds}}s) at <{{metaLink}}>',
+  phaseError:
+    ':x: Meta synthesis {{phase}} phase failed at <{{dirLink}}>\n   Error: {{error}}',
+};
+
+/** Compile raw template strings into Handlebars delegates. */
+function compileTemplates(
+  raw: Partial<TemplateStrings> | undefined,
+): CompiledTemplates {
+  const merged: TemplateStrings = {
+    phaseStart: raw?.phaseStart ?? DEFAULT_TEMPLATES.phaseStart,
+    phaseEnd: raw?.phaseEnd ?? DEFAULT_TEMPLATES.phaseEnd,
+    phaseError: raw?.phaseError ?? DEFAULT_TEMPLATES.phaseError,
+  };
+  return {
+    phaseStart: Handlebars.compile(merged.phaseStart),
+    phaseEnd: Handlebars.compile(merged.phaseEnd),
+    phaseError: Handlebars.compile(merged.phaseError),
+  };
+}
 
 function formatNumber(n: number): string {
   return n.toLocaleString('en-US');
 }
 
-function formatTokens(tokens: number | undefined): string {
-  return tokens !== undefined
-    ? formatNumber(tokens) + ' tokens'
-    : 'unknown tokens';
-}
-
-function formatSeconds(durationMs: number): string {
-  const seconds = durationMs / 1000;
-  return Math.round(seconds).toString() + 's';
-}
-
-function titleCasePhase(phase: ProgressPhase): string {
-  return phase.charAt(0).toUpperCase() + phase.slice(1);
-}
-
 /**
- * URL-encode each path segment individually so that spaces and special
- * characters are safe while preserving the `/` separators.
- */
-function encodePathSegments(p: string): string {
-  return p
-    .split('/')
-    .map((seg) => encodeURIComponent(seg))
-    .join('/');
-}
-
-/**
- * Resolve a filesystem path to a jeeves-server browse path segment.
+ * Resolve a filesystem path to a browse URL via the jeeves-server
+ * resolve-path API. Returns the raw path as fallback on any failure.
  *
- * - Windows: `j:/domains/foo` → `/j/domains/foo` (drive-letter transform).
- * - Linux with serverDriveRoots: `/opt/jeeves/content/slack` + roots
- *   `{ content: "/opt/jeeves/content" }` → `/content/slack`.
- * - Linux without serverDriveRoots: returns the normalized path unchanged
- *   (browse link will be invalid, but this is the pre-existing behavior).
+ * On HTTP 200, uses publicUrl if present, otherwise prefixes serverUrl
+ * to browseUrl. On any error or non-200 response, returns fsPath as-is.
  */
-function resolveServerPath(
-  path: string,
-  serverDriveRoots?: Record<string, string>,
-): string {
-  const normalized = normalizePath(path);
-
-  // Windows: drive letter present — use existing transform
-  if (/^[A-Za-z]:/.test(normalized)) {
-    return normalized.replace(/^([A-Za-z]):/, '/$1');
-  }
-
-  // Linux: attempt serverDriveRoots resolution (longest/most-specific root wins)
-  if (serverDriveRoots) {
-    const sorted = Object.entries(serverDriveRoots)
-      .map(
-        ([label, root]) =>
-          [label, normalizePath(root).replace(/\/+$/, '')] as const,
-      )
-      .sort((a, b) => b[1].length - a[1].length);
-
-    for (const [label, normalizedRoot] of sorted) {
-      if (
-        normalized === normalizedRoot ||
-        normalized.startsWith(normalizedRoot + '/')
-      ) {
-        const relative = normalized
-          .slice(normalizedRoot.length)
-          .replace(/^\//, '');
-        return `/${label}${relative ? '/' + relative : ''}`;
-      }
+async function resolveLink(fsPath: string, serverUrl: string): Promise<string> {
+  try {
+    const url = new URL('/api/resolve-path', serverUrl);
+    url.searchParams.set('fsPath', fsPath);
+    const res = await fetch(url.toString(), {
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!res.ok) return fsPath;
+    const data = (await res.json()) as {
+      browsePath?: string;
+      browseUrl?: string;
+      publicUrl?: string;
+    };
+    if (data.publicUrl) return data.publicUrl;
+    if (data.browseUrl) {
+      const base = serverUrl.replace(/\/+$/, '');
+      return base + data.browseUrl;
     }
+    return fsPath;
+  } catch {
+    return fsPath;
   }
-
-  // Fallback: no drive roots configured or no match — return as-is
-  return normalized;
 }
 
-/** Build a link (or plain path) to the owner directory. */
-function buildDirectoryLink(
-  path: string,
-  serverBaseUrl?: string,
-  serverDriveRoots?: Record<string, string>,
-): string {
-  const resolved = resolveServerPath(path, serverDriveRoots);
-  const encoded = encodePathSegments(resolved);
-
-  if (!serverBaseUrl) return resolved;
-
-  const base = serverBaseUrl.replace(/\/+$/, '');
-  return `${base}/path${encoded}`;
+/** Resolve browse links for both the owner directory and its meta.json. */
+async function resolveLinks(
+  ownerPath: string,
+  serverUrl: string,
+): Promise<{ dirLink: string; metaLink: string }> {
+  const dirLink = await resolveLink(ownerPath, serverUrl);
+  // Derive metaLink by appending /.meta/meta.json to the resolved dir link
+  const metaLink = dirLink.replace(/\/+$/, '') + '/.meta/meta.json';
+  return { dirLink, metaLink };
 }
 
-/** Build a link (or plain path) to the entity's meta.json output file. */
-function buildMetaJsonLink(
-  path: string,
-  serverBaseUrl?: string,
-  serverDriveRoots?: Record<string, string>,
-): string {
-  const resolved = resolveServerPath(path, serverDriveRoots);
-  const metaJsonPath = `${resolved}/.meta/meta.json`;
-  const encoded = encodePathSegments(metaJsonPath);
-
-  if (!serverBaseUrl) return metaJsonPath;
-
-  const base = serverBaseUrl.replace(/\/+$/, '');
-  return `${base}/path${encoded}`;
+/** Data bag passed to every Handlebars template. */
+interface TemplateData {
+  dirPath: string;
+  metaPath: string;
+  dirLink: string;
+  metaLink: string;
+  phase: string;
+  seconds?: string;
+  tokens?: string;
+  error?: string;
 }
 
-export function formatProgressEvent(
+/**
+ * Render the appropriate template for a progress event.
+ *
+ * @param event - The progress event to render.
+ * @param templates - Compiled Handlebars templates.
+ * @param serverUrl - jeeves-server URL for resolve-path API.
+ * @returns Rendered message string.
+ */
+export async function renderProgressEvent(
   event: ProgressEvent,
-  serverBaseUrl?: string,
-  serverDriveRoots?: Record<string, string>,
-): string {
-  switch (event.type) {
-    case 'synthesis_start': {
-      const dirLink = buildDirectoryLink(
-        event.path,
-        serverBaseUrl,
-        serverDriveRoots,
-      );
-      return `🔬 Started meta synthesis: ${dirLink}`;
-    }
+  templates: CompiledTemplates,
+  serverUrl: string,
+): Promise<string> {
+  const ownerPath = event.path;
+  const metaPath = ownerPath.replace(/\/+$/, '') + '/.meta/meta.json';
+  const phase = (event.phase ?? 'unknown').toUpperCase();
+  const { dirLink, metaLink } = await resolveLinks(ownerPath, serverUrl);
 
-    case 'phase_start': {
-      if (!event.phase) {
-        return '  ⚙️ Phase started';
-      }
-      return `  ⚙️ ${titleCasePhase(event.phase)} phase started`;
-    }
+  const base: TemplateData = {
+    dirPath: ownerPath,
+    metaPath,
+    dirLink,
+    metaLink,
+    phase,
+  };
+
+  switch (event.type) {
+    case 'phase_start':
+      return templates.phaseStart(base);
 
     case 'phase_complete': {
-      const phase = event.phase ? titleCasePhase(event.phase) : 'Phase';
-      const tokenStr = formatTokens(event.tokens);
-      const duration =
-        event.durationMs !== undefined ? formatSeconds(event.durationMs) : '0s';
-      return `  ✅ ${phase} complete (${tokenStr} / ${duration})`;
-    }
-
-    case 'synthesis_complete': {
-      const metaLink = buildMetaJsonLink(
-        event.path,
-        serverBaseUrl,
-        serverDriveRoots,
-      );
-      const tokenStr = formatTokens(event.tokens);
-      const duration =
+      const seconds =
         event.durationMs !== undefined
-          ? formatSeconds(event.durationMs)
-          : '0.0s';
-      return `✅ Completed: ${metaLink} (${tokenStr} / ${duration})`;
+          ? String(Math.round(event.durationMs / 1000))
+          : '0';
+      const tokens =
+        event.tokens !== undefined ? formatNumber(event.tokens) : 'unknown';
+      return templates.phaseEnd({ ...base, seconds, tokens });
     }
 
     case 'error': {
-      const dirLink = buildDirectoryLink(
-        event.path,
-        serverBaseUrl,
-        serverDriveRoots,
-      );
-      const phase = event.phase ? `${titleCasePhase(event.phase)} ` : '';
-      const error = event.error ?? 'Unknown error';
-      return `❌ Synthesis failed at ${phase}phase: ${dirLink}\n   Error: ${error}`;
+      const seconds =
+        event.durationMs !== undefined
+          ? String(Math.round(event.durationMs / 1000))
+          : '0';
+      const errorMsg = event.error ?? 'Unknown error';
+      return templates.phaseError({ ...base, seconds, error: errorMsg });
     }
 
-    default: {
+    default:
       return 'Unknown progress event';
-    }
   }
 }
 
@@ -228,10 +208,22 @@ type GatewayInvokeRequest = {
 export class ProgressReporter {
   private readonly config: ProgressReporterConfig;
   private readonly logger: Logger;
+  private templates: CompiledTemplates;
+  private readonly serverUrl: string;
 
   public constructor(config: ProgressReporterConfig, logger: Logger) {
     this.config = config;
     this.logger = logger;
+    this.templates = compileTemplates(config.templates);
+    this.serverUrl = config.serverUrl ?? 'http://127.0.0.1:1934';
+  }
+
+  /**
+   * Recompile templates from new config (supports hot-reload).
+   * Call when the template strings change at runtime.
+   */
+  public updateTemplates(templates: Partial<TemplateStrings>): void {
+    this.templates = compileTemplates(templates);
   }
 
   public async report(event: ProgressEvent): Promise<void> {
@@ -240,11 +232,18 @@ export class ProgressReporter {
     const target = this.config.reportTarget ?? this.config.reportChannel;
     if (!target) return;
 
-    const message = formatProgressEvent(
-      event,
-      this.config.serverBaseUrl,
-      this.config.serverDriveRoots,
-    );
+    let message: string;
+    try {
+      message = await renderProgressEvent(
+        event,
+        this.templates,
+        this.serverUrl,
+      );
+    } catch (err) {
+      this.logger.warn({ err }, 'Progress event rendering failed');
+      return;
+    }
+
     const url = new URL('/tools/invoke', this.config.gatewayUrl);
 
     const args: GatewayInvokeRequest['args'] = {

--- a/packages/service/src/progress/index.ts
+++ b/packages/service/src/progress/index.ts
@@ -8,8 +8,11 @@
  * @module progress
  */
 
+import { fetchWithTimeout } from '@karmaniverous/jeeves';
 import Handlebars from 'handlebars';
 import type { Logger } from 'pino';
+
+import { DEFAULT_TEMPLATE_STRINGS } from '../schema/config.js';
 
 export type ProgressPhase = 'architect' | 'builder' | 'critic';
 
@@ -59,22 +62,14 @@ export type ProgressReporterConfig = {
   templates?: Partial<TemplateStrings>;
 };
 
-const DEFAULT_TEMPLATES: TemplateStrings = {
-  phaseStart: ':gear: Started meta synthesis {{phase}} phase of <{{dirLink}}>',
-  phaseEnd:
-    ':white_check_mark: Completed meta synthesis {{phase}} phase ({{tokens}} tokens / {{seconds}}s) at <{{metaLink}}>',
-  phaseError:
-    ':x: Meta synthesis {{phase}} phase failed at <{{dirLink}}>\n   Error: {{error}}',
-};
-
 /** Compile raw template strings into Handlebars delegates. */
 function compileTemplates(
   raw: Partial<TemplateStrings> | undefined,
 ): CompiledTemplates {
   const merged: TemplateStrings = {
-    phaseStart: raw?.phaseStart ?? DEFAULT_TEMPLATES.phaseStart,
-    phaseEnd: raw?.phaseEnd ?? DEFAULT_TEMPLATES.phaseEnd,
-    phaseError: raw?.phaseError ?? DEFAULT_TEMPLATES.phaseError,
+    phaseStart: raw?.phaseStart ?? DEFAULT_TEMPLATE_STRINGS.phaseStart,
+    phaseEnd: raw?.phaseEnd ?? DEFAULT_TEMPLATE_STRINGS.phaseEnd,
+    phaseError: raw?.phaseError ?? DEFAULT_TEMPLATE_STRINGS.phaseError,
   };
   return {
     phaseStart: Handlebars.compile(merged.phaseStart),
@@ -94,13 +89,14 @@ function formatNumber(n: number): string {
  * On HTTP 200, uses publicUrl if present, otherwise prefixes serverUrl
  * to browseUrl. On any error or non-200 response, returns fsPath as-is.
  */
+/** Timeout for resolve-path API calls (ms). */
+const RESOLVE_PATH_TIMEOUT_MS = 3000;
+
 async function resolveLink(fsPath: string, serverUrl: string): Promise<string> {
   try {
     const url = new URL('/api/resolve-path', serverUrl);
     url.searchParams.set('fsPath', fsPath);
-    const res = await fetch(url.toString(), {
-      signal: AbortSignal.timeout(3000),
-    });
+    const res = await fetchWithTimeout(url.toString(), RESOLVE_PATH_TIMEOUT_MS);
     if (!res.ok) return fsPath;
     const data = (await res.json()) as {
       browsePath?: string;
@@ -209,21 +205,16 @@ export class ProgressReporter {
   private readonly config: ProgressReporterConfig;
   private readonly logger: Logger;
   private templates: CompiledTemplates;
+  /** Snapshot of template source strings used to compile `this.templates`. */
+  private lastTemplateSource: string;
   private readonly serverUrl: string;
 
   public constructor(config: ProgressReporterConfig, logger: Logger) {
     this.config = config;
     this.logger = logger;
     this.templates = compileTemplates(config.templates);
+    this.lastTemplateSource = JSON.stringify(config.templates);
     this.serverUrl = config.serverUrl ?? 'http://127.0.0.1:1934';
-  }
-
-  /**
-   * Recompile templates from new config (supports hot-reload).
-   * Call when the template strings change at runtime.
-   */
-  public updateTemplates(templates: Partial<TemplateStrings>): void {
-    this.templates = compileTemplates(templates);
   }
 
   public async report(event: ProgressEvent): Promise<void> {
@@ -231,6 +222,15 @@ export class ProgressReporter {
     // Legacy mode: reportChannel alone acts as the target (backward compatible).
     const target = this.config.reportTarget ?? this.config.reportChannel;
     if (!target) return;
+
+    // Detect template hot-reload: config.templates may be mutated by
+    // applyHotReloadedConfig; recompile when the source strings change.
+    const currentSource = JSON.stringify(this.config.templates);
+    if (currentSource !== this.lastTemplateSource) {
+      this.templates = compileTemplates(this.config.templates);
+      this.lastTemplateSource = currentSource;
+      this.logger.info('Progress templates recompiled (hot-reload)');
+    }
 
     let message: string;
     try {

--- a/packages/service/src/progress/index.ts
+++ b/packages/service/src/progress/index.ts
@@ -227,9 +227,16 @@ export class ProgressReporter {
     // applyHotReloadedConfig; recompile when the source strings change.
     const currentSource = JSON.stringify(this.config.templates);
     if (currentSource !== this.lastTemplateSource) {
-      this.templates = compileTemplates(this.config.templates);
-      this.lastTemplateSource = currentSource;
-      this.logger.info('Progress templates recompiled (hot-reload)');
+      try {
+        this.templates = compileTemplates(this.config.templates);
+        this.lastTemplateSource = currentSource;
+        this.logger.info('Progress templates recompiled (hot-reload)');
+      } catch (err) {
+        this.logger.warn(
+          { err },
+          'Failed to compile hot-reloaded templates; keeping previous templates',
+        );
+      }
     }
 
     let message: string;

--- a/packages/service/src/progress/progress.test.ts
+++ b/packages/service/src/progress/progress.test.ts
@@ -1,8 +1,8 @@
-// Helpers to compile default templates for tests
 import Handlebars from 'handlebars';
 import type { Logger } from 'pino';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { DEFAULT_TEMPLATE_STRINGS } from '../schema/config.js';
 import {
   type ProgressEvent,
   ProgressReporter,
@@ -14,21 +14,15 @@ function makeCompiledTemplates(overrides?: {
   phaseEnd?: string;
   phaseError?: string;
 }) {
-  const defaults = {
-    phaseStart:
-      ':gear: Started meta synthesis {{phase}} phase of <{{dirLink}}>',
-    phaseEnd:
-      ':white_check_mark: Completed meta synthesis {{phase}} phase ({{tokens}} tokens / {{seconds}}s) at <{{metaLink}}>',
-    phaseError:
-      ':x: Meta synthesis {{phase}} phase failed at <{{dirLink}}>\n   Error: {{error}}',
-  };
   return {
     phaseStart: Handlebars.compile(
-      overrides?.phaseStart ?? defaults.phaseStart,
+      overrides?.phaseStart ?? DEFAULT_TEMPLATE_STRINGS.phaseStart,
     ),
-    phaseEnd: Handlebars.compile(overrides?.phaseEnd ?? defaults.phaseEnd),
+    phaseEnd: Handlebars.compile(
+      overrides?.phaseEnd ?? DEFAULT_TEMPLATE_STRINGS.phaseEnd,
+    ),
     phaseError: Handlebars.compile(
-      overrides?.phaseError ?? defaults.phaseError,
+      overrides?.phaseError ?? DEFAULT_TEMPLATE_STRINGS.phaseError,
     ),
   };
 }

--- a/packages/service/src/progress/progress.test.ts
+++ b/packages/service/src/progress/progress.test.ts
@@ -1,11 +1,37 @@
+// Helpers to compile default templates for tests
+import Handlebars from 'handlebars';
 import type { Logger } from 'pino';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
-  formatProgressEvent,
   type ProgressEvent,
   ProgressReporter,
+  renderProgressEvent,
 } from './index.js';
+
+function makeCompiledTemplates(overrides?: {
+  phaseStart?: string;
+  phaseEnd?: string;
+  phaseError?: string;
+}) {
+  const defaults = {
+    phaseStart:
+      ':gear: Started meta synthesis {{phase}} phase of <{{dirLink}}>',
+    phaseEnd:
+      ':white_check_mark: Completed meta synthesis {{phase}} phase ({{tokens}} tokens / {{seconds}}s) at <{{metaLink}}>',
+    phaseError:
+      ':x: Meta synthesis {{phase}} phase failed at <{{dirLink}}>\n   Error: {{error}}',
+  };
+  return {
+    phaseStart: Handlebars.compile(
+      overrides?.phaseStart ?? defaults.phaseStart,
+    ),
+    phaseEnd: Handlebars.compile(overrides?.phaseEnd ?? defaults.phaseEnd),
+    phaseError: Handlebars.compile(
+      overrides?.phaseError ?? defaults.phaseError,
+    ),
+  };
+}
 
 function createLogger() {
   return {
@@ -13,214 +39,251 @@ function createLogger() {
   } as unknown as Logger;
 }
 
-describe('formatProgressEvent', () => {
-  it('formats synthesis_start with directory path', () => {
-    const e: ProgressEvent = { type: 'synthesis_start', path: 'x' };
-    expect(formatProgressEvent(e)).toBe('🔬 Started meta synthesis: x');
+/** Extract the URL string from a fetch input argument. */
+function getInputUrl(input: string | URL | Request): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+/** Mock fetch to return a 404 so resolveLink falls back to raw paths. */
+function mockFetchNotFound() {
+  return vi
+    .spyOn(globalThis, 'fetch')
+    .mockImplementation(() =>
+      Promise.resolve(new Response('not found', { status: 404 })),
+    );
+}
+
+describe('renderProgressEvent', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
   });
 
-  it('formats phase_start', () => {
-    const e: ProgressEvent = {
+  it('renders phase_start with ARCHITECT and dirLink fallback', async () => {
+    mockFetchNotFound();
+    const templates = makeCompiledTemplates();
+    const event: ProgressEvent = {
       type: 'phase_start',
       path: 'j:/domains/github/org',
       phase: 'architect',
     };
-    expect(formatProgressEvent(e)).toBe('  ⚙️ Architect phase started');
+    const result = await renderProgressEvent(
+      event,
+      templates,
+      'http://127.0.0.1:1934',
+    );
+    expect(result).toBe(
+      ':gear: Started meta synthesis ARCHITECT phase of <j:/domains/github/org>',
+    );
   });
 
-  it('formats phase_complete', () => {
-    const e: ProgressEvent = {
+  it('renders phase_complete with formatted tokens and seconds', async () => {
+    mockFetchNotFound();
+    const templates = makeCompiledTemplates();
+    const event: ProgressEvent = {
       type: 'phase_complete',
       path: 'j:/domains/github/org',
       phase: 'builder',
-      tokens: 1234,
-      durationMs: 1500,
+      tokens: 38200,
+      durationMs: 4500,
     };
-    expect(formatProgressEvent(e)).toBe(
-      '  ✅ Builder complete (1,234 tokens / 2s)',
+    const result = await renderProgressEvent(
+      event,
+      templates,
+      'http://127.0.0.1:1934',
     );
+    expect(result).toContain('BUILDER');
+    expect(result).toContain('38,200');
+    expect(result).toContain('5s');
   });
 
-  it('formats synthesis_complete', () => {
-    const e: ProgressEvent = {
-      type: 'synthesis_complete',
-      path: 'x',
-      tokens: 10,
-      durationMs: 2500,
+  it('renders phase_complete with "unknown" tokens when undefined', async () => {
+    mockFetchNotFound();
+    const templates = makeCompiledTemplates();
+    const event: ProgressEvent = {
+      type: 'phase_complete',
+      path: 'j:/domains/github/org',
+      phase: 'builder',
+      durationMs: 1000,
     };
-    expect(formatProgressEvent(e)).toBe(
-      '✅ Completed: x/.meta/meta.json (10 tokens / 3s)',
+    const result = await renderProgressEvent(
+      event,
+      templates,
+      'http://127.0.0.1:1934',
     );
+    expect(result).toContain('unknown');
   });
 
-  it('formats error with directory path', () => {
-    const e: ProgressEvent = {
+  it('renders error with CRITIC and dirLink fallback', async () => {
+    mockFetchNotFound();
+    const templates = makeCompiledTemplates();
+    const event: ProgressEvent = {
       type: 'error',
-      path: 'x',
+      path: 'j:/domains/github/org',
       phase: 'critic',
       error: 'boom',
     };
-    expect(formatProgressEvent(e)).toBe(
-      '❌ Synthesis failed at Critic phase: x\n   Error: boom',
+    const result = await renderProgressEvent(
+      event,
+      templates,
+      'http://127.0.0.1:1934',
+    );
+    expect(result).toBe(
+      ':x: Meta synthesis CRITIC phase failed at <j:/domains/github/org>\n   Error: boom',
     );
   });
 
-  it('constructs directory link in synthesis_start when serverBaseUrl is set', () => {
-    const e: ProgressEvent = {
-      type: 'synthesis_start',
-      path: 'D:\\domains\\github\\org',
-    };
-    const result = formatProgressEvent(e, 'http://localhost:1938');
-    expect(result).toContain('http://localhost:1938/path/D/domains/github/org');
-    expect(result).not.toContain('meta.json');
-  });
-
-  it('constructs meta.json link in synthesis_complete when serverBaseUrl is set', () => {
-    const e: ProgressEvent = {
-      type: 'synthesis_complete',
+  it('uses publicUrl from resolve-path API when available', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            browsePath: 'j/domains/github/org',
+            browseUrl: '/browse/j/domains/github/org',
+            publicUrl: 'https://jeeves.example.com/browse/j/domains/github/org',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      ),
+    );
+    const templates = makeCompiledTemplates();
+    const event: ProgressEvent = {
+      type: 'phase_start',
       path: 'j:/domains/github/org',
-      tokens: 100,
-      durationMs: 5000,
+      phase: 'architect',
     };
-    const result = formatProgressEvent(e, 'https://meta.example.com');
+    const result = await renderProgressEvent(
+      event,
+      templates,
+      'http://127.0.0.1:1934',
+    );
     expect(result).toContain(
-      'https://meta.example.com/path/j/domains/github/org/.meta/meta.json',
+      'https://jeeves.example.com/browse/j/domains/github/org',
     );
   });
 
-  it('uses plain directory path when serverBaseUrl is not set', () => {
-    const e: ProgressEvent = { type: 'synthesis_start', path: 'x' };
-    const result = formatProgressEvent(e);
-    expect(result).toBe('🔬 Started meta synthesis: x');
-  });
-
-  it('URL-encodes path segments with special characters', () => {
-    const e: ProgressEvent = {
-      type: 'synthesis_start',
-      path: 'j:/domains/slack/dm-Bob Louthan (D123)',
+  it('uses browseUrl + serverUrl when publicUrl is absent', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            browsePath: 'j/domains/github/org',
+            browseUrl: '/browse/j/domains/github/org',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      ),
+    );
+    const templates = makeCompiledTemplates();
+    const event: ProgressEvent = {
+      type: 'phase_start',
+      path: 'j:/domains/github/org',
+      phase: 'architect',
     };
-    const result = formatProgressEvent(e, 'http://localhost:1934');
+    const result = await renderProgressEvent(
+      event,
+      templates,
+      'http://127.0.0.1:1934',
+    );
     expect(result).toContain(
-      'http://localhost:1934/path/j/domains/slack/dm-Bob%20Louthan%20(D123)',
+      'http://127.0.0.1:1934/browse/j/domains/github/org',
     );
   });
 
-  it('URL-encodes meta.json link in synthesis_complete', () => {
-    const e: ProgressEvent = {
-      type: 'synthesis_complete',
-      path: 'j:/domains/slack/dm-Bob Louthan (D123)',
-      tokens: 50,
-      durationMs: 1000,
-    };
-    const result = formatProgressEvent(e, 'http://localhost:1934');
-    expect(result).toContain(
-      'http://localhost:1934/path/j/domains/slack/dm-Bob%20Louthan%20(D123)/.meta/meta.json',
+  it('falls back to raw path when resolve-path API is unreachable', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.reject(new Error('connection refused')),
     );
+    const templates = makeCompiledTemplates();
+    const event: ProgressEvent = {
+      type: 'phase_start',
+      path: 'j:/domains/github/org',
+      phase: 'architect',
+    };
+    const result = await renderProgressEvent(
+      event,
+      templates,
+      'http://127.0.0.1:1934',
+    );
+    expect(result).toContain('j:/domains/github/org');
+    expect(result).not.toContain('http://127.0.0.1:1934/browse');
   });
 
-  it('renders "unknown tokens" when tokens is undefined in phase_complete', () => {
-    const e: ProgressEvent = {
+  it('metaLink appends /.meta/meta.json to the resolved dirLink', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            browsePath: 'j/domains/github/org',
+            browseUrl: '/browse/j/domains/github/org',
+            publicUrl: 'https://jeeves.example.com/browse/j/domains/github/org',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      ),
+    );
+    const templates = makeCompiledTemplates();
+    const event: ProgressEvent = {
       type: 'phase_complete',
-      path: 'x',
-      phase: 'builder',
-      durationMs: 1000,
-    };
-    expect(formatProgressEvent(e)).toBe(
-      '  ✅ Builder complete (unknown tokens / 1s)',
-    );
-  });
-
-  it('renders "unknown tokens" when tokens is undefined in synthesis_complete', () => {
-    const e: ProgressEvent = {
-      type: 'synthesis_complete',
-      path: 'x',
+      path: 'j:/domains/github/org',
+      phase: 'critic',
+      tokens: 100,
       durationMs: 2000,
     };
-    expect(formatProgressEvent(e)).toBe(
-      '✅ Completed: x/.meta/meta.json (unknown tokens / 2s)',
+    const result = await renderProgressEvent(
+      event,
+      templates,
+      'http://127.0.0.1:1934',
+    );
+    expect(result).toContain(
+      'https://jeeves.example.com/browse/j/domains/github/org/.meta/meta.json',
     );
   });
 
-  describe('serverDriveRoots (Linux path resolution)', () => {
-    const serverDriveRoots = { content: '/opt/jeeves/content' };
-    const base = 'http://localhost:1934';
-
-    it('resolves Linux path via serverDriveRoots for synthesis_start', () => {
-      const e: ProgressEvent = {
-        type: 'synthesis_start',
-        path: '/opt/jeeves/content/slack/general',
-      };
-      const result = formatProgressEvent(e, base, serverDriveRoots);
-      expect(result).toContain(
-        'http://localhost:1934/path/content/slack/general',
-      );
+  it('renders phase_start with custom template', async () => {
+    mockFetchNotFound();
+    const templates = makeCompiledTemplates({
+      phaseStart: 'CUSTOM: {{phase}} → {{dirPath}}',
     });
+    const event: ProgressEvent = {
+      type: 'phase_start',
+      path: 'j:/domains/mydir',
+      phase: 'builder',
+    };
+    const result = await renderProgressEvent(
+      event,
+      templates,
+      'http://127.0.0.1:1934',
+    );
+    expect(result).toBe('CUSTOM: BUILDER → j:/domains/mydir');
+  });
 
-    it('resolves Linux path via serverDriveRoots for synthesis_complete', () => {
-      const e: ProgressEvent = {
-        type: 'synthesis_complete',
-        path: '/opt/jeeves/content/slack/general',
-        tokens: 100,
-        durationMs: 3000,
-      };
-      const result = formatProgressEvent(e, base, serverDriveRoots);
-      expect(result).toContain(
-        'http://localhost:1934/path/content/slack/general/.meta/meta.json',
-      );
+  it('exposes dirPath and metaPath as raw paths in template data', async () => {
+    mockFetchNotFound();
+    const templates = makeCompiledTemplates({
+      phaseStart: '{{dirPath}} | {{metaPath}}',
     });
-
-    it('falls back to raw path when no roots match', () => {
-      const e: ProgressEvent = {
-        type: 'synthesis_start',
-        path: '/var/data/other/path',
-      };
-      const result = formatProgressEvent(e, base, serverDriveRoots);
-      // No matching root — falls back to normalized path
-      expect(result).toContain(
-        'http://localhost:1934/path/var/data/other/path',
-      );
-    });
-
-    it('resolves exact root match (no trailing relative path)', () => {
-      const e: ProgressEvent = {
-        type: 'synthesis_start',
-        path: '/opt/jeeves/content',
-      };
-      const result = formatProgressEvent(e, base, serverDriveRoots);
-      expect(result).toContain('http://localhost:1934/path/content');
-    });
-
-    it('prefers the longest matching root when roots overlap', () => {
-      const overlappingRoots = {
-        jeeves: '/opt/jeeves',
-        content: '/opt/jeeves/content',
-      };
-      const e: ProgressEvent = {
-        type: 'synthesis_start',
-        path: '/opt/jeeves/content/slack/general',
-      };
-      const result = formatProgressEvent(e, base, overlappingRoots);
-      // Must match "content" (longer root), not "jeeves"
-      expect(result).toContain(
-        'http://localhost:1934/path/content/slack/general',
-      );
-    });
-
-    it('does not affect Windows paths (drive letter takes priority)', () => {
-      const e: ProgressEvent = {
-        type: 'synthesis_start',
-        path: 'j:/domains/github/org',
-      };
-      const result = formatProgressEvent(e, base, serverDriveRoots);
-      expect(result).toContain(
-        'http://localhost:1934/path/j/domains/github/org',
-      );
-    });
+    const event: ProgressEvent = {
+      type: 'phase_start',
+      path: 'j:/domains/mydir',
+      phase: 'architect',
+    };
+    const result = await renderProgressEvent(
+      event,
+      templates,
+      'http://127.0.0.1:1934',
+    );
+    expect(result).toBe('j:/domains/mydir | j:/domains/mydir/.meta/meta.json');
   });
 });
 
 describe('ProgressReporter', () => {
-  it('is a no-op when reportChannel is not set', async () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('is a no-op when neither reportChannel nor reportTarget is set', async () => {
     const logger = createLogger();
     const reporter = new ProgressReporter(
       { gatewayUrl: 'http://127.0.0.1:18789' },
@@ -233,10 +296,13 @@ describe('ProgressReporter', () => {
         Promise.resolve(new Response('', { status: 200 })),
       );
 
-    await reporter.report({ type: 'synthesis_start', path: 'x' });
+    await reporter.report({
+      type: 'phase_start',
+      path: 'x',
+      phase: 'architect',
+    });
 
     expect(fetchSpy).not.toHaveBeenCalled();
-    fetchSpy.mockRestore();
   });
 
   it('posts to gateway /tools/invoke with message tool', async () => {
@@ -246,13 +312,19 @@ describe('ProgressReporter', () => {
         gatewayUrl: 'http://127.0.0.1:18789',
         gatewayApiKey: 'k',
         reportChannel: 'C123',
+        serverUrl: 'http://127.0.0.1:1934',
       },
       logger,
     );
 
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
-      .mockImplementation((_input, init) => {
+      .mockImplementation((input, init) => {
+        // First call is the resolve-path API; subsequent call is the gateway invoke
+        const url = getInputUrl(input);
+        if (url.includes('resolve-path')) {
+          return Promise.resolve(new Response('not found', { status: 404 }));
+        }
         const rawBody = init?.body;
         if (typeof rawBody !== 'string') {
           throw new Error('Expected request body to be a string');
@@ -265,15 +337,18 @@ describe('ProgressReporter', () => {
         expect(body.tool).toBe('message');
         expect(body.args.action).toBe('send');
         expect(body.args.target).toBe('C123');
-        expect(body.args.message).toContain('Started meta synthesis');
+        expect(body.args.message).toContain('ARCHITECT');
 
         return Promise.resolve(new Response('', { status: 200 }));
       });
 
-    await reporter.report({ type: 'synthesis_start', path: 'x' });
+    await reporter.report({
+      type: 'phase_start',
+      path: 'x',
+      phase: 'architect',
+    });
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    fetchSpy.mockRestore();
+    expect(fetchSpy).toHaveBeenCalledTimes(2); // resolve-path + gateway
   });
 
   it('sends channel field when both reportChannel and reportTarget are set', async () => {
@@ -283,13 +358,18 @@ describe('ProgressReporter', () => {
         gatewayUrl: 'http://127.0.0.1:18789',
         reportChannel: 'slack',
         reportTarget: 'C456',
+        serverUrl: 'http://127.0.0.1:1934',
       },
       logger,
     );
 
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
-      .mockImplementation((_input, init) => {
+      .mockImplementation((input, init) => {
+        const url = getInputUrl(input);
+        if (url.includes('resolve-path')) {
+          return Promise.resolve(new Response('not found', { status: 404 }));
+        }
         const rawBody = init?.body;
         if (typeof rawBody !== 'string') {
           throw new Error('Expected request body to be a string');
@@ -310,9 +390,9 @@ describe('ProgressReporter', () => {
         return Promise.resolve(new Response('', { status: 200 }));
       });
 
-    await reporter.report({ type: 'synthesis_start', path: 'x' });
+    await reporter.report({ type: 'phase_start', path: 'x', phase: 'builder' });
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
     fetchSpy.mockRestore();
   });
 
@@ -322,13 +402,18 @@ describe('ProgressReporter', () => {
       {
         gatewayUrl: 'http://127.0.0.1:18789',
         reportChannel: 'C123',
+        serverUrl: 'http://127.0.0.1:1934',
       },
       logger,
     );
 
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
-      .mockImplementation((_input, init) => {
+      .mockImplementation((input, init) => {
+        const url = getInputUrl(input);
+        if (url.includes('resolve-path')) {
+          return Promise.resolve(new Response('not found', { status: 404 }));
+        }
         const rawBody = init?.body;
         if (typeof rawBody !== 'string') {
           throw new Error('Expected request body to be a string');
@@ -349,30 +434,35 @@ describe('ProgressReporter', () => {
         return Promise.resolve(new Response('', { status: 200 }));
       });
 
-    await reporter.report({ type: 'synthesis_start', path: 'x' });
+    await reporter.report({ type: 'phase_start', path: 'x', phase: 'critic' });
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
     fetchSpy.mockRestore();
   });
 
   it('logs warning on gateway error and does not throw', async () => {
     const logger = createLogger();
     const reporter = new ProgressReporter(
-      { gatewayUrl: 'http://127.0.0.1:18789', reportChannel: 'C123' },
+      {
+        gatewayUrl: 'http://127.0.0.1:18789',
+        reportChannel: 'C123',
+        serverUrl: 'http://127.0.0.1:1934',
+      },
       logger,
     );
 
-    const fetchSpy = vi
-      .spyOn(globalThis, 'fetch')
-      .mockImplementation(() =>
-        Promise.resolve(new Response('nope', { status: 500 })),
-      );
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = getInputUrl(input);
+      if (url.includes('resolve-path')) {
+        return Promise.resolve(new Response('not found', { status: 404 }));
+      }
+      return Promise.resolve(new Response('nope', { status: 500 }));
+    });
 
     await expect(
-      reporter.report({ type: 'synthesis_start', path: 'x' }),
+      reporter.report({ type: 'phase_start', path: 'x', phase: 'architect' }),
     ).resolves.toBeUndefined();
 
     expect(logger.warn).toHaveBeenCalled();
-    fetchSpy.mockRestore();
   });
 });

--- a/packages/service/src/progress/progress.test.ts
+++ b/packages/service/src/progress/progress.test.ts
@@ -6,6 +6,7 @@ import { DEFAULT_TEMPLATE_STRINGS } from '../schema/config.js';
 import {
   type ProgressEvent,
   ProgressReporter,
+  type ProgressReporterConfig,
   renderProgressEvent,
 } from './index.js';
 
@@ -30,6 +31,7 @@ function makeCompiledTemplates(overrides?: {
 function createLogger() {
   return {
     warn: vi.fn(),
+    info: vi.fn(),
   } as unknown as Logger;
 }
 
@@ -270,6 +272,21 @@ describe('renderProgressEvent', () => {
     );
     expect(result).toBe('j:/domains/mydir | j:/domains/mydir/.meta/meta.json');
   });
+
+  it('renders UNKNOWN phase when event.phase is undefined', async () => {
+    mockFetchNotFound();
+    const templates = makeCompiledTemplates();
+    const event: ProgressEvent = {
+      type: 'phase_start',
+      path: 'j:/domains/mydir',
+    };
+    const result = await renderProgressEvent(
+      event,
+      templates,
+      'http://127.0.0.1:1934',
+    );
+    expect(result).toContain('UNKNOWN');
+  });
 });
 
 describe('ProgressReporter', () => {
@@ -458,5 +475,48 @@ describe('ProgressReporter', () => {
     ).resolves.toBeUndefined();
 
     expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('recompiles templates when config.templates is mutated (hot-reload)', async () => {
+    const config: ProgressReporterConfig = {
+      gatewayUrl: 'http://127.0.0.1:18789',
+      reportChannel: 'C123',
+      serverUrl: 'http://127.0.0.1:1934',
+      templates: { ...DEFAULT_TEMPLATE_STRINGS },
+    };
+    const logger = createLogger();
+    const reporter = new ProgressReporter(config, logger);
+
+    vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+      const url = getInputUrl(input);
+      if (url.includes('resolve-path')) {
+        return Promise.resolve(new Response('not found', { status: 404 }));
+      }
+      return Promise.resolve(new Response('', { status: 200 }));
+    });
+
+    // Mutate config.templates (simulates applyHotReloadedConfig)
+    config.templates!.phaseStart = 'HOT_RELOADED: {{phase}}';
+
+    await reporter.report({
+      type: 'phase_start',
+      path: 'x',
+      phase: 'architect',
+    });
+
+    // Verify the hot-reloaded template was used
+    const gatewayCall = vi
+      .mocked(globalThis.fetch)
+      .mock.calls.find((c) => getInputUrl(c[0]).includes('tools/invoke'));
+    expect(gatewayCall).toBeDefined();
+    const body = JSON.parse(gatewayCall![1]?.body as string) as {
+      args: { message: string };
+    };
+    expect(body.args.message).toBe('HOT_RELOADED: ARCHITECT');
+
+    // Verify recompilation was logged
+    expect(logger.info).toHaveBeenCalledWith(
+      'Progress templates recompiled (hot-reload)',
+    );
   });
 });

--- a/packages/service/src/routes/__testUtils.ts
+++ b/packages/service/src/routes/__testUtils.ts
@@ -39,6 +39,15 @@ const DEFAULT_TEST_CONFIG: RouteDeps['config'] = {
   stagingRetries: 10,
   stagingRetryDelayMs: 250,
   previewDeltaFilesCap: 50,
+  serverUrl: 'http://127.0.0.1:1934',
+  templates: {
+    phaseStart:
+      ':gear: Started meta synthesis {{phase}} phase of <{{dirLink}}>',
+    phaseEnd:
+      ':white_check_mark: Completed meta synthesis {{phase}} phase ({{tokens}} tokens / {{seconds}}s) at <{{metaLink}}>',
+    phaseError:
+      ':x: Meta synthesis {{phase}} phase failed at <{{dirLink}}>\n   Error: {{error}}',
+  },
 };
 
 /** Default service stats for tests. */

--- a/packages/service/src/routes/__testUtils.ts
+++ b/packages/service/src/routes/__testUtils.ts
@@ -16,6 +16,7 @@ import { vi } from 'vitest';
 import { MetaCache } from '../cache.js';
 import type { WatcherClient } from '../interfaces/index.js';
 import { SynthesisQueue } from '../queue/index.js';
+import { DEFAULT_TEMPLATE_STRINGS } from '../schema/config.js';
 import type { RouteDeps, ServiceStats } from './index.js';
 
 /** Default service config for tests. */
@@ -40,14 +41,7 @@ const DEFAULT_TEST_CONFIG: RouteDeps['config'] = {
   stagingRetryDelayMs: 250,
   previewDeltaFilesCap: 50,
   serverUrl: 'http://127.0.0.1:1934',
-  templates: {
-    phaseStart:
-      ':gear: Started meta synthesis {{phase}} phase of <{{dirLink}}>',
-    phaseEnd:
-      ':white_check_mark: Completed meta synthesis {{phase}} phase ({{tokens}} tokens / {{seconds}}s) at <{{metaLink}}>',
-    phaseError:
-      ':x: Meta synthesis {{phase}} phase failed at <{{dirLink}}>\n   Error: {{error}}',
-  },
+  templates: { ...DEFAULT_TEMPLATE_STRINGS },
 };
 
 /** Default service stats for tests. */

--- a/packages/service/src/routes/status.test.ts
+++ b/packages/service/src/routes/status.test.ts
@@ -5,8 +5,10 @@
  */
 
 import Fastify, { type FastifyInstance } from 'fastify';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { MetaCache } from '../cache.js';
+import type { MetaEntry, MetaListResult } from '../discovery/listMetas.js';
 import { SynthesisQueue } from '../queue/index.js';
 import { makeTestDeps, makeTestLogger } from './__testUtils.js';
 import type { RouteDeps } from './index.js';
@@ -216,5 +218,82 @@ describe('GET /status', () => {
     const res = await app.inject({ method: 'GET', url: '/status' });
     const body = res.json<StatusResponse>();
     expect(body.health.serviceState).toBe('stopping');
+  });
+
+  it('includes metaCounts when watcher data is available', async () => {
+    const cache = new MetaCache();
+    const entries: MetaEntry[] = [
+      {
+        path: 'j:/domains/a',
+        depth: 0,
+        emphasis: 1,
+        stalenessSeconds: 100,
+        hasError: false,
+        locked: false,
+        disabled: false,
+        lastSynthesized: '2026-01-01T00:00:00Z',
+        node: {
+          metaPath: 'j:/domains/a/.meta',
+          ownerPath: 'j:/domains/a',
+        },
+        meta: {},
+      },
+      {
+        path: 'j:/domains/b',
+        depth: 0,
+        emphasis: 1,
+        stalenessSeconds: 0,
+        hasError: true,
+        locked: false,
+        disabled: true,
+        lastSynthesized: null,
+        node: {
+          metaPath: 'j:/domains/b/.meta',
+          ownerPath: 'j:/domains/b',
+        },
+        meta: {},
+      },
+    ] as MetaEntry[];
+
+    vi.spyOn(cache, 'get').mockResolvedValue({
+      entries,
+      summary: {
+        total: 2,
+        stale: 1,
+        errors: 1,
+        locked: 0,
+        disabled: 1,
+        neverSynthesized: 1,
+        tokens: { architect: 0, builder: 0, critic: 0 },
+        stalestPath: 'j:/domains/a',
+        lastSynthesizedPath: 'j:/domains/a',
+        lastSynthesizedAt: '2026-01-01T00:00:00Z',
+      },
+      tree: { roots: [], nodeMap: new Map() },
+    } as unknown as MetaListResult);
+
+    const deps = makeTestDeps({
+      queue: new SynthesisQueue(makeTestLogger()),
+      stats: TEST_STATS,
+      cache,
+    });
+    app = Fastify();
+    registerStatusRoute(app, deps);
+    await app.ready();
+
+    const res = await app.inject({ method: 'GET', url: '/status' });
+    const body = res.json<
+      StatusResponse & { health: { metaCounts: unknown } }
+    >();
+
+    expect(body.health.metaCounts).toEqual({
+      total: 2,
+      enabled: 1,
+      disabled: 1,
+      neverSynthesized: 1,
+      stale: 1,
+      errors: 1,
+      locked: 0,
+    });
   });
 });

--- a/packages/service/src/routes/status.ts
+++ b/packages/service/src/routes/status.ts
@@ -19,6 +19,7 @@ import {
 import type { FastifyInstance } from 'fastify';
 
 import { SERVICE_NAME, SERVICE_VERSION } from '../constants.js';
+import { computeSummary } from '../discovery/computeSummary.js';
 import {
   buildPhaseCandidates,
   derivePhaseState,
@@ -104,6 +105,15 @@ export function registerStatusRoute(
       };
 
       let nextPhase: NextPhaseCandidate | null = null;
+      let metaCounts: {
+        total: number;
+        enabled: number;
+        disabled: number;
+        neverSynthesized: number;
+        stale: number;
+        errors: number;
+        locked: number;
+      } | null = null;
 
       try {
         const metaResult = await cache.get(config, watcher);
@@ -132,6 +142,18 @@ export function registerStatusRoute(
             staleness: winner.effectiveStaleness,
           };
         }
+
+        // Meta counts summary
+        const summary = computeSummary(metaResult.entries, config.depthWeight);
+        metaCounts = {
+          total: summary.total,
+          enabled: summary.total - summary.disabled,
+          disabled: summary.disabled,
+          neverSynthesized: summary.neverSynthesized,
+          stale: summary.stale,
+          errors: summary.errors,
+          locked: summary.locked,
+        };
       } catch {
         // Watcher unreachable — phase summary unavailable
       }
@@ -160,6 +182,7 @@ export function registerStatusRoute(
         },
         phaseStateSummary,
         nextPhase,
+        metaCounts,
       };
     },
   });

--- a/packages/service/src/scheduler/scheduler.test.ts
+++ b/packages/service/src/scheduler/scheduler.test.ts
@@ -40,6 +40,15 @@ function createTestConfig() {
     stagingRetries: 10,
     stagingRetryDelayMs: 250,
     previewDeltaFilesCap: 50,
+    serverUrl: 'http://127.0.0.1:1934',
+    templates: {
+      phaseStart:
+        ':gear: Started meta synthesis {{phase}} phase of <{{dirLink}}>',
+      phaseEnd:
+        ':white_check_mark: Completed meta synthesis {{phase}} phase ({{tokens}} tokens / {{seconds}}s) at <{{metaLink}}>',
+      phaseError:
+        ':x: Meta synthesis {{phase}} phase failed at <{{dirLink}}>\n   Error: {{error}}',
+    },
   };
 }
 

--- a/packages/service/src/scheduler/scheduler.test.ts
+++ b/packages/service/src/scheduler/scheduler.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MetaCache } from '../cache.js';
 import { SynthesisQueue } from '../queue/index.js';
+import { DEFAULT_TEMPLATE_STRINGS } from '../schema/config.js';
 import type { HttpWatcherClient } from '../watcher-client/index.js';
 import { Scheduler } from './index.js';
 
@@ -41,14 +42,7 @@ function createTestConfig() {
     stagingRetryDelayMs: 250,
     previewDeltaFilesCap: 50,
     serverUrl: 'http://127.0.0.1:1934',
-    templates: {
-      phaseStart:
-        ':gear: Started meta synthesis {{phase}} phase of <{{dirLink}}>',
-      phaseEnd:
-        ':white_check_mark: Completed meta synthesis {{phase}} phase ({{tokens}} tokens / {{seconds}}s) at <{{metaLink}}>',
-      phaseError:
-        ':x: Meta synthesis {{phase}} phase failed at <{{dirLink}}>\n   Error: {{error}}',
-    },
+    templates: { ...DEFAULT_TEMPLATE_STRINGS },
   };
 }
 

--- a/packages/service/src/schema/config.test.ts
+++ b/packages/service/src/schema/config.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { metaConfigSchema, serviceConfigSchema } from './config.js';
+import {
+  DEFAULT_TEMPLATE_STRINGS,
+  metaConfigSchema,
+  serviceConfigSchema,
+} from './config.js';
 
 const validConfig = {
   watcherUrl: 'http://localhost:3456',
@@ -83,12 +87,49 @@ describe('metaConfigSchema', () => {
   });
 });
 
-describe('serviceConfigSchema autoSeed', () => {
+describe('serviceConfigSchema new fields', () => {
   const validServiceConfig = {
     ...validConfig,
     port: 1938,
     schedule: '*/30 * * * *',
   };
+
+  it('defaults serverUrl to http://127.0.0.1:1934', () => {
+    const result = serviceConfigSchema.safeParse(validServiceConfig);
+    expect(result.success).toBe(true);
+    expect(result.data?.serverUrl).toBe('http://127.0.0.1:1934');
+  });
+
+  it('defaults templates to DEFAULT_TEMPLATE_STRINGS', () => {
+    const result = serviceConfigSchema.safeParse(validServiceConfig);
+    expect(result.success).toBe(true);
+    expect(result.data?.templates).toEqual(DEFAULT_TEMPLATE_STRINGS);
+  });
+
+  it('accepts custom template overrides', () => {
+    const result = serviceConfigSchema.safeParse({
+      ...validServiceConfig,
+      templates: { phaseStart: 'CUSTOM {{phase}}' },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.templates.phaseStart).toBe('CUSTOM {{phase}}');
+    // Other templates should still get defaults
+    expect(result.data?.templates.phaseEnd).toBe(
+      DEFAULT_TEMPLATE_STRINGS.phaseEnd,
+    );
+    expect(result.data?.templates.phaseError).toBe(
+      DEFAULT_TEMPLATE_STRINGS.phaseError,
+    );
+  });
+
+  it('accepts custom serverUrl', () => {
+    const result = serviceConfigSchema.safeParse({
+      ...validServiceConfig,
+      serverUrl: 'http://custom:9999',
+    });
+    expect(result.success).toBe(true);
+    expect(result.data?.serverUrl).toBe('http://custom:9999');
+  });
 
   it('defaults autoSeed to empty array', () => {
     const result = serviceConfigSchema.safeParse(validServiceConfig);

--- a/packages/service/src/schema/config.ts
+++ b/packages/service/src/schema/config.ts
@@ -52,16 +52,6 @@ export const serviceConfigSchema = metaConfigSchema.extend({
   /** Channel/user ID to send progress messages to. */
   reportTarget: z.string().optional(),
 
-  /** Optional base URL for the service, used to construct entity links in progress reports. */
-  serverBaseUrl: z.string().optional(),
-
-  /**
-   * Optional mapping of server drive labels to absolute filesystem paths.
-   * Used on Linux to resolve absolute paths to jeeves-server browse paths.
-   * Example: `{ "content": "/opt/jeeves/content" }`
-   */
-  serverDriveRoots: z.record(z.string(), z.string()).optional(),
-
   /**
    * URL of the local jeeves-server instance, used by the ProgressReporter
    * to resolve filesystem paths to browse links via the resolve-path API.

--- a/packages/service/src/schema/config.ts
+++ b/packages/service/src/schema/config.ts
@@ -62,6 +62,45 @@ export const serviceConfigSchema = metaConfigSchema.extend({
    */
   serverDriveRoots: z.record(z.string(), z.string()).optional(),
 
+  /**
+   * URL of the local jeeves-server instance, used by the ProgressReporter
+   * to resolve filesystem paths to browse links via the resolve-path API.
+   * Default: http://127.0.0.1:1934
+   */
+  serverUrl: z.string().default('http://127.0.0.1:1934'),
+
+  /**
+   * Handlebars templates for progress reporting messages.
+   * Each template receives a standard set of data keys (dirLink, metaLink,
+   * phase, tokens, seconds, error).
+   */
+  templates: z
+    .object({
+      phaseStart: z
+        .string()
+        .default(
+          ':gear: Started meta synthesis {{phase}} phase of <{{dirLink}}>',
+        ),
+      phaseEnd: z
+        .string()
+        .default(
+          ':white_check_mark: Completed meta synthesis {{phase}} phase ({{tokens}} tokens / {{seconds}}s) at <{{metaLink}}>',
+        ),
+      phaseError: z
+        .string()
+        .default(
+          ':x: Meta synthesis {{phase}} phase failed at <{{dirLink}}>\n   Error: {{error}}',
+        ),
+    })
+    .default(() => ({
+      phaseStart:
+        ':gear: Started meta synthesis {{phase}} phase of <{{dirLink}}>',
+      phaseEnd:
+        ':white_check_mark: Completed meta synthesis {{phase}} phase ({{tokens}} tokens / {{seconds}}s) at <{{metaLink}}>',
+      phaseError:
+        ':x: Meta synthesis {{phase}} phase failed at <{{dirLink}}>\n   Error: {{error}}',
+    })),
+
   /** Interval in ms for periodic watcher health check. 0 = disabled. Default: 60000. */
   watcherHealthIntervalMs: z.number().int().min(0).default(60_000),
 

--- a/packages/service/src/schema/config.ts
+++ b/packages/service/src/schema/config.ts
@@ -14,6 +14,15 @@ import { z } from 'zod';
 
 export { type MetaConfig, metaConfigSchema };
 
+/** Default Handlebars template strings for progress reporting. Single source of truth. */
+export const DEFAULT_TEMPLATE_STRINGS = {
+  phaseStart: ':gear: Started meta synthesis {{phase}} phase of <{{dirLink}}>',
+  phaseEnd:
+    ':white_check_mark: Completed meta synthesis {{phase}} phase ({{tokens}} tokens / {{seconds}}s) at <{{metaLink}}>',
+  phaseError:
+    ':x: Meta synthesis {{phase}} phase failed at <{{dirLink}}>\n   Error: {{error}}',
+} as const;
+
 /** Zod schema for logging configuration. */
 const loggingSchema = z.object({
   /** Log level. */
@@ -66,30 +75,11 @@ export const serviceConfigSchema = metaConfigSchema.extend({
    */
   templates: z
     .object({
-      phaseStart: z
-        .string()
-        .default(
-          ':gear: Started meta synthesis {{phase}} phase of <{{dirLink}}>',
-        ),
-      phaseEnd: z
-        .string()
-        .default(
-          ':white_check_mark: Completed meta synthesis {{phase}} phase ({{tokens}} tokens / {{seconds}}s) at <{{metaLink}}>',
-        ),
-      phaseError: z
-        .string()
-        .default(
-          ':x: Meta synthesis {{phase}} phase failed at <{{dirLink}}>\n   Error: {{error}}',
-        ),
+      phaseStart: z.string().default(DEFAULT_TEMPLATE_STRINGS.phaseStart),
+      phaseEnd: z.string().default(DEFAULT_TEMPLATE_STRINGS.phaseEnd),
+      phaseError: z.string().default(DEFAULT_TEMPLATE_STRINGS.phaseError),
     })
-    .default(() => ({
-      phaseStart:
-        ':gear: Started meta synthesis {{phase}} phase of <{{dirLink}}>',
-      phaseEnd:
-        ':white_check_mark: Completed meta synthesis {{phase}} phase ({{tokens}} tokens / {{seconds}}s) at <{{metaLink}}>',
-      phaseError:
-        ':x: Meta synthesis {{phase}} phase failed at <{{dirLink}}>\n   Error: {{error}}',
-    })),
+    .default(() => ({ ...DEFAULT_TEMPLATE_STRINGS })),
 
   /** Interval in ms for periodic watcher health check. 0 = disabled. Default: 60000. */
   watcherHealthIntervalMs: z.number().int().min(0).default(60_000),

--- a/packages/service/src/schema/index.ts
+++ b/packages/service/src/schema/index.ts
@@ -6,6 +6,7 @@
 
 export {
   type AutoSeedRule,
+  DEFAULT_TEMPLATE_STRINGS,
   type MetaConfig,
   metaConfigSchema,
   type ServiceConfig,

--- a/packages/service/src/watcher-client/HttpWatcherClient.ts
+++ b/packages/service/src/watcher-client/HttpWatcherClient.ts
@@ -7,7 +7,7 @@
  * @module watcher-client/HttpWatcherClient
  */
 
-import { sleepAsync } from '@karmaniverous/jeeves';
+import { fetchWithTimeout, sleepAsync } from '@karmaniverous/jeeves';
 
 import type {
   InferenceRuleSpec,
@@ -64,11 +64,10 @@ export class HttpWatcherClient implements WatcherClient {
     const url = this.baseUrl + endpoint;
 
     for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
-      const res = await fetch(url, {
+      const res = await fetchWithTimeout(url, this.timeoutMs, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
-        signal: AbortSignal.timeout(this.timeoutMs),
       });
 
       if (res.ok) {


### PR DESCRIPTION
## Summary

Four improvements bundled as a coordinated release (pairs with jeeves-server 3.12):

### #93: Generate plugin configSchema from Zod
- New \packages/openclaw/src/pluginConfigSchema.ts\ defines the plugin config as a Zod schema
- Build-time script \scripts/generate-plugin-schema.mjs\ generates the JSON Schema in \openclaw.plugin.json\ via Zod 4's \	oJSONSchema()\
- Wired into prebuild via \generate-schema\ npm script
- Eliminates hand-written JSON Schema drift

### #94: Use core fetchWithTimeout in HttpWatcherClient
- Replaced raw \etch()\ + \AbortSignal.timeout()\ in \HttpWatcherClient.post()\ with \etchWithTimeout\ from \@karmaniverous/jeeves\
- Retry wrapper unchanged; inner fetch now delegates to core's timeout utility

### #129: Templated progress reporting + status meta counts
- Replaced hardcoded \ormatProgressEvent()\ switch-case with configurable Handlebars templates
- Removed \synthesis_start\ and \synthesis_complete\ event types (irrelevant in phase-per-session model)
- New config keys: \	emplates.phaseStart\, \	emplates.phaseEnd\, \	emplates.phaseError\ (hot-reloadable)
- Template data keys: dirPath, metaPath, dirLink, metaLink, phase, seconds, tokens, error
- Links resolved via jeeves-server resolve-path API with graceful fallback to raw paths
- Added \metaCounts\ to \GET /status\ response (total, enabled, disabled, neverSynthesized, stale, errors, locked)

### #210: Use server resolve-path API for progress links
- Removed \serverBaseUrl\ and \serverDriveRoots\ from service config schema
- Path resolution now fully delegated to jeeves-server's \GET /api/resolve-path\ endpoint
- New config key: \serverUrl\ (defaults to \http://127.0.0.1:1934\)

## Post-Implementation Hardening
- **SOLID/DRY Pass:** Extracted \DEFAULT_TEMPLATE_STRINGS\ single-source-of-truth across schemas and tests; fixed template hot-reload bug.
- **Documentation Sync:** Updated \SKILL.md\, Migration Guides, and \rchitecture.md\ to reflect the newly introduced schema keys, \metaCounts\ addition, and \etchWithTimeout\ behavior.
- **Test Gap Filling:** Added tests to cover config defaults, hot-reload detection, \metaCounts\ logic, and fallback rendering, bringing coverage to 586 passing tests.

## Quality Checks
- \
pm run build\ — clean
- \
pm run typecheck\ — zero errors
- \
pm run lint\ — zero errors, zero warnings
- \
pm test\ — 586 tests passed

## Dependency Audit
Major bumps available (defer to chore PR):
- \commander\ 14 → 15
- \@commander-js/extra-typings\ 14 → 15

Minor/patch bumps available across all workspaces (safe to defer).